### PR TITLE
Rename to LokalBot, add brand, palette, waveform

### DIFF
--- a/LokalBot/Info.plist
+++ b/LokalBot/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>LokalBotV3</string>
+	<string>LokalBot</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>
@@ -25,11 +25,11 @@
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>NSAudioCaptureUsageDescription</key>
-	<string>LokalBotV3 records the meeting app's audio output so the other participants are captured. Audio never leaves this Mac.</string>
+	<string>LokalBot records the meeting app's audio output so the other participants are captured. Audio never leaves this Mac.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>LokalBotV3 records your side of meetings from the microphone. Audio never leaves this Mac.</string>
+	<string>LokalBot records your side of meetings from the microphone. Audio never leaves this Mac.</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>
-	<string>LokalBotV3 reads your calendar to confirm meetings and title recordings. Calendar data never leaves this Mac.</string>
+	<string>LokalBot reads your calendar to confirm meetings and title recordings. Calendar data never leaves this Mac.</string>
 	<key>SUEnableAutomaticChecks</key>
 	<false/>
 	<key>SUFeedURL</key>

--- a/LokalBot/LokalBotApp.swift
+++ b/LokalBot/LokalBotApp.swift
@@ -38,9 +38,10 @@ struct LokalBotV3App: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     var body: some Scene {
-        Window("LokalBotV3", id: "main") {
+        Window("LokalBot", id: "main") {
             MainWindowView()
                 .environmentObject(app)
+                .brandTinted()
         }
         .defaultSize(width: 1180, height: 740)
         .commands {
@@ -52,13 +53,32 @@ struct LokalBotV3App: App {
                 }
                 .keyboardShortcut("r", modifiers: [.command, .shift])
             }
+            // ⌘K opens the command palette. Registered at the app level so it
+            // works from anywhere; the palette window is opened via openWindow.
+            CommandGroup(after: .toolbar) {
+                Button("Command Palette…") {
+                    WindowAccess.shared.open("palette")
+                }
+                .keyboardShortcut("k", modifiers: [.command])
+            }
         }
 
-        Window("Welcome to LokalBotV3", id: "onboarding") {
+        Window("Welcome to LokalBot", id: "onboarding") {
             OnboardingView()
                 .environmentObject(app)
         }
         .windowResizability(.contentSize)
+
+        // The ⌘K command palette. A lightweight, keyboard-first launcher that
+        // records, navigates, and opens recent meetings without the sidebar.
+        Window("Command Palette", id: "palette") {
+            CommandPaletteView()
+                .environmentObject(app)
+                .brandTinted()
+        }
+        .windowResizability(.contentSize)
+        .windowStyle(.hiddenTitleBar)
+        .defaultPosition(.center)
 
         MenuBarExtra {
             MenuBarView()

--- a/LokalBot/Services/LokalBotCLIInstaller.swift
+++ b/LokalBot/Services/LokalBotCLIInstaller.swift
@@ -106,7 +106,7 @@ struct LokalBotCLIInstaller {
             case .bundleNotShipped:
                 return "This build doesn't ship the lokalbot-cli — install the latest release."
             case .bundleNotStable:
-                return "The app is running from a translocated or read-only location. Move LokalBotV3.app to /Applications and relaunch."
+                return "The app is running from a translocated or read-only location. Move LokalBot.app to /Applications and relaunch."
             case .fileSystem(let message):
                 return message
             }

--- a/LokalBot/Services/MeetingPlayer.swift
+++ b/LokalBot/Services/MeetingPlayer.swift
@@ -11,6 +11,8 @@ final class MeetingPlayer: NSObject, ObservableObject {
     @Published private(set) var currentTime: TimeInterval = 0
     @Published private(set) var duration: TimeInterval = 0
     @Published private(set) var isLoaded = false
+    /// Playback rate (1.0 = normal). AVAudioPlayer honors `enableRate` + `rate`.
+    @Published var speed: Float = 1.0 { didSet { applySpeed() } }
 
     private var players: [AVAudioPlayer] = []
     private var ticker: Timer?
@@ -24,8 +26,10 @@ final class MeetingPlayer: NSObject, ObservableObject {
             .compactMap { try? AVAudioPlayer(contentsOf: $0) }
         for player in players {
             player.delegate = self
+            player.enableRate = true
             player.prepareToPlay()
         }
+        applySpeed()
         duration = players.map(\.duration).max() ?? 0
         currentTime = 0
         isLoaded = !players.isEmpty
@@ -43,9 +47,18 @@ final class MeetingPlayer: NSObject, ObservableObject {
         }
         // Schedule against a shared device-time anchor so both tracks stay in sync.
         let anchor = (players.first?.deviceCurrentTime ?? 0) + 0.05
-        for player in players { player.play(atTime: anchor) }
+        for player in players {
+            player.enableRate = true
+            player.rate = speed
+            player.play(atTime: anchor)
+        }
         isPlaying = true
         startTicker()
+    }
+
+    /// Push the current `speed` to every player (live rate change).
+    private func applySpeed() {
+        for player in players where player.enableRate { player.rate = speed }
     }
 
     func pause() {

--- a/LokalBot/Support/Brand.swift
+++ b/LokalBot/Support/Brand.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Brand identity, kept in lockstep with the app icon and the marketing site.
+/// The icon is an L-shaped robot on a dark slate plate, drawn in a mint→teal
+/// gradient (`#6ef2dc → #23c4ae`) with a single amber antenna (`#fbbf24`).
+/// These are the only three brand colors — applied as the app accent so the UI
+/// reads as LokalBot, not "default macOS accent", reinforcing the mascot and
+/// the privacy/local-first stance.
+enum Brand {
+    /// Primary accent (the gradient's mid-point). Used for `.tint`.
+    static let teal = Color(red: 0.137, green: 0.769, blue: 0.682)       // #23c4ae
+    /// Bright end of the gradient — glows, active states, the recording eye.
+    static let tealBright = Color(red: 0.431, green: 0.949, blue: 0.863) // #6ef2dc
+    /// The single warm note — reserved for the live "recording" indicator,
+    /// mirroring the antenna dot on the icon.
+    static let amber = Color(red: 0.984, green: 0.749, blue: 0.141)      // #fbbf24
+    /// "Me" speaker (mic track) — the user's own voice.
+    static let me = teal
+    /// "Them" speaker (system track) — other participants.
+    static let them = Color(red: 0.49, green: 0.62, blue: 0.76)
+
+    /// Vertical gradient used on hero surfaces (onboarding, empty states) to
+    /// echo the icon body without leaning on the system accent.
+    static let gradient = LinearGradient(
+        colors: [tealBright, teal],
+        startPoint: .topLeading, endPoint: .bottomTrailing)
+
+    /// A view modifier that sets the brand tint and offers a softer fallback
+    /// in High Contrast / Increase Contrast where the teal can read thin.
+    struct TintModifier: ViewModifier {
+        func body(content: Content) -> some View {
+            content.tint(teal)
+                .accentColor(teal)
+        }
+    }
+}
+
+extension View {
+    /// Apply the LokalBot brand accent app-wide.
+    func brandTinted() -> some View { modifier(Brand.TintModifier()) }
+}

--- a/LokalBot/Views/CommandPaletteView.swift
+++ b/LokalBot/Views/CommandPaletteView.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+
+/// A ⌘K command palette for keyboard-first navigation. Fires record/stop,
+/// jumps to any sidebar section, opens recent meetings, and toggles cotyping —
+/// all from a single fuzzy-filtered list. Built for the power-user audience
+/// (menu-bar residents, agent-CLI users) who reach for the keyboard, not the
+/// trackpad. Summoned via ⌘K (registered in `LokalBotApp.commands`).
+struct CommandPaletteView: View {
+    @EnvironmentObject var app: AppState
+    @Environment(\.dismiss) private var dismiss
+    @State private var query = ""
+    @State private var selection = 0
+    @FocusState private var fieldFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Image(systemName: "command")
+                    .foregroundStyle(.tint).font(.title3)
+                TextField("Type a command or search meetings…", text: $query)
+                    .textFieldStyle(.plain)
+                    .font(.title3)
+                    .focused($fieldFocused)
+                    .onSubmit { runSelection() }
+                    .accessibilityIdentifier("palette.input")
+                Text("⌘K").font(.caption.monospaced()).foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 16).padding(.vertical, 14)
+            Divider()
+
+            if results.isEmpty {
+                Text("No matches")
+                    .font(.callout).foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(Array(results.enumerated()), id: \.element.id) { index, item in
+                            PaletteRow(item: item, selected: index == selection)
+                                .contentShape(Rectangle())
+                                .onTapGesture { run(item) }
+                                .accessibilityIdentifier("palette.row.\(item.id)")
+                        }
+                    }
+                    .padding(6)
+                }
+            }
+        }
+        .frame(width: 560, height: 420)
+        .background(.regularMaterial)
+        .onAppear { fieldFocused = true }
+        .onChange(of: query) { selection = 0 }
+        .onKeyPress(.upArrow) { move(by: -1); return .handled }
+        .onKeyPress(.downArrow) { move(by: 1); return .handled }
+        .onKeyPress(.escape) { dismiss(); return .handled }
+    }
+
+    // MARK: - Items
+
+    /// Everything the palette can do, computed live from app state. Actions
+    /// first (they're stable), then recent meetings whose titles match.
+    private var results: [PaletteItem] {
+        let actions: [PaletteItem] = [
+            .init(id: "record", icon: app.isRecording ? "stop.circle.fill" : "record.circle",
+                  title: app.isRecording ? "Stop recording" : "Record now",
+                  subtitle: "Recording", action: {
+                app.isRecording ? app.stopRecording()
+                                : app.startRecording(context: app.recordingContext(for: app.detector.activeApp), source: "palette")
+            }),
+            .init(id: "nav.meetings", icon: "waveform.circle", title: "Go to Meetings",
+                  subtitle: "Library", action: { app.navSection = .meetings }),
+            .init(id: "nav.chat", icon: "bubble.left.and.bubble.right", title: "Go to Chat",
+                  subtitle: "Library", action: { app.navSection = .chat }),
+            .init(id: "nav.timeline", icon: "calendar.day.timeline.left", title: "Go to Timeline",
+                  subtitle: "Library", action: { app.navSection = .timeline }),
+            .init(id: "nav.search", icon: "magnifyingglass", title: "Go to Search",
+                  subtitle: "Library", action: { app.navSection = .search }),
+            .init(id: "nav.cotyping", icon: "text.cursor",
+                  title: app.settings.cotypingEnabled ? "Go to Cotyping (on)" : "Go to Cotyping (off)",
+                  subtitle: "Automation", action: { app.navSection = .cotyping }),
+            .init(id: "nav.models", icon: "brain", title: "Go to Models",
+                  subtitle: "Configure", action: { app.navSection = .models }),
+            .init(id: "nav.settings", icon: "gearshape", title: "Go to Settings",
+                  subtitle: "Configure", action: { app.navSection = .settings })
+        ]
+        let meetings = app.meetings.prefix(8).map { meeting in
+            PaletteItem(id: "meeting.\(meeting.id.uuidString)", icon: "waveform",
+                        title: meeting.title,
+                        subtitle: "Open · \(meeting.appName) · \(meeting.durationLabel)",
+                        action: {
+                app.navSection = .meetings
+                app.selectedMeetingIDs = [meeting.id]
+            })
+        }
+        let all = actions + meetings
+        let q = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !q.isEmpty else { return all }
+        // Token-containment match: every query token must appear in title/subtitle.
+        let tokens = q.split(separator: " ").map(String.init)
+        return all.filter { item in
+            let hay = (item.title + " " + item.subtitle).lowercased()
+            return tokens.allSatisfy { hay.contains($0) }
+        }
+    }
+
+    private func move(by delta: Int) {
+        guard !results.isEmpty else { return }
+        selection = (selection + delta + results.count) % results.count
+    }
+
+    private func runSelection() {
+        guard results.indices.contains(selection) else { return }
+        run(results[selection])
+    }
+
+    private func run(_ item: PaletteItem) {
+        item.action()
+        dismiss()
+    }
+}
+
+private struct PaletteItem: Identifiable {
+    let id: String
+    let icon: String
+    let title: String
+    let subtitle: String
+    let action: () -> Void
+}
+
+private struct PaletteRow: View {
+    let item: PaletteItem
+    let selected: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: item.icon)
+                .font(.title3).foregroundStyle(.tint)
+                .frame(width: 26)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(item.title).font(.callout).lineLimit(1)
+                Text(item.subtitle).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+            }
+            Spacer()
+            if selected {
+                Image(systemName: "return")
+                    .font(.caption).foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.horizontal, 10).padding(.vertical, 8)
+        .background(selected ? Color.accentColor.opacity(0.15) : .clear,
+                    in: RoundedRectangle(cornerRadius: 8))
+        .overlay(RoundedRectangle(cornerRadius: 8)
+            .strokeBorder(selected ? Color.accentColor.opacity(0.4) : .clear, lineWidth: 1))
+    }
+}

--- a/LokalBot/Views/MainWindowView.swift
+++ b/LokalBot/Views/MainWindowView.swift
@@ -142,14 +142,16 @@ struct MainWindowView: View {
                 Label("Timeline", systemImage: "calendar.day.timeline.left")
                     .tag(AppState.NavSection.timeline)
                     .accessibilityIdentifier("sidebar.timeline")
-                Label("Cotyping", systemImage: "text.cursor")
-                    .tag(AppState.NavSection.cotyping)
-                    .accessibilityIdentifier("sidebar.cotyping")
                 Label("Search", systemImage: "magnifyingglass")
                     .tag(AppState.NavSection.search)
                     .accessibilityIdentifier("sidebar.search")
             }
-            Section("Engine") {
+            Section("Automation") {
+                Label("Cotyping", systemImage: "text.cursor")
+                    .tag(AppState.NavSection.cotyping)
+                    .accessibilityIdentifier("sidebar.cotyping")
+            }
+            Section("Configure") {
                 Label("Models", systemImage: "brain")
                     .tag(AppState.NavSection.models)
                     .accessibilityIdentifier("sidebar.models")
@@ -174,8 +176,8 @@ struct MainWindowView: View {
     @ViewBuilder private var detailPane: some View {
         if app.navSection == .settings {
             // Settings selected → the detail pane shows live permission
-            // status (same panel as onboarding).
-            ScrollView { OnboardingView() }
+            // status (permission-repair surface, not the first-run value walk).
+            ScrollView { OnboardingView(mode: .permissions) }
         } else if let meeting = app.selectedMeeting {
             MeetingDetailView(meeting: meeting)
                 .id(meeting.id)
@@ -190,10 +192,7 @@ struct MainWindowView: View {
                 }
             }
         } else {
-            ContentUnavailableView(
-                "No meeting selected",
-                systemImage: "waveform.circle",
-                description: Text("Recordings appear here automatically and are transcribed & summarized after the meeting ends."))
+            GettingStartedCard()
         }
     }
 
@@ -368,25 +367,71 @@ struct MeetingDetailView: View {
     // MARK: Player
 
     private var playerBar: some View {
-        HStack(spacing: 12) {
-            Button {
-                player.playPause()
-            } label: {
-                Image(systemName: player.isPlaying ? "pause.circle.fill" : "play.circle.fill")
-                    .font(.system(size: 28))
-            }
-            .buttonStyle(.plain)
+        let progress = player.duration > 0 ? player.currentTime / player.duration : 0
+        return VStack(spacing: 8) {
+            HStack(spacing: 12) {
+                Button {
+                    player.playPause()
+                } label: {
+                    Image(systemName: player.isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                        .font(.system(size: 28)).foregroundStyle(.tint)
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.space, modifiers: [])
+                .help("Play / pause (Space)")
 
-            Text(Transcript.stamp(player.currentTime))
-                .font(.caption.monospacedDigit()).foregroundStyle(.secondary)
-            Slider(value: Binding(get: { player.currentTime },
-                                  set: { player.seek(to: $0) }),
-                   in: 0...max(player.duration, 1))
-            Text(Transcript.stamp(player.duration))
-                .font(.caption.monospacedDigit()).foregroundStyle(.secondary)
+                WaveformView(url: folder.appendingPathComponent("mic.m4a"),
+                             progress: progress) { p in
+                    player.seek(to: p * player.duration)
+                }
+                .help("Drag to scrub")
+
+                speedMenu
+            }
+            HStack(spacing: 6) {
+                Text(Transcript.stamp(player.currentTime))
+                Spacer()
+                Text(Transcript.stamp(player.duration))
+            }
+            .font(.caption.monospacedDigit()).foregroundStyle(.secondary)
+            .padding(.horizontal, 4)
         }
-        .padding(.horizontal, 12).padding(.vertical, 8)
+        .padding(.horizontal, 12).padding(.vertical, 10)
         .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 9))
+    }
+
+    /// Playback-speed cycler (1× → 1.25× → 1.5× → 2× → back to 1×). A compact
+    /// Menu rather than a stepper so it reads as a label and fits the bar.
+    private var speedMenu: some View {
+        Menu {
+            ForEach([1.0, 1.25, 1.5, 1.75, 2.0], id: \.self) { rate in
+                Button {
+                    player.speed = Float(rate)
+                } label: {
+                    if abs(Double(player.speed) - rate) < 0.01 {
+                        Label("\(formattedSpeed(rate))×", systemImage: "checkmark")
+                    } else {
+                        Text("\(formattedSpeed(rate))×")
+                    }
+                }
+            }
+            Divider()
+            Button("Reset to 1×") { player.speed = 1.0 }
+        } label: {
+            Text(formattedSpeed(Double(player.speed)) + "×")
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(player.speed == 1.0 ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tint))
+                .frame(minWidth: 38)
+                .padding(.horizontal, 6).padding(.vertical, 3)
+                .background(.quaternary.opacity(0.6), in: Capsule())
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .accessibilityIdentifier("player.speed")
+    }
+
+    private func formattedSpeed(_ rate: Double) -> String {
+        rate.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(rate)) : String(rate)
     }
 
     @ViewBuilder private var statusRow: some View {
@@ -487,7 +532,8 @@ struct MeetingDetailView: View {
 }
 
 /// Minimal line-based Markdown renderer — headings, bullets, checkboxes,
-/// and inline bold/italic/code via AttributedString. Enough for summary.md.
+/// ordered lists, blockquotes, and horizontal rules, with inline
+/// bold/italic/code via AttributedString. Enough for summary.md.
 struct MarkdownText: View {
     let text: String
     init(_ text: String) { self.text = text }
@@ -504,6 +550,8 @@ struct MarkdownText: View {
         let trimmed = line.trimmingCharacters(in: .whitespaces)
         if trimmed.isEmpty {
             Spacer().frame(height: 2)
+        } else if trimmed == "---" || trimmed == "***" || trimmed == "___" {
+            Divider().padding(.vertical, 4)
         } else if trimmed.hasPrefix("### ") {
             inline(String(trimmed.dropFirst(4))).font(.headline).padding(.top, 4)
         } else if trimmed.hasPrefix("## ") {
@@ -521,9 +569,31 @@ struct MarkdownText: View {
                 Text("•")
                 inline(String(trimmed.dropFirst(2)))
             }
+        } else if let ordered = Self.orderedListItem(trimmed) {
+            HStack(alignment: .top, spacing: 6) {
+                Text("\(ordered.number).").font(.body.monospacedDigit())
+                inline(ordered.rest)
+            }
+        } else if trimmed.hasPrefix("> ") {
+            HStack(alignment: .top, spacing: 8) {
+                // A thin accent rule reads as a quote bar without a custom shape.
+                Rectangle().fill(.tint.opacity(0.6)).frame(width: 2)
+                inline(String(trimmed.dropFirst(2)))
+                    .italic().foregroundStyle(.secondary)
+            }
         } else {
             inline(trimmed)
         }
+    }
+
+    /// Matches "1. text", "12. text" — returns the number and the remainder.
+    private static func orderedListItem(_ trimmed: String) -> (number: Int, rest: String)? {
+        guard let dot = trimmed.firstIndex(of: "."), trimmed[..<dot].allSatisfy(\.isNumber),
+              let number = Int(trimmed[..<dot]),
+              trimmed.index(after: dot) < trimmed.endIndex,
+              trimmed[trimmed.index(after: dot)] == " " else { return nil }
+        let rest = String(trimmed[trimmed.index(dot, offsetBy: 2)...])
+        return (number, rest)
     }
 
     private func inline(_ s: String) -> Text {
@@ -532,6 +602,106 @@ struct MarkdownText: View {
             Text(attributed)
         } else {
             Text(s)
+        }
+    }
+}
+
+/// The empty-state card shown when no meeting is selected. Orients across the
+/// three pillars (record → recap → search/ask) and a couple of one-tap setup
+/// steps, so a brand-new user lands somewhere useful instead of a blank pane.
+/// Dismissed once and remembered via `@AppStorage`.
+struct GettingStartedCard: View {
+    @EnvironmentObject var app: AppState
+    @AppStorage("lokalbotv3.gettingStartedDismissed") private var dismissed = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                HStack(spacing: 14) {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 14).fill(Brand.gradient)
+                            .frame(width: 48, height: 48)
+                        Image(systemName: "waveform.badge.magnifyingglass")
+                            .font(.system(size: 22)).foregroundStyle(.white)
+                    }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Welcome to LokalBot").font(.title2.bold())
+                        Text("Record meetings, get the recap, and search everything — all on-device.")
+                            .font(.callout).foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Button { dismissed = true } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.title3).foregroundStyle(.tertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Dismiss")
+                    .accessibilityIdentifier("welcome.dismiss")
+                }
+
+                HStack(spacing: 12) {
+                    pillar("waveform", "Record",
+                           app.isRecording ? "Recording now…" : "LokalBot auto-detects meetings, or start one here.",
+                           isRecording: app.isRecording)
+                    pillar("doc.text.magnifyingglass", "Recap",
+                           "A transcript and structured summary land the moment a call ends.", isRecording: nil)
+                    pillar("magnifyingglass", "Search & ask",
+                           "Full-text, meaning, and screen-text search — plus chat over your library.", isRecording: nil)
+                }
+
+                Text("Get started").font(.headline)
+                VStack(alignment: .leading, spacing: 10) {
+                    stepRow(done: app.isRecording || !app.meetings.isEmpty) {
+                        Text("Record a meeting — it appears in the list automatically.")
+                    }
+                    stepRow(done: nil) {
+                        HStack(spacing: 8) {
+                            Button("Turn on day tracking") { app.navSection = .timeline }
+                                .buttonStyle(.bordered).controlSize(.small)
+                            Text("to see where your time goes.")
+                        }
+                    }
+                    stepRow(done: app.settings.cotypingEnabled ? true : nil) {
+                        HStack(spacing: 8) {
+                            Button("Try cotyping") { app.navSection = .cotyping }
+                                .buttonStyle(.bordered).controlSize(.small)
+                            Text("— inline AI autocomplete that stays on your Mac.")
+                        }
+                    }
+                }
+                .padding(14)
+                .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 12))
+
+                Text("Tip: press ⌘K anywhere to record, navigate, or jump to a meeting.")
+                    .font(.caption).foregroundStyle(.tertiary)
+            }
+            .padding(24)
+            .frame(maxWidth: 560, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+    }
+
+    private func pillar(_ icon: String, _ title: String, _ body: String,
+                        isRecording: Bool?) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(isRecording == true ? AnyShapeStyle(Brand.amber) : AnyShapeStyle(.tint))
+            Text(title).font(.headline)
+            Text(body).font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    /// `done`: nil = actionable (hollow circle), true/false = checkmark/number.
+    private func stepRow<S: View>(done: Bool?, @ViewBuilder _ content: () -> S) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: done == true ? "checkmark.circle.fill" : "circle")
+                .foregroundStyle(done == true ? Color.green : Brand.teal)
+                .padding(.top, 2)
+            content().font(.callout)
         }
     }
 }

--- a/LokalBot/Views/MenuBarView.swift
+++ b/LokalBot/Views/MenuBarView.swift
@@ -187,7 +187,7 @@ struct MenuBarView: View {
 
     private var footer: some View {
         HStack(spacing: 12) {
-            Button("Open LokalBotV3") { WindowAccess.shared.open("main") }
+            Button("Open LokalBot") { WindowAccess.shared.open("main") }
                 .buttonStyle(.plain).foregroundStyle(.tint)
             Button("Settings") {
                 app.navSection = .settings

--- a/LokalBot/Views/OnboardingView.swift
+++ b/LokalBot/Views/OnboardingView.swift
@@ -1,21 +1,153 @@
 import SwiftUI
 import AppKit
 
-/// Permission onboarding (design §6: "requested progressively, with
-/// explanations"). All TCC state, prompting, deep-links, polling and relaunch
-/// now live in the shared `PermissionManager`; this view is presentation only.
+/// First-run onboarding. Redesigned value-first: a short walk through what
+/// LokalBot *does* (record → transcribe → summarize, all on-device) before the
+/// permission asks, so the user grants with intent. The final step is the
+/// permission panel (TCC state, prompting, deep-links, polling, relaunch all
+/// live in the shared `PermissionManager`; this view is presentation only).
+///
+/// Two modes: `.welcome` (the dedicated first-run window — the value walk then
+/// permissions) and `.permissions` (the Settings re-entry surface, which only
+/// ever repairs permissions). The latter is what the main window's Settings
+/// detail shows.
 struct OnboardingView: View {
+    enum Mode { case welcome, permissions }
+    var mode: Mode = .welcome
+
     @EnvironmentObject var app: AppState
     @StateObject private var permissions = PermissionManager.shared
+    @State private var step = 0
 
     var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 18) {
+                if mode == .permissions || step >= steps.count {
+                    permissionsStep
+                } else {
+                    steps[step]
+                }
+            }
+            .padding(24)
+            .frame(width: 560)
+
+            if mode == .welcome, step < steps.count {
+                footerNav
+            }
+        }
+        .onAppear {
+            // The Settings surface is always the permission panel; only the
+            // first-run window does the value walk (starting at welcome).
+            if mode == .permissions { step = steps.count }
+            permissions.startPolling()
+        }
+        .onDisappear { permissions.stopPolling() }
+        .animation(.easeInOut(duration: 0.2), value: step)
+    }
+
+    // MARK: - Value steps (0…2)
+
+    /// The pre-permission steps: what LokalBot does, how a meeting flows, and
+    /// the privacy stance. Each is a self-contained view; the index drives nav.
+    private var steps: [AnyView] {
+        [
+            AnyView(welcomeStep),
+            AnyView(flowStep),
+            AnyView(privacyStep)
+        ]
+    }
+
+    private var welcomeStep: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            heroMark
+            Text("LokalBot is your meeting brain.").font(.title.bold())
+            Text("It records both sides of every call, turns them into a transcript, and writes the recap — decisions, action items, and all. Then it lets you search every word, and ask questions in plain language.")
+                .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 10) {
+                pillar("waveform", "Record", "Both sides, auto-detected")
+                pillar("doc.text.magnifyingglass", "Recap", "Transcript + summary")
+                pillar("bubble.left.and.bubble.right", "Ask", "Chat over your library")
+            }
+        }
+    }
+
+    private var flowStep: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("How a meeting flows").font(.title2.bold())
+            VStack(alignment: .leading, spacing: 12) {
+                flowRow(number: "1", icon: "magnifyingglass", title: "It notices the call",
+                        body: "LokalBot watches for Zoom, Teams, Meet, and more — and starts recording both sides on its own.")
+                flowRow(number: "2", icon: "waveform.badge.checkmark", title: "It transcribes & summarizes",
+                        body: "On-device models turn the audio into a labeled transcript and a structured recap the moment the call ends.")
+                flowRow(number: "3", icon: "lock.shield", title: "It stays on your Mac",
+                        body: "Everything lands in a local library you can search, replay, and ask questions about. Nothing is uploaded.")
+            }
+        }
+    }
+
+    private var privacyStep: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Private by construction").font(.title2.bold())
+            Label {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Your audio, transcripts, and summaries never leave this Mac.")
+                        .font(.callout).foregroundStyle(.primary)
+                    Text("Transcription and summarization run on-device with Apple Silicon. The only network calls are optional: a one-time model download, or pointing summaries at a backend you choose.")
+                        .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+                }
+            } icon: {
+                Image(systemName: "lock.shield.fill")
+                    .font(.system(size: 30)).foregroundStyle(Brand.teal.gradient)
+            }
+            Divider()
+            Label("No account. No subscription. No telemetry.", systemImage: "checkmark.seal")
+                .font(.callout).foregroundStyle(.secondary)
+        }
+    }
+
+    private func flowRow(number: String, icon: String, title: String, body: String) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            ZStack {
+                Circle().fill(Brand.teal.gradient).frame(width: 30, height: 30)
+                Text(number).font(.callout.bold()).foregroundStyle(.white)
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Label(title, systemImage: icon).font(.headline)
+                Text(body).font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func pillar(_ icon: String, _ title: String, _ body: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Image(systemName: icon).font(.title2).foregroundStyle(.tint)
+            Text(title).font(.headline)
+            Text(body).font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var heroMark: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 18).fill(Brand.gradient)
+                .frame(width: 56, height: 56)
+            Image(systemName: "waveform.badge.magnifyingglass")
+                .font(.system(size: 26)).foregroundStyle(.white)
+        }
+    }
+
+    // MARK: - Step 3: Permissions (the original, focused panel)
+
+    private var permissionsStep: some View {
         VStack(alignment: .leading, spacing: 18) {
             HStack(spacing: 12) {
-                Image(systemName: "lock.shield.fill")
-                    .font(.system(size: 30)).foregroundStyle(.tint)
+                Image(systemName: "key.fill")
+                    .font(.system(size: 30)).foregroundStyle(Brand.teal.gradient)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Welcome to LokalBotV3").font(.title2.bold())
-                    Text("Three macOS permissions make everything work. All data stays on this Mac.")
+                    Text("Grant three permissions").font(.title2.bold())
+                    Text("They make everything work. All data stays on this Mac.")
                         .font(.callout).foregroundStyle(.secondary)
                 }
             }
@@ -38,9 +170,9 @@ struct OnboardingView: View {
                     .resizable().frame(width: 44, height: 44)
                     .onDrag { NSItemProvider(object: Bundle.main.bundleURL as NSURL) }
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Adding LokalBotV3 manually in System Settings?")
+                    Text("Adding LokalBot manually in System Settings?")
                         .font(.headline)
-                    Text("Drag this icon straight into the permission list — it's always the right copy. Remove any older “LokalBotV3” entries first.")
+                    Text("Drag this icon straight into the permission list — it's always the right copy. Remove any older “LokalBot” entries first.")
                         .font(.caption).foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -54,11 +186,11 @@ struct OnboardingView: View {
 
             Divider()
             HStack {
-                Label("If a permission was granted while LokalBotV3 was running, relaunch to apply it.",
+                Label("If a permission was granted while LokalBot was running, relaunch to apply it.",
                       systemImage: "arrow.triangle.2.circlepath")
                     .font(.caption).foregroundStyle(.secondary)
                 Spacer()
-                Button("Relaunch LokalBotV3") { PermissionManager.relaunch() }
+                Button("Relaunch LokalBot") { PermissionManager.relaunch() }
                 if permissions.allGranted {
                     Text("All set ✓").font(.callout.bold()).foregroundStyle(.green)
                 }
@@ -66,10 +198,6 @@ struct OnboardingView: View {
         }
         .padding(24)
         .frame(width: 560)
-        // TCC posts no change notification, so poll while this panel is visible
-        // to catch grants the user makes over in System Settings.
-        .onAppear { permissions.startPolling() }
-        .onDisappear { permissions.stopPolling() }
     }
 
     private func row(_ permission: AppPermission, icon: String, title: String, why: String) -> some View {
@@ -98,5 +226,33 @@ struct OnboardingView: View {
         }
         .padding(10)
         .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 9))
+    }
+
+    // MARK: - Nav
+
+    private var footerNav: some View {
+        HStack {
+            stepDots
+            Spacer()
+            if step > 0 {
+                Button("Back") { step -= 1 }
+            }
+            Button(step == steps.count - 1 ? "Continue to permissions" : "Next") {
+                step += 1
+            }
+            .buttonStyle(.borderedProminent)
+            .keyboardShortcut(.return, modifiers: [])
+        }
+        .padding(.horizontal, 24).padding(.bottom, 20)
+    }
+
+    private var stepDots: some View {
+        HStack(spacing: 6) {
+            ForEach(0..<steps.count, id: \.self) { index in
+                Circle()
+                    .fill(index == step ? Brand.teal : Color.secondary.opacity(0.3))
+                    .frame(width: 6, height: 6)
+            }
+        }
     }
 }

--- a/LokalBot/Views/SettingsView.swift
+++ b/LokalBot/Views/SettingsView.swift
@@ -34,8 +34,8 @@ struct SettingsView: View {
             if shows("General", ["launch", "login", "startup", "open at login", "auto start",
                                  "menu bar", "menubar", "dock", "window", "background", "tray"]) {
                 Section("General") {
-                    LaunchAtLogin.Toggle("Launch LokalBotV3 at login")
-                    Text("Start LokalBotV3 automatically so it's ready to catch meetings.")
+                    LaunchAtLogin.Toggle("Launch LokalBot at login")
+                    Text("Start LokalBot automatically so it's ready to catch meetings.")
                         .font(.caption).foregroundStyle(.secondary)
 
                     Toggle("Menu bar only (hide Dock icon)", isOn: $app.settings.menuBarOnly)
@@ -115,19 +115,16 @@ struct SettingsView: View {
                 }
             }
 
-            if shows("Cotyping", ["cotyping", "autocomplete", "inline", "ghost", "suggestion", "typing", "complete", "tab", "autocorrect"]) {
+            if shows("Cotyping", ["cotyping", "autocomplete", "inline", "ghost", "suggestion", "typing", "complete", "tab", "autocorrect", "emoji", "macro", "privacy", "exclude", "exclusion", "clipboard", "learn"]) {
                 Section("Cotyping") {
                     Toggle("Inline AI autocomplete (cotyping)", isOn: $app.settings.cotypingEnabled)
                     Text("Suggests text inline as you type in other apps. Choose its model under Models (it can differ from summarization). Needs Accessibility + Input Monitoring; open the Cotyping tab for setup and a live preview.")
                         .font(.caption).foregroundStyle(.secondary)
-                    if app.settings.cotypingEnabled {
-                        TextField("Your name (optional — tunes the voice)", text: $app.settings.cotypingUserName)
-                        TextField("Writing style (optional, e.g. \u{201c}concise, British spelling\u{201d})", text: $app.settings.cotypingStyleNote)
-                        TextField("Languages you write in (optional, e.g. \u{201c}English, German\u{201d})",
-                                  text: $app.settings.cotypingLanguages)
-                        TextField("Notes / glossary (optional — names, jargon, style)",
-                                  text: $app.settings.cotypingExtendedContext, axis: .vertical)
-                            .lineLimit(1...3)
+                }
+                // Model + live stats sit highest: the "is it on, and is it working?"
+                // answers a user wants first, before any behavior tuning.
+                if app.settings.cotypingEnabled, shows("Cotyping", ["model", "stats", "generated", "accepted", "latency"]) {
+                    Section("Model & activity") {
                         Toggle("Use a dedicated high-quality cotyping model", isOn: $app.settings.cotypingUseSeparateModel)
                         CotypingModelPreparationView(compact: true)
                         if app.settings.cotypingUseSeparateModel {
@@ -139,67 +136,6 @@ struct SettingsView: View {
                             Text("Gemma 4 E4B Q5 XL is the recommended quality target; Qwen3.5 2B and LFM2.5 1.2B are smaller latency options.")
                                 .font(.caption).foregroundStyle(.secondary)
                         }
-                        Toggle("Learn from accepted completions", isOn: $app.settings.cotypingUseLocalLearning)
-                        if app.settings.cotypingUseLocalLearning {
-                            Stepper("Use \(app.settings.cotypingLearningExamplesInPrompt) learned examples",
-                                    value: $app.settings.cotypingLearningExamplesInPrompt, in: 1...5)
-                            CotypingLearningControls(store: app.cotypingLearning)
-                        }
-                        Stepper("Suggestion length: up to \(app.settings.cotypingMaxWords) words",
-                                value: $app.settings.cotypingMaxWords, in: 2...50)
-                        Toggle("Allow multi-line suggestions", isOn: $app.settings.cotypingMultiLine)
-                        Toggle("Stream suggestions while generating", isOn: $app.settings.cotypingStreamSuggestionsWhileGenerating)
-                        Text("When off, suggestions appear once fully formed, matching Cotypist's default. Turn on to show token-by-token partials sooner.")
-                            .font(.caption).foregroundStyle(.secondary)
-                        Toggle("Use app & window context", isOn: $app.settings.cotypingUseAppContext)
-                        Text("Conditions suggestions on the focused app and its window title (email subject, chat channel, page title) for sharper, on-topic completions. Read locally via Accessibility; skipped in code editors and terminals.")
-                            .font(.caption).foregroundStyle(.secondary)
-                        Toggle("Use the clipboard as context", isOn: $app.settings.cotypingUseClipboard)
-                        Text("Folds what you just copied into the prompt so suggestions can build on it. Read fresh each time and never stored. Off by default — turn on only if you want the model to see your clipboard.")
-                            .font(.caption).foregroundStyle(.secondary)
-                        Toggle("Match the app\u{2019}s font and text color", isOn: $app.settings.cotypingMatchHostStyle)
-                        Text("Ghost text mimics the field you\u{2019}re typing in (font family and a dimmed version of its text color) instead of a fixed style. Read locally via Accessibility; cached per field.")
-                            .font(.caption).foregroundStyle(.secondary)
-                        Picker("Show suggestions", selection: $app.settings.cotypingMirrorPreference) {
-                            ForEach(CotypingMirrorPreference.allCases) { Text($0.label).tag($0) }
-                        }
-                        Text("\u{201c}Automatic\u{201d} draws ghost text inline at the caret, but falls back to a popup below the caret when its geometry is unreliable or the caret is mid-line.")
-                            .font(.caption).foregroundStyle(.secondary)
-                        Toggle("Autocorrect the word you're typing", isOn: $app.settings.cotypingAutocorrect)
-                        Text("Spots a misspelled word and offers the fix inline — Tab swaps it. Uses the macOS spell checker (on-device); never touches code, URLs, or numbers.")
-                            .font(.caption).foregroundStyle(.secondary)
-                        Toggle("Emoji autocomplete (\u{201c}:rocket:\u{201d} \u{2192} \u{1f680})", isOn: $app.settings.cotypingEmoji)
-                        Toggle("Macros (\u{201c}/5+5\u{201d}, \u{201c}/today\u{201d}, \u{201c}/10km->mi\u{201d})", isOn: $app.settings.cotypingMacros)
-                        Text("Type \u{201c}/\u{201d} then an expression — math, dates, unit/currency conversion, or random — and the result shows inline. Accept to swap it in.")
-                            .font(.caption).foregroundStyle(.secondary)
-                        Picker("Accept next", selection: $app.settings.cotypingAcceptKey) {
-                            ForEach(CotypingAcceptKey.allCases) { Text($0.label).tag($0) }
-                        }
-                        Picker("Each accept takes", selection: $app.settings.cotypingAcceptGranularity) {
-                            ForEach(CotypingAcceptGranularity.allCases) { Text($0.label).tag($0) }
-                        }
-                        Picker("Accept whole suggestion", selection: $app.settings.cotypingFullAcceptKey) {
-                            ForEach(CotypingFullAcceptKey.allCases) { Text($0.label).tag($0) }
-                        }
-                        Toggle("Paste large / multi-line accepts", isOn: $app.settings.cotypingPasteInsertion)
-                        Text("Commits big or multi-line suggestions via paste instead of synthetic keystrokes \u{2014} steadier in some apps. Briefly uses the clipboard, then restores it.")
-                            .font(.caption).foregroundStyle(.secondary)
-                        LabeledContent("Pause before suggesting") {
-                            Text("\(app.settings.cotypingDebounceMs) ms").foregroundStyle(.secondary)
-                        }
-                        Slider(value: Binding(
-                            get: { Double(app.settings.cotypingDebounceMs) },
-                            set: { app.settings.cotypingDebounceMs = Int($0) }),
-                            in: 20...1000, step: 20)
-                        TextField("Never suggest in (app names, comma-separated)",
-                                  text: $app.settings.cotypingExcludedApps)
-                        Text("Cotyping never runs in password fields. Add apps (or terminals) here to exclude them too.")
-                            .font(.caption).foregroundStyle(.secondary)
-                        TextField("Never suggest on (websites, comma-separated)",
-                                  text: $app.settings.cotypingExcludedDomains)
-                        Text("Block cotyping on specific sites (e.g. \u{201c}bank.com\u{201d}). Subdomains included; read locally via Accessibility in browsers.")
-                            .font(.caption).foregroundStyle(.secondary)
-                        Divider().padding(.vertical, 2)
                         LabeledContent("Suggestions generated") {
                             Text("\(cotypingStats.stats.generations)").foregroundStyle(.secondary)
                         }
@@ -223,6 +159,93 @@ struct SettingsView: View {
                             Button("Reset cotyping stats", role: .destructive) { cotypingStats.clear() }
                                 .font(.caption)
                         }
+                    }
+                }
+                if app.settings.cotypingEnabled, shows("Cotyping", ["voice", "name", "style", "language", "length", "multiline", "stream", "learn", "glossary"]) {
+                    Section("Voice & behavior") {
+                        TextField("Your name (optional — tunes the voice)", text: $app.settings.cotypingUserName)
+                        TextField("Writing style (optional, e.g. \u{201c}concise, British spelling\u{201d})", text: $app.settings.cotypingStyleNote)
+                        TextField("Languages you write in (optional, e.g. \u{201c}English, German\u{201d})",
+                                  text: $app.settings.cotypingLanguages)
+                        TextField("Notes / glossary (optional — names, jargon, style)",
+                                  text: $app.settings.cotypingExtendedContext, axis: .vertical)
+                            .lineLimit(1...3)
+                        Stepper("Suggestion length: up to \(app.settings.cotypingMaxWords) words",
+                                value: $app.settings.cotypingMaxWords, in: 2...50)
+                        Toggle("Allow multi-line suggestions", isOn: $app.settings.cotypingMultiLine)
+                        Toggle("Stream suggestions while generating", isOn: $app.settings.cotypingStreamSuggestionsWhileGenerating)
+                        Text("When off, suggestions appear once fully formed, matching Cotypist's default. Turn on to show token-by-token partials sooner.")
+                            .font(.caption).foregroundStyle(.secondary)
+                        LabeledContent("Pause before suggesting") {
+                            Text("\(app.settings.cotypingDebounceMs) ms").foregroundStyle(.secondary)
+                        }
+                        Slider(value: Binding(
+                            get: { Double(app.settings.cotypingDebounceMs) },
+                            set: { app.settings.cotypingDebounceMs = Int($0) }),
+                            in: 20...1000, step: 20)
+                        Toggle("Learn from accepted completions", isOn: $app.settings.cotypingUseLocalLearning)
+                        if app.settings.cotypingUseLocalLearning {
+                            Stepper("Use \(app.settings.cotypingLearningExamplesInPrompt) learned examples",
+                                    value: $app.settings.cotypingLearningExamplesInPrompt, in: 1...5)
+                            CotypingLearningControls(store: app.cotypingLearning)
+                        }
+                    }
+                }
+                if app.settings.cotypingEnabled, shows("Cotyping", ["context", "app", "window", "clipboard", "font", "color", "match", "render", "popup", "automatic"]) {
+                    Section("Context & rendering") {
+                        Toggle("Use app & window context", isOn: $app.settings.cotypingUseAppContext)
+                        Text("Conditions suggestions on the focused app and its window title (email subject, chat channel, page title) for sharper, on-topic completions. Read locally via Accessibility; skipped in code editors and terminals.")
+                            .font(.caption).foregroundStyle(.secondary)
+                        Toggle("Use the clipboard as context", isOn: $app.settings.cotypingUseClipboard)
+                        Text("Folds what you just copied into the prompt so suggestions can build on it. Read fresh each time and never stored. Off by default — turn on only if you want the model to see your clipboard.")
+                            .font(.caption).foregroundStyle(.secondary)
+                        Toggle("Match the app\u{2019}s font and text color", isOn: $app.settings.cotypingMatchHostStyle)
+                        Text("Ghost text mimics the field you\u{2019}re typing in (font family and a dimmed version of its text color) instead of a fixed style. Read locally via Accessibility; cached per field.")
+                            .font(.caption).foregroundStyle(.secondary)
+                        Picker("Show suggestions", selection: $app.settings.cotypingMirrorPreference) {
+                            ForEach(CotypingMirrorPreference.allCases) { Text($0.label).tag($0) }
+                        }
+                        Text("\u{201c}Automatic\u{201d} draws ghost text inline at the caret, but falls back to a popup below the caret when its geometry is unreliable or the caret is mid-line.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                if app.settings.cotypingEnabled, shows("Cotyping", ["autocorrect", "spell", "emoji", "macro", "convert", "expression"]) {
+                    Section("Shortcuts") {
+                        Toggle("Autocorrect the word you're typing", isOn: $app.settings.cotypingAutocorrect)
+                        Text("Spots a misspelled word and offers the fix inline — Tab swaps it. Uses the macOS spell checker (on-device); never touches code, URLs, or numbers.")
+                            .font(.caption).foregroundStyle(.secondary)
+                        Toggle("Emoji autocomplete (\u{201c}:rocket:\u{201d} \u{2192} \u{1f680})", isOn: $app.settings.cotypingEmoji)
+                        Toggle("Macros (\u{201c}/5+5\u{201d}, \u{201c}/today\u{201d}, \u{201c}/10km->mi\u{201d})", isOn: $app.settings.cotypingMacros)
+                        Text("Type \u{201c}/\u{201d} then an expression — math, dates, unit/currency conversion, or random — and the result shows inline. Accept to swap it in.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                if app.settings.cotypingEnabled, shows("Cotyping", ["accept", "key", "granularity", "paste", "insertion", "advanced"]) {
+                    Section("Accept & insert") {
+                        Picker("Accept next", selection: $app.settings.cotypingAcceptKey) {
+                            ForEach(CotypingAcceptKey.allCases) { Text($0.label).tag($0) }
+                        }
+                        Picker("Each accept takes", selection: $app.settings.cotypingAcceptGranularity) {
+                            ForEach(CotypingAcceptGranularity.allCases) { Text($0.label).tag($0) }
+                        }
+                        Picker("Accept whole suggestion", selection: $app.settings.cotypingFullAcceptKey) {
+                            ForEach(CotypingFullAcceptKey.allCases) { Text($0.label).tag($0) }
+                        }
+                        Toggle("Paste large / multi-line accepts", isOn: $app.settings.cotypingPasteInsertion)
+                        Text("Commits big or multi-line suggestions via paste instead of synthetic keystrokes \u{2014} steadier in some apps. Briefly uses the clipboard, then restores it.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                if app.settings.cotypingEnabled, shows("Cotyping", ["exclude", "exclusion", "never", "app", "website", "domain", "password", "privacy", "block"]) {
+                    Section("Privacy & exclusions") {
+                        TextField("Never suggest in (app names, comma-separated)",
+                                  text: $app.settings.cotypingExcludedApps)
+                        Text("Cotyping never runs in password fields. Add apps (or terminals) here to exclude them too.")
+                            .font(.caption).foregroundStyle(.secondary)
+                        TextField("Never suggest on (websites, comma-separated)",
+                                  text: $app.settings.cotypingExcludedDomains)
+                        Text("Block cotyping on specific sites (e.g. \u{201c}bank.com\u{201d}). Subdomains included; read locally via Accessibility in browsers.")
+                            .font(.caption).foregroundStyle(.secondary)
                     }
                 }
             }
@@ -333,7 +356,7 @@ struct SettingsView: View {
                                 Label("Installed", systemImage: "checkmark.circle.fill")
                                     .foregroundStyle(.green)
                             } else if !installer.isBundleLocationStable {
-                                Label("Move LokalBotV3.app to /Applications first",
+                                Label("Move LokalBot.app to /Applications first",
                                       systemImage: "exclamationmark.triangle.fill")
                                     .foregroundStyle(.orange)
                             } else {

--- a/LokalBot/Views/TimelineView.swift
+++ b/LokalBot/Views/TimelineView.swift
@@ -24,9 +24,9 @@ struct TimelineView: View {
     /// Inspector (digest/totals/ask) width — the pane the user resizes; the
     /// track fills the rest, so widening the digest narrows the track. Floored
     /// at `minInspectorWidth` (it can grow, never shrink past it) and persisted.
-    private let minInspectorWidth: CGFloat = 710
+    private let minInspectorWidth: CGFloat = 480
     private let trackFloorWidth: CGFloat = 160
-    @AppStorage("timeline.inspectorWidth") private var inspectorWidth = 710.0
+    @AppStorage("timeline.inspectorWidth") private var inspectorWidth = 480.0
     /// Live width while the divider is dragged (nil otherwise). Driving the drag
     /// through @State rather than @AppStorage keeps it fluid — UserDefaults is
     /// written once on release, not on every drag tick.

--- a/LokalBot/Views/WaveformView.swift
+++ b/LokalBot/Views/WaveformView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+import AVFoundation
+
+/// A clickable waveform scrubber for the meeting player. Peaks are computed
+/// once from the audio file (downsampled so ~`bins` bars span the width),
+/// cached per path so re-showing a meeting is instant. Played bars use the
+/// brand teal; unplayed are muted — the same Me/Them identity the rest of the
+/// app uses. Dragging scrubs; clicking seeks.
+///
+/// For a two-track meeting the mic track (Me) drives the shape; it's the one
+/// you can rely on, and rendering both as one waveform keeps the scrubber
+/// readable at small heights.
+struct WaveformView: View {
+    let url: URL?
+    let progress: Double          // 0…1 of the track played
+    let onSeek: (Double) -> Void  // progress 0…1
+
+    @State private var peaks: [Float]?
+    private let bins = 160
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                if let peaks {
+                    barLayer(peaks, in: geo.size, played: false)
+                    barLayer(peaks, in: geo.size, played: true)
+                } else {
+                    // Cheap placeholder until the (off-main) analysis lands.
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(.quaternary.opacity(0.4))
+                }
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        let p = max(0, min(1, value.location.x / max(geo.size.width, 1)))
+                        onSeek(p)
+                    }
+            )
+        }
+        .frame(height: 40)
+        .task(id: url?.path) { await load() }
+    }
+
+    /// Mirrored bars around the horizontal centerline — the classic waveform.
+    private func barLayer(_ peaks: [Float], in size: CGSize, played: Bool) -> some View {
+        let count = peaks.count
+        let spacing: CGFloat = 2
+        let barWidth = max(1, (size.width - spacing * CGFloat(count - 1)) / CGFloat(count))
+        let cut = Int(Double(count) * progress)
+        return Canvas { ctx, _ in
+            for (index, peak) in peaks.enumerated() {
+                let isPlayed = index < cut
+                guard played == isPlayed else { continue }
+                let h = max(2, CGFloat(peak) * size.height)
+                let x = CGFloat(index) * (barWidth + spacing)
+                let rect = CGRect(x: x, y: (size.height - h) / 2, width: barWidth, height: h)
+                ctx.fill(Path(roundedRect: rect, cornerRadius: barWidth / 2),
+                         with: .color(played ? Brand.teal : Color.secondary.opacity(0.35)))
+            }
+        }
+    }
+
+    /// Downsample the file to `bins` peak values, off the main actor. Uses the
+    /// PCM float buffer directly — fast enough for an hour-long AAC file.
+    private func load() async {
+        guard let url, FileManager.default.fileExists(atPath: url.path) else { return }
+        if let cached = WaveformCache.shared.object(forKey: url.path as NSString) {
+            peaks = cached.peaks
+            return
+        }
+        let path = url.path
+        let computed = await Task.detached(priority: .utility) { () -> [Float]? in
+            guard let file = try? AVAudioFile(forReading: URL(fileURLWithPath: path)) else { return nil }
+            guard let format = AVAudioFormat(standardFormatWithSampleRate: file.fileFormat.sampleRate,
+                                             channels: 1) else { return nil }
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: format,
+                                                frameCapacity: AVAudioFrameCount(file.length)) else { return nil }
+            try? file.read(into: buffer)
+            guard let data = buffer.floatChannelData?[0] else { return nil }
+            let total = Int(buffer.frameLength)
+            let bin = max(1, total / bins)
+            var out: [Float] = []
+            out.reserveCapacity(bins)
+            for start in stride(from: 0, to: total, by: bin) {
+                let end = min(start + bin, total)
+                var peak: Float = 0
+                for i in start..<end { peak = max(peak, abs(data[i])) }
+                out.append(peak)
+            }
+            // Normalize so the quietest-recorded file still fills the bar height.
+            let maxPeak = out.max() ?? 1
+            return maxPeak > 0 ? out.map { $0 / maxPeak } : out
+        }.value
+        if let computed {
+            WaveformCache.shared.setObject(PeaksBox(computed), forKey: path as NSString)
+            peaks = computed
+        }
+    }
+}
+
+/// `NSCache` requires a class; wrap the peaks array so a session can memoize
+/// the (relatively) expensive audio decode per file.
+private final class PeaksBox {
+    let peaks: [Float]
+    init(_ peaks: [Float]) { self.peaks = peaks }
+}
+
+private enum WaveformCache {
+    static let shared = NSCache<NSString, PeaksBox>()
+}

--- a/project.yml
+++ b/project.yml
@@ -100,16 +100,16 @@ targetTemplates:
     info:
       path: LokalBot/Info.plist
       properties:
-        CFBundleDisplayName: LokalBotV3
+        CFBundleDisplayName: LokalBot
         CFBundleIconFile: AppIcon
         NSMicrophoneUsageDescription: >-
-          LokalBotV3 records your side of meetings from the microphone.
+          LokalBot records your side of meetings from the microphone.
           Audio never leaves this Mac.
         NSAudioCaptureUsageDescription: >-
-          LokalBotV3 records the meeting app's audio output so the other
+          LokalBot records the meeting app's audio output so the other
           participants are captured. Audio never leaves this Mac.
         NSCalendarsFullAccessUsageDescription: >-
-          LokalBotV3 reads your calendar to confirm meetings and title
+          LokalBot reads your calendar to confirm meetings and title
           recordings. Calendar data never leaves this Mac.
         LSApplicationCategoryType: public.app-category.productivity
         # Sparkle auto-update. SUFeedURL points at the appcast published with

--- a/web/index.html
+++ b/web/index.html
@@ -85,6 +85,10 @@
             <span class="track track--me">Me</span>
             <span class="track track--them">Them</span>
           </div>
+          <ul class="appcard__lines" aria-hidden="true">
+            <li><span class="spk spk--me">Me</span><span class="t">Let’s ship the <mark>on-device</mark> build Friday.</span></li>
+            <li><span class="spk spk--them">Them</span><span class="t">Agreed — I’ll send the recap with action items.</span></li>
+          </ul>
         </div>
       </div>
     </section>

--- a/web/styles.css
+++ b/web/styles.css
@@ -291,6 +291,36 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
 .track--me { color: var(--teal-bright); border-color: rgba(35, 196, 174, 0.4); background: var(--teal-soft); }
 .track--them { color: var(--text-dim); }
 
+/* Hero transcript snippet — shows the Me/Them transcript + a search match,
+   so the abstract app card also hints at the product's core artifact. */
+.appcard__lines {
+  margin: 18px 0 0;
+  padding: 12px 14px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: rgba(0, 0, 0, 0.28);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+}
+.appcard__lines li { display: flex; gap: 9px; align-items: baseline; }
+.appcard__lines .spk {
+  flex: 0 0 auto;
+  font-size: 0.62rem; font-weight: 700; letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 7px; border-radius: var(--pill);
+}
+.appcard__lines .spk--me { color: var(--teal-bright); background: var(--teal-soft); }
+.appcard__lines .spk--them { color: var(--text-dim); background: rgba(150, 180, 200, 0.1); }
+.appcard__lines .t { font-size: 0.8rem; color: var(--text-dim); line-height: 1.35; }
+.appcard__lines mark {
+  color: var(--teal-ink);
+  background: var(--teal-bright);
+  border-radius: 3px;
+  padding: 0 2px;
+}
+
 @keyframes wave { to { transform: scaleY(1); } }
 @keyframes float { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-12px); } }
 @keyframes pulse {


### PR DESCRIPTION
- Rename LokalBotV3 to LokalBot across the app and project.
- Add Brand.swift for app-wide brand tinting.
- Add CommandPaletteView for keyboard-first navigation.
- Add WaveformView for audio scrubbing and playback speed.
- Redesign OnboardingView with a value-first flow.
- Reorganize sidebar sections and update web landing page.

## Summary

<!--
One or two sentences: what changed and why. Skip the play-by-play.
The diff already shows what; this section should explain why.
-->

## Validation

<!--
What you actually ran and what you actually saw, not what you intended to run.
Examples:

  xcodegen generate
  xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot \
    -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
  # ** TEST SUCCEEDED **  N tests, 0 failures

  swiftlint lint --strict --quiet
  # exit 0

For UI changes, attach a screenshot or short screen recording.
For changes that can't be verified end-to-end yet, say so explicitly.
-->

## Linked issues

<!--
Use `Fixes #N` to auto-close on merge, `Refs #N` to link without closing.
-->

## Risk / rollout notes

<!--
Anything reviewers should know that isn't visible from the diff:
- project.yml, settings, or schema migrations
- Behavior changes that touch existing recording / transcription / summary flows
- Permission (TCC) or signing / notarization implications
- Performance characteristics worth flagging

Skip this section entirely if there's nothing to flag.
-->
