### PR TITLE
feat: in-process libllama cotyping runtime (dedicated Gemma default, HTTP fallback)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ Vendor/
 
 # Vercel CLI local link
 .vercel/
+
+# SDD progress ledger (scratch)
+.superpowers/

--- a/Docs/CotypingParityQA.md
+++ b/Docs/CotypingParityQA.md
@@ -30,10 +30,14 @@ Passing target:
 - p95 latency is at or below 2000 ms.
 - Expected-term hits are reviewed as a quality signal, not a hard pass/fail.
 
-Exact runtime parity is not complete while LokalBot runs suggestions through its
-dedicated HTTP `llama-server` process and Cotypist/Cotabby use an in-process
-llama.cpp runtime with prefix-state reuse. Treat the benchmark as a product
-quality check until the runtime path is shared or ported.
+- **Generation runtime — DONE.** Cotyping now decodes the built-in GGUF model
+  in-process via `libllama` (`b9789`), holding a persistent KV cache and
+  re-prefilling only the typed suffix (`LocalLlamaCotypingEngine` →
+  `LlamaCotypingRuntime`). The HTTP `llama-server` path remains as the fallback
+  for non-GGUF backends, when the in-process runtime is toggled off
+  (`cotypingInProcessRuntime`), or on load failure. A/B latency is measured by
+  `CotypingBenchmarkRunner.runAB(local:http:...)` over the default scenarios
+  (TTFT + p95 deltas).
 
 ## Manual Side-by-Side
 

--- a/Docs/CotypingParityQA.md
+++ b/Docs/CotypingParityQA.md
@@ -4,7 +4,9 @@ This checklist keeps LokalBot's cotyping work aligned with the quality bar obser
 
 Parity defaults:
 
-- Gemma 4 E4B Q5 XL is the recommended cotyping model.
+- Gemma 4 E4B Q5 XL is the default cotyping model. Cotyping always runs its own
+  dedicated model on a separate `llama-server` instance — there is no option to
+  reuse the summarization model, and no fallback to the bundled tiny model.
 - Suggestion length defaults to 20 words, matching Cotypist/Cotabby's 12-20 word preset upper bound.
 - Debounce defaults to 20 ms.
 - Streaming partial suggestions default off, matching Cotypist/Cotabby.
@@ -86,15 +88,16 @@ side-by-side screenshot pass.
 
 ## Model Prep Check
 
-Use "Prepare high-quality cotyping" in Cotyping, Models, or Settings.
+Cotyping always runs its own dedicated model. Use "Prepare high-quality cotyping"
+in Cotyping, Models, or Settings to fetch it.
 
 Expected behavior:
 
-- Dedicated cotyping is enabled.
-- Gemma 4 E4B Q5 XL is selected.
-- The Hugging Face download starts if the model is missing.
+- Gemma 4 E4B Q5 XL is the selected cotyping model by default.
+- The Hugging Face download starts if the model is missing (~6.66 GB).
+- Until the model is present, cotyping reports that it needs the download — there
+  is no fallback to the bundled summarization model.
 - Once downloaded, the status shows ready and cotyping uses the dedicated server.
 
-Gemma 4 E4B Q5 XL reuse is still supported: if Cotypist already has the parity
-GGUF in its Application Support folder, LokalBot uses that file read-only
-instead of redownloading it.
+LokalBot always downloads and manages its own copy of the model under its storage
+folder. It does not reuse another app's model files.

--- a/Docs/superpowers/plans/2026-06-29-inprocess-cotyping-runtime.md
+++ b/Docs/superpowers/plans/2026-06-29-inprocess-cotyping-runtime.md
@@ -1,0 +1,1551 @@
+# In-process `libllama` Cotyping Runtime Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the per-keystroke HTTP→`llama-server`→SSE cotyping path with an in-process `libllama` runtime that holds a persistent KV cache, re-prefills only the typed suffix, streams tokens natively, and cancels instantly — for the built-in GGUF backend only, with the HTTP engine retained as fallback.
+
+**Architecture:** Additive seam swap. The coordinator already depends only on `CotypingCompleting`. We add a `LlamaCore` C-interop module over the already-vendored `libllama.dylib` (`b9789`), an `LlamaCotypingRuntime` actor that owns the model/context/KV, a `LocalLlamaCotypingEngine: CotypingCompleting` that reuses the existing normalizer + stop policy, and a `CotypingEngineSelector` that routes built-in-GGUF-on-Apple-Silicon to the local engine and everything else to the existing HTTP `CotypingEngine`. Nothing in the orchestration, prompting, normalization, overlay, accept, learning, or debounce layers changes.
+
+**Tech Stack:** Swift 5.10 (actors, structured concurrency), C-interop via Clang module map, llama.cpp `libllama` C API pinned to release `b9789` (vendored `libllama.0.0.9789.dylib` + `libggml*.dylib`), Metal offload, XcodeGen (`project.yml` → `LokalBot.xcodeproj`), XCTest, `xcodebuild`.
+
+## Global Constraints
+
+Every task's requirements implicitly include this section. Values are copied verbatim from the design spec (`Docs/superpowers/specs/2026-06-29-inprocess-cotyping-runtime-design.md`) and standing project constraints.
+
+- **100% on-device.** Nothing leaves the device. No cloud calls. The in-process runtime makes zero network requests; it loads a local GGUF and decodes locally.
+- **Clipboard context is sensitive.** Read fresh at generation time, never cached or persisted. This plan does not touch clipboard handling — `CotypingRequestBuilder` already reads it fresh and the prompt arrives pre-built in `CotypingRequest`.
+- **Platform:** macOS 15.0+, Apple Silicon only. `MACOSX_DEPLOYMENT_TARGET = 15.0`.
+- **Version lock:** llama.cpp release **`b9789`**. Code against the *vendored header*, not memory. The dylibs are already in `Vendor/llama-cpp/` (`libllama.0.0.9789.dylib`); headers are fetched at the same tag.
+- **No new third-party dependency, no new binary in the bundle.** Reuse the exact dylibs and GGUF models already shipped. One model format (GGUF).
+- **Contained blast radius (spec §3):** Do NOT modify `CotypingCoordinator`, `CotypingPromptRenderer`/`CotypingRequestBuilder`, `CotypingTextNormalizer`, `CotypingOverlayController`, accept logic, the learning store, the debounce policy, or `LlamaServer`. The HTTP `CotypingEngine` stays as the fallback + non-GGUF path.
+- **No main-thread blocking.** `llama_decode` runs off the main actor (on the `LlamaCotypingRuntime` actor's executor). Only ghost-painting hops to `@MainActor`.
+- **Cotyping seam is `@MainActor`.** `CotypingCompleting` is `@MainActor`; all conformers and the selector are `@MainActor`.
+
+### Pinned `b9789` C API (verified via `nm -gU Vendor/llama-cpp/libllama.dylib`)
+
+These exact symbols are exported by the vendored dylib. Use these — the older `llama_kv_cache_*` / `llama_kv_self_*` / `llama_new_context_with_model` names are deprecated/renamed and MUST NOT be used (prefer the new names below, both happen to be exported):
+
+- Lifecycle: `llama_backend_init()`, `llama_backend_free()`, `llama_model_default_params()`, `llama_model_load_from_file(path, params)`, `llama_model_free(model)`, `llama_context_default_params()`, `llama_init_from_model(model, params)`, `llama_free(ctx)`.
+- Vocab/tokenize: `llama_model_get_vocab(model)`, `llama_vocab_n_tokens(vocab)`, `llama_vocab_bos(vocab)`, `llama_vocab_eos(vocab)`, `llama_vocab_is_eog(vocab, token)`, `llama_tokenize(vocab, text, text_len, tokens, n_max, add_special, parse_special)`, `llama_token_to_piece(vocab, token, buf, length, lstrip, special)`.
+- KV / memory (incremental prefill): `llama_get_memory(ctx)`, `llama_memory_seq_rm(mem, seq_id, p0, p1)`, `llama_memory_clear(mem, data)`.
+- Batch/decode: `llama_batch_init(n_tokens, embd, n_seq_max)`, `llama_batch_free(batch)`, `llama_decode(ctx, batch)`, `llama_n_ctx(ctx)`, `llama_n_batch(ctx)`.
+- Sampler: `llama_sampler_chain_default_params()`, `llama_sampler_chain_init(params)`, `llama_sampler_chain_add(chain, smpl)`, `llama_sampler_init_penalties(last_n, repeat, freq, present)`, `llama_sampler_init_top_k(k)`, `llama_sampler_init_top_p(p, min_keep)`, `llama_sampler_init_min_p(p, min_keep)`, `llama_sampler_init_temp(t)`, `llama_sampler_init_dist(seed)`, `llama_sampler_sample(smpl, ctx, idx)`, `llama_sampler_accept(smpl, token)`, `llama_sampler_free(smpl)`.
+
+Swift bridging notes: opaque `struct *` arrive as `OpaquePointer?`; `llama_token`/`llama_pos`/`llama_seq_id` are `Int32`; `llama_memory_t` is `OpaquePointer?`; `llama_batch` is a value struct with `token`, `pos`, `n_seq_id`, `seq_id`, `logits`, `n_tokens` fields; `min_keep` params are `size_t` (pass Swift `Int`); seed is `UInt32`.
+
+---
+
+## File Structure
+
+**Create:**
+- `Vendor/llama-cpp/include/module.modulemap` — declares the `LlamaCore` Clang module (headers fetched by the build script alongside it).
+- `LokalBot/Cotyping/Llama/IncrementalPrefill.swift` — pure common-prefix helper (the latency heart).
+- `LokalBot/Cotyping/Llama/LlamaSamplerSpec.swift` — pure config→sampler-chain descriptor mapping.
+- `LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift` — the inference actor (model/context/KV/decode).
+- `LokalBot/Cotyping/Llama/LocalLlamaCotypingEngine.swift` — `CotypingCompleting` conformer (the seam).
+- `LokalBot/Cotyping/Llama/CotypingEngineSelector.swift` — per-completion local-vs-HTTP router + prewarm.
+- `LokalBotTests/IncrementalPrefillTests.swift`
+- `LokalBotTests/LlamaSamplerSpecTests.swift`
+- `LokalBotTests/CotypingEngineSelectorTests.swift`
+- `LokalBotTests/LlamaCotypingRuntimeTests.swift` — integration, gated on bundled model presence.
+- `LokalBotTests/CotypingABBenchmarkTests.swift`
+
+**Modify:**
+- `Scripts/fetch-llama.sh` — also fetch `b9789` headers into `Vendor/llama-cpp/include/`.
+- `project.yml` — header search path + `SWIFT_INCLUDE_PATHS` (module map) + link `-lllama` + `LD_RUNPATH_SEARCH_PATHS`.
+- `LokalBot/Models/AppSettings.swift` — add `cotypingInProcessRuntime: Bool` (default `true`), tolerant decode.
+- `LokalBot/LokalBotApp.swift` — `cotypingEngine` becomes a `CotypingEngineSelector`; prewarm on cotyping-enable.
+- `LokalBot/Cotyping/CotypingBenchmark.swift` — A/B (local vs HTTP) summary + TTFT/prefill probes.
+- `LokalBot/Views/SettingsView.swift` — a toggle for the in-process runtime flag.
+- `Docs/CotypingParityQA.md` — mark the runtime parity item complete; document the A/B benchmark.
+
+---
+
+## Task 1: Build spike — `LlamaCore` C module links, loads, and runs
+
+The riskiest piece (spec risk: "Link / `@rpath` issues"; open question #2: exact header set). Prove the module imports, the dylib links, `@rpath` resolves at runtime, and a real C call executes — before any runtime code is written. Fold header fetch + module map + project wiring into this one task; its deliverable is a passing test that calls into `libllama`.
+
+**Files:**
+- Modify: `Scripts/fetch-llama.sh`
+- Create: `Vendor/llama-cpp/include/module.modulemap`
+- Modify: `project.yml`
+- Test: `LokalBotTests/LlamaCoreSmokeTests.swift` (create)
+
+**Interfaces:**
+- Consumes: vendored `Vendor/llama-cpp/libllama.dylib` (+ `libggml*.dylib`), `b9789`.
+- Produces: a Swift-importable module `LlamaCore` exposing the `b9789` C API; build settings other targets inherit (`HEADER_SEARCH_PATHS`, `SWIFT_INCLUDE_PATHS`, link flags, rpath). Later tasks `import LlamaCore`.
+
+- [ ] **Step 1: Add header fetch to `Scripts/fetch-llama.sh`**
+
+Open `Scripts/fetch-llama.sh`. It already sets `TAG=b9789`, `SERVER_DIR=Vendor/llama-cpp`, and downloads/extracts `llama-$TAG-bin-macos-arm64.tar.gz`. After the block that copies `llama-server` + `*.dylib` into `$SERVER_DIR`, add a header-fetch block. The macOS bin tarball does not reliably ship headers, so fetch them from the pinned source tag. Insert:
+
+```bash
+# --- Public C headers for in-process libllama (LlamaCore module) ---
+# Fetched from the pinned source tag so the Swift module compiles against the
+# exact b9789 API the vendored dylib exports. Idempotent: skip if present.
+INCLUDE_DIR="$SERVER_DIR/include"
+RAW_BASE="https://raw.githubusercontent.com/ggml-org/llama.cpp/$TAG"
+HEADERS=(
+  "include/llama.h"
+  "ggml/include/ggml.h"
+  "ggml/include/ggml-backend.h"
+  "ggml/include/ggml-alloc.h"
+  "ggml/include/ggml-cpu.h"
+  "ggml/include/ggml-metal.h"
+)
+mkdir -p "$INCLUDE_DIR"
+for h in "${HEADERS[@]}"; do
+  dest="$INCLUDE_DIR/$(basename "$h")"
+  if [ ! -f "$dest" ]; then
+    echo "fetch-llama: downloading header $(basename "$h")"
+    curl -fsSL "$RAW_BASE/$h" -o "$dest"
+  fi
+done
+```
+
+- [ ] **Step 2: Run the script and confirm headers land**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && bash Scripts/fetch-llama.sh && ls Vendor/llama-cpp/include`
+Expected: lists `llama.h ggml.h ggml-backend.h ggml-alloc.h ggml-cpu.h ggml-metal.h` (and no error). If `curl` 404s on a header, that header moved at this tag — open the tag tree at `https://github.com/ggml-org/llama.cpp/tree/b9789/ggml/include` to find its path and fix the `HEADERS` entry. This is the open-question-#2 resolution: confirm the transitive set compiles in Step 6 and trim/extend here.
+
+- [ ] **Step 3: Confirm the dylib install name + that the needed symbols exist**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && otool -D Vendor/llama-cpp/libllama.dylib && nm -gU Vendor/llama-cpp/libllama.dylib | grep -E '_llama_(backend_init|model_default_params|model_load_from_file|init_from_model|get_memory|memory_seq_rm|tokenize|decode|sampler_sample)$' | sort`
+Expected: `otool -D` prints an install name (e.g. `@rpath/libllama.0.0.9789.dylib` or `@rpath/libllama.dylib`); the `nm` grep lists all nine symbols. Note the `@rpath` value — Step 5 must make that rpath resolve.
+
+- [ ] **Step 4: Create the `LlamaCore` module map**
+
+Create `Vendor/llama-cpp/include/module.modulemap`:
+
+```
+module LlamaCore {
+    header "llama.h"
+    header "ggml.h"
+    header "ggml-backend.h"
+    header "ggml-alloc.h"
+    header "ggml-cpu.h"
+    export *
+}
+```
+
+(If Step 6 reports a missing header that `llama.h` transitively includes, add a `header "..."` line for it here and a corresponding entry in the script's `HEADERS` array, then re-run Step 2.)
+
+- [ ] **Step 5: Wire `project.yml` — header path, module, link, rpath**
+
+Open `project.yml`. It has **no top-level `settings:` block** today — shared app settings live in the `LokalBotApp` *template* (which `LokalBot`, `LokalBot Dev`, and `LokalBot UI Test Host` all inherit), and each target has its own `settings.base`. Make two additions:
+
+**(a)** Add a **new top-level `settings:` block** (place it right after the `options:` block, before `packages:`) so every target — the app targets *and* `LokalBotTests`, which `import LlamaCore` directly — sees the module:
+
+```yaml
+settings:
+  base:
+    HEADER_SEARCH_PATHS:
+      - $(inherited)
+      - $(SRCROOT)/Vendor/llama-cpp/include
+    SWIFT_INCLUDE_PATHS:
+      - $(inherited)
+      - $(SRCROOT)/Vendor/llama-cpp/include
+```
+
+**(b)** Add the link flags to the **`LokalBotApp` template's** existing `settings.base` (around line 124, alongside `SWIFT_VERSION`/`DEVELOPMENT_TEAM`), so all three app targets link the dylib and get the runtime search path — but the test bundle does not (it resolves libllama symbols through its `TEST_HOST` app at runtime):
+
+```yaml
+        LIBRARY_SEARCH_PATHS:
+          - $(inherited)
+          - $(SRCROOT)/Vendor/llama-cpp
+        OTHER_LDFLAGS:
+          - $(inherited)
+          - -lllama
+        LD_RUNPATH_SEARCH_PATHS:
+          - $(inherited)
+          - "@executable_path/../Resources/llama-cpp"
+```
+
+Notes: `-lllama` resolves the `libllama.dylib` symlink in `Vendor/llama-cpp`. The dylibs continue to be copied into `Contents/Resources/llama-cpp/` by the existing `Vendor/llama-cpp` folder **resource** build phase in the template (DO NOT remove it — `llama-server` and the in-process link both rely on those Resources copies). The rpath `@executable_path/../Resources/llama-cpp` makes the linked `@rpath/libllama*.dylib` (and transitively `libggml*.dylib`) resolve at runtime. The `Vendor/llama-cpp/include/` headers also get copied into the bundle as part of that folder resource — harmless (a few KB).
+
+- [ ] **Step 6: Regenerate the project and write the smoke test**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodegen generate`
+Expected: `Loaded project ... Created project at LokalBot.xcodeproj` with no error.
+
+Create `LokalBotTests/LlamaCoreSmokeTests.swift`:
+
+```swift
+import XCTest
+import LlamaCore
+
+/// Proves the LlamaCore module imports, the vendored libllama.dylib links, and
+/// the @rpath resolves at runtime by executing real b9789 C calls.
+final class LlamaCoreSmokeTests: XCTestCase {
+    func testBackendInitAndDefaultParamsLink() {
+        llama_backend_init()
+        let model = llama_model_default_params()
+        // Full Metal offload is what the runtime will request; the field must exist.
+        XCTAssertGreaterThanOrEqual(model.n_gpu_layers, 0)
+        let ctx = llama_context_default_params()
+        XCTAssertGreaterThan(ctx.n_ctx, 0)
+        llama_backend_free()
+    }
+}
+```
+
+- [ ] **Step 7: Run the smoke test (it must build, link, and pass)**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/LlamaCoreSmokeTests 2>&1 | tail -25`
+Expected: `Test Suite 'LlamaCoreSmokeTests' passed`, `** TEST SUCCEEDED **`. If it fails to *link* (`Undefined symbols` / `library not found for -lllama`), fix `LIBRARY_SEARCH_PATHS`/`OTHER_LDFLAGS` (Step 5) and regenerate. If it builds but *crashes at runtime* (`dyld: Library not loaded: @rpath/libllama...`), the rpath is wrong — re-check the install name from Step 3 against `LD_RUNPATH_SEARCH_PATHS`. If a *header* is missing during compile, add it (Step 4 note).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot
+git add Scripts/fetch-llama.sh Vendor/llama-cpp/include/module.modulemap project.yml LokalBot.xcodeproj LokalBotTests/LlamaCoreSmokeTests.swift
+git commit -m "build: link in-process libllama via LlamaCore module (b9789)"
+```
+
+(If `Vendor/llama-cpp/include/*.h` are tracked rather than `.gitignore`d like the dylibs, `git add` them too; match whatever the existing `Vendor/llama-cpp` dylibs do — check `git check-ignore Vendor/llama-cpp/libllama.dylib` first.)
+
+---
+
+## Task 2: `IncrementalPrefill.commonPrefixLength` — the latency heart (pure)
+
+Pure, no libllama, fully unit-testable. Returns how many leading tokens two sequences share, so the runtime drops only the diverged KV tail.
+
+**Files:**
+- Create: `LokalBot/Cotyping/Llama/IncrementalPrefill.swift`
+- Test: `LokalBotTests/IncrementalPrefillTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `enum IncrementalPrefill { static func commonPrefixLength(_ a: [Int32], _ b: [Int32]) -> Int }`. Used by `LlamaCotypingRuntime` (Task 4).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `LokalBotTests/IncrementalPrefillTests.swift`:
+
+```swift
+import XCTest
+@testable import LokalBot
+
+final class IncrementalPrefillTests: XCTestCase {
+    func testEmptyInputs() {
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([], []), 0)
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([1, 2], []), 0)
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([], [1, 2]), 0)
+    }
+
+    func testIdenticalSequences() {
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([1, 2, 3], [1, 2, 3]), 3)
+    }
+
+    func testDivergeAtZero() {
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([9, 2, 3], [1, 2, 3]), 0)
+    }
+
+    func testOneIsPrefixOfOther() {
+        // Typing forward: old cache [1,2,3], new prompt [1,2,3,4,5] → reuse 3.
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([1, 2, 3], [1, 2, 3, 4, 5]), 3)
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([1, 2, 3, 4, 5], [1, 2, 3]), 3)
+    }
+
+    func testDivergeInMiddle() {
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([1, 2, 3, 4], [1, 2, 9, 4]), 2)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/IncrementalPrefillTests 2>&1 | tail -15`
+Expected: FAIL — `cannot find 'IncrementalPrefill' in scope` (compile error).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `LokalBot/Cotyping/Llama/IncrementalPrefill.swift`:
+
+```swift
+import Foundation
+
+/// Pure helper for KV-cache reuse. Given the token sequence currently resident
+/// in the llama context (`cached`) and the freshly tokenized prompt (`next`),
+/// returns the number of leading tokens they share. The runtime keeps that
+/// prefix in the KV cache and re-prefills only `next[p...]`, which is what makes
+/// per-keystroke decode cheap as the user types forward.
+enum IncrementalPrefill {
+    static func commonPrefixLength(_ a: [Int32], _ b: [Int32]) -> Int {
+        let limit = min(a.count, b.count)
+        var p = 0
+        while p < limit && a[p] == b[p] { p += 1 }
+        return p
+    }
+}
+```
+
+- [ ] **Step 4: Add the file to the project and run the test**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodegen generate && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/IncrementalPrefillTests 2>&1 | tail -15`
+Expected: `Test Suite 'IncrementalPrefillTests' passed`, 5 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot
+git add LokalBot/Cotyping/Llama/IncrementalPrefill.swift LokalBotTests/IncrementalPrefillTests.swift LokalBot.xcodeproj
+git commit -m "feat: add IncrementalPrefill.commonPrefixLength for KV reuse"
+```
+
+---
+
+## Task 3: `LlamaSamplerSpec` — config→sampler-chain descriptor (pure)
+
+Map `CotypingConfiguration`'s sampler knobs to an ordered, value-typed descriptor of the llama sampler chain. Keeping the *mapping* pure makes it unit-testable without libllama (spec §14 "Sampler-config mapping"); the runtime (Task 4) turns the descriptor into the real C chain.
+
+**Files:**
+- Create: `LokalBot/Cotyping/Llama/LlamaSamplerSpec.swift`
+- Test: `LokalBotTests/LlamaSamplerSpecTests.swift`
+
+**Interfaces:**
+- Consumes: `CotypingConfiguration` (fields `temperature`, `topP`, `topK`, `minP`, `repeatPenalty`, `seed`).
+- Produces:
+  - `enum LlamaSamplerSpec: Equatable { case penalties(lastN: Int32, repeat: Float, freq: Float, present: Float); case topK(Int32); case topP(Float, minKeep: Int); case minP(Float, minKeep: Int); case temp(Float); case dist(seed: UInt32) }`
+  - `static func LlamaSamplerSpec.specs(temperature: Float, topK: Int32, topP: Float, minP: Float, repeatPenalty: Float, repeatLastN: Int32, seed: UInt32) -> [LlamaSamplerSpec]`
+  - `static func LlamaSamplerSpec.specs(from config: CotypingConfiguration) -> [LlamaSamplerSpec]`
+  - Used by `LlamaCotypingRuntime.makeSampler` (Task 4) and `LocalLlamaCotypingEngine` (Task 5, maps the per-request params).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `LokalBotTests/LlamaSamplerSpecTests.swift`:
+
+```swift
+import XCTest
+@testable import LokalBot
+
+final class LlamaSamplerSpecTests: XCTestCase {
+    func testStandardConfigMapsToOrderedChain() {
+        let specs = LlamaSamplerSpec.specs(from: .standard)
+        XCTAssertEqual(specs, [
+            .penalties(lastN: 64, repeat: 1.05, freq: 0, present: 0),
+            .topK(20),
+            .topP(0.7, minKeep: 1),
+            .minP(0.08, minKeep: 1),
+            .temp(0.1),
+            .dist(seed: 0x00C0_FFEE),
+        ])
+    }
+
+    func testExplicitParamsPreserveSamplerOrder() {
+        let specs = LlamaSamplerSpec.specs(
+            temperature: 0.2, topK: 40, topP: 0.9, minP: 0.05,
+            repeatPenalty: 1.1, repeatLastN: 64, seed: 42)
+        XCTAssertEqual(specs.map(\.order), [0, 1, 2, 3, 4, 5])
+        XCTAssertEqual(specs.last, .dist(seed: 42))
+    }
+}
+
+private extension LlamaSamplerSpec {
+    var order: Int {
+        switch self {
+        case .penalties: 0
+        case .topK: 1
+        case .topP: 2
+        case .minP: 3
+        case .temp: 4
+        case .dist: 5
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/LlamaSamplerSpecTests 2>&1 | tail -15`
+Expected: FAIL — `cannot find 'LlamaSamplerSpec' in scope`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `LokalBot/Cotyping/Llama/LlamaSamplerSpec.swift`:
+
+```swift
+import Foundation
+
+/// Value-typed description of the llama.cpp sampler chain, in apply order.
+/// Pure so the config→chain mapping is unit-testable without libllama; the
+/// runtime turns each case into the matching `llama_sampler_init_*` call.
+///
+/// Order mirrors llama.cpp's `common` default for this subset:
+/// penalties → top_k → top_p → min_p → temp → dist (final distribution sampler).
+enum LlamaSamplerSpec: Equatable {
+    case penalties(lastN: Int32, repeat: Float, freq: Float, present: Float)
+    case topK(Int32)
+    case topP(Float, minKeep: Int)
+    case minP(Float, minKeep: Int)
+    case temp(Float)
+    case dist(seed: UInt32)
+
+    static func specs(
+        temperature: Float,
+        topK: Int32,
+        topP: Float,
+        minP: Float,
+        repeatPenalty: Float,
+        repeatLastN: Int32,
+        seed: UInt32
+    ) -> [LlamaSamplerSpec] {
+        [
+            .penalties(lastN: repeatLastN, repeat: repeatPenalty, freq: 0, present: 0),
+            .topK(topK),
+            .topP(topP, minKeep: 1),
+            .minP(minP, minKeep: 1),
+            .temp(temperature),
+            .dist(seed: seed),
+        ]
+    }
+
+    static func specs(from config: CotypingConfiguration) -> [LlamaSamplerSpec] {
+        specs(
+            temperature: Float(config.temperature),
+            topK: Int32(config.topK),
+            topP: Float(config.topP),
+            minP: Float(config.minP),
+            repeatPenalty: Float(config.repeatPenalty),
+            repeatLastN: 64,
+            seed: UInt32(truncatingIfNeeded: config.seed))
+    }
+}
+```
+
+(Verified against `LokalBot/Cotyping/CotypingModels.swift`: `CotypingConfiguration` stores `temperature`/`topP`/`minP`/`repeatPenalty` as `Double` and `topK`/`seed` as `Int`, so the `Float(...)`, `Int32(...)`, and `UInt32(truncatingIfNeeded:)` conversions above are exactly the required casts. `CotypingConfiguration.standard` is the source of the expected values in the test.)
+
+- [ ] **Step 4: Add to project and run the test**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodegen generate && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/LlamaSamplerSpecTests 2>&1 | tail -15`
+Expected: `Test Suite 'LlamaSamplerSpecTests' passed`, 2 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot
+git add LokalBot/Cotyping/Llama/LlamaSamplerSpec.swift LokalBotTests/LlamaSamplerSpecTests.swift LokalBot.xcodeproj
+git commit -m "feat: add LlamaSamplerSpec config→sampler-chain mapping"
+```
+
+---
+
+## Task 4: `LlamaCotypingRuntime` — the inference actor
+
+Owns the model + context + KV. Loads once, warms up, tokenizes, runs incremental prefill + the decode loop, all off the main actor. This is the largest task; its integration test is gated on the bundled `Qwen3.5-0.8B-Q4_K_M` model being present and proves both deterministic output and KV reuse.
+
+**Files:**
+- Create: `LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift`
+- Test: `LokalBotTests/LlamaCotypingRuntimeTests.swift`
+
+**Interfaces:**
+- Consumes: `LlamaCore` (Task 1), `IncrementalPrefill.commonPrefixLength` (Task 2), `LlamaSamplerSpec` (Task 3).
+- Produces (the actor's surface, used by `LocalLlamaCotypingEngine` in Task 5):
+  - `actor LlamaCotypingRuntime`
+  - `enum LlamaRuntimeError: Error { case modelLoadFailed(String); case contextInitFailed; case decodeFailed }`
+  - `func loadIfNeeded(modelPath: String) throws`
+  - `func unload()`
+  - `var isLoaded: Bool { get }`
+  - `func tokenize(_ text: String, addBOS: Bool) -> [Int32]`
+  - `func generate(promptTokens: [Int32], maxTokens: Int, samplerSpecs: [LlamaSamplerSpec], onToken: @Sendable (String) -> Bool) -> String`
+  - `private(set) var lastPrefillTokenCount: Int` — number of tokens decoded during the most recent prefill (the KV-reuse probe).
+  - `func prewarm(modelPath: String) throws` — `loadIfNeeded` already runs a priming decode, so this is `loadIfNeeded`.
+
+- [ ] **Step 1: Write the failing integration test (gated on the bundled model)**
+
+Create `LokalBotTests/LlamaCotypingRuntimeTests.swift`:
+
+```swift
+import XCTest
+@testable import LokalBot
+
+final class LlamaCotypingRuntimeTests: XCTestCase {
+
+    /// Resolves the bundled tiny model from the app bundle's Resources, or skips.
+    private func bundledModelPath() throws -> String {
+        let entry = ModelCatalog.entry(id: ModelCatalog.bundledID)!
+        let storage = StorageManager()
+        guard let url = ModelCatalog.localURL(for: entry, storage: storage) else {
+            throw XCTSkip("Bundled model \(entry.fileName) not present; skipping libllama integration test.")
+        }
+        return url.path
+    }
+
+    private let standardSpecs = LlamaSamplerSpec.specs(from: .standard)
+
+    func testLoadsAndGeneratesDeterministically() async throws {
+        let path = try bundledModelPath()
+        let runtime = LlamaCotypingRuntime()
+        try await runtime.loadIfNeeded(modelPath: path)
+        let loaded = await runtime.isLoaded
+        XCTAssertTrue(loaded)
+
+        let prompt = await runtime.tokenize("The capital of France is", addBOS: true)
+        XCTAssertFalse(prompt.isEmpty)
+
+        let first = await runtime.generate(
+            promptTokens: prompt, maxTokens: 8, samplerSpecs: standardSpecs) { _ in true }
+        XCTAssertFalse(first.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+        // Same prompt + fixed seed (0x00C0FFEE in standardSpecs) → identical output.
+        try await runtime.loadIfNeeded(modelPath: path) // no-op reload
+        let second = await runtime.generate(
+            promptTokens: prompt, maxTokens: 8, samplerSpecs: standardSpecs) { _ in true }
+        XCTAssertEqual(first, second, "fixed seed must produce deterministic output")
+    }
+
+    func testKVReuseDecodesOnlySuffix() async throws {
+        let path = try bundledModelPath()
+        let runtime = LlamaCotypingRuntime()
+        try await runtime.loadIfNeeded(modelPath: path)
+
+        let base = await runtime.tokenize("Hi Sarah, thanks for sending this over. I wanted to follow", addBOS: true)
+        _ = await runtime.generate(promptTokens: base, maxTokens: 2, samplerSpecs: standardSpecs) { _ in true }
+        let firstPrefill = await runtime.lastPrefillTokenCount
+        XCTAssertEqual(firstPrefill, base.count, "cold prompt prefills every token")
+
+        // Extend the prompt: the shared prefix must be reused, only the suffix decoded.
+        let extended = base + (await runtime.tokenize(" up tomorrow", addBOS: false))
+        _ = await runtime.generate(promptTokens: extended, maxTokens: 2, samplerSpecs: standardSpecs) { _ in true }
+        let secondPrefill = await runtime.lastPrefillTokenCount
+        XCTAssertLessThan(secondPrefill, extended.count, "KV reuse must skip the shared prefix")
+        XCTAssertEqual(secondPrefill, extended.count - base.count,
+                       "only the appended suffix should be prefilled")
+    }
+
+    func testOnTokenReturningFalseStopsDecode() async throws {
+        let path = try bundledModelPath()
+        let runtime = LlamaCotypingRuntime()
+        try await runtime.loadIfNeeded(modelPath: path)
+        let prompt = await runtime.tokenize("Once upon a time", addBOS: true)
+        var count = 0
+        let out = await runtime.generate(
+            promptTokens: prompt, maxTokens: 20, samplerSpecs: standardSpecs
+        ) { _ in count += 1; return count < 3 }   // stop after 3 tokens
+        XCTAssertLessThanOrEqual(count, 3)
+        XCTAssertFalse(out.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/LlamaCotypingRuntimeTests 2>&1 | tail -15`
+Expected: FAIL — `cannot find 'LlamaCotypingRuntime' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift`:
+
+```swift
+import Foundation
+import LlamaCore
+
+enum LlamaRuntimeError: Error, Equatable {
+    case modelLoadFailed(String)
+    case contextInitFailed
+    case decodeFailed
+}
+
+/// In-process llama.cpp runtime for cotyping. Owns the model, a persistent
+/// context + KV cache, and serializes all inference on the actor's executor
+/// (off the main actor). Re-prefills only the diverged suffix per call
+/// (`IncrementalPrefill`), which is what makes per-keystroke decode cheap.
+///
+/// Pinned to llama.cpp `b9789`; symbols verified against the vendored dylib.
+actor LlamaCotypingRuntime {
+    private var model: OpaquePointer?
+    private var ctx: OpaquePointer?
+    private var vocab: OpaquePointer?
+    private var loadedModelPath: String?
+    /// Tokens currently resident in the KV cache (basis for incremental prefill).
+    private var cachedTokens: [Int32] = []
+    private(set) var lastPrefillTokenCount: Int = 0
+
+    private static var backendReady = false
+
+    var isLoaded: Bool { model != nil && ctx != nil }
+
+    // MARK: - Lifecycle
+
+    func loadIfNeeded(modelPath: String) throws {
+        if isLoaded, loadedModelPath == modelPath { return }
+        unload()
+
+        if !Self.backendReady {
+            llama_backend_init()
+            Self.backendReady = true
+        }
+
+        var mparams = llama_model_default_params()
+        mparams.n_gpu_layers = 99   // full Metal offload (matches LlamaServer's -ngl 99)
+        guard let m = llama_model_load_from_file(modelPath, mparams) else {
+            throw LlamaRuntimeError.modelLoadFailed(modelPath)
+        }
+
+        var cparams = llama_context_default_params()
+        cparams.n_ctx = 2048        // matches LlamaServer.cotyping.contextTokens
+        cparams.n_batch = 2048
+        let threads = Int32(max(1, ProcessInfo.processInfo.activeProcessorCount - 2))
+        cparams.n_threads = threads
+        cparams.n_threads_batch = threads
+        guard let c = llama_init_from_model(m, cparams) else {
+            llama_model_free(m)
+            throw LlamaRuntimeError.contextInitFailed
+        }
+
+        model = m
+        ctx = c
+        vocab = llama_model_get_vocab(m)
+        loadedModelPath = modelPath
+        cachedTokens = []
+        lastPrefillTokenCount = 0
+        warmup()
+    }
+
+    /// Prewarm == load + the priming decode `loadIfNeeded` already performs.
+    func prewarm(modelPath: String) throws { try loadIfNeeded(modelPath: modelPath) }
+
+    func unload() {
+        if let c = ctx { llama_free(c) }
+        if let m = model { llama_model_free(m) }
+        ctx = nil
+        model = nil
+        vocab = nil
+        loadedModelPath = nil
+        cachedTokens = []
+    }
+
+    /// Runs one priming decode so Metal pipelines are hot before the first real
+    /// keystroke, then clears the KV so generation starts from a clean cache.
+    private func warmup() {
+        guard let vocab, let ctx else { return }
+        let bos = llama_vocab_bos(vocab)
+        _ = decode([bos], startPos: 0, logitsLastOnly: true)
+        llama_memory_clear(llama_get_memory(ctx), true)
+        cachedTokens = []
+    }
+
+    // MARK: - Tokenize / detokenize
+
+    func tokenize(_ text: String, addBOS: Bool) -> [Int32] {
+        guard let vocab else { return [] }
+        return text.withCString { cstr -> [Int32] in
+            let textLen = Int32(strlen(cstr))
+            var capacity = textLen + (addBOS ? 1 : 0) + 8
+            var tokens = [Int32](repeating: 0, count: Int(capacity))
+            var n = llama_tokenize(vocab, cstr, textLen, &tokens, capacity, addBOS, true)
+            if n < 0 {                      // buffer too small: -n is required size
+                capacity = -n
+                tokens = [Int32](repeating: 0, count: Int(capacity))
+                n = llama_tokenize(vocab, cstr, textLen, &tokens, capacity, addBOS, true)
+            }
+            return Array(tokens.prefix(Int(max(0, n))))
+        }
+    }
+
+    private func piece(for token: Int32) -> String {
+        guard let vocab else { return "" }
+        var buf = [CChar](repeating: 0, count: 64)
+        var n = llama_token_to_piece(vocab, token, &buf, Int32(buf.count), 0, false)
+        if n < 0 {
+            buf = [CChar](repeating: 0, count: Int(-n))
+            n = llama_token_to_piece(vocab, token, &buf, Int32(buf.count), 0, false)
+        }
+        guard n > 0 else { return "" }
+        let bytes = buf.prefix(Int(n)).map { UInt8(bitPattern: $0) }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+
+    // MARK: - Decode
+
+    /// Decodes `tokens` starting at `startPos` in sequence 0. When
+    /// `logitsLastOnly` is true only the final token requests logits (prefill).
+    @discardableResult
+    private func decode(_ tokens: [Int32], startPos: Int32, logitsLastOnly: Bool) -> Bool {
+        guard let ctx, !tokens.isEmpty else { return true }
+        var batch = llama_batch_init(Int32(tokens.count), 0, 1)
+        defer { llama_batch_free(batch) }
+        for i in 0..<tokens.count {
+            batch.token[i] = tokens[i]
+            batch.pos[i] = startPos + Int32(i)
+            batch.n_seq_id[i] = 1
+            batch.seq_id[i]![0] = 0
+            batch.logits[i] = (logitsLastOnly ? (i == tokens.count - 1) : true) ? 1 : 0
+        }
+        batch.n_tokens = Int32(tokens.count)
+        return llama_decode(ctx, batch) == 0
+    }
+
+    // MARK: - Generate
+
+    func generate(
+        promptTokens: [Int32],
+        maxTokens: Int,
+        samplerSpecs: [LlamaSamplerSpec],
+        onToken: @Sendable (String) -> Bool
+    ) -> String {
+        guard let ctx, let vocab, !promptTokens.isEmpty else { return "" }
+        guard let sampler = makeSampler(samplerSpecs) else { return "" }
+        defer { llama_sampler_free(sampler) }
+
+        let mem = llama_get_memory(ctx)
+        let reuse = IncrementalPrefill.commonPrefixLength(cachedTokens, promptTokens)
+        // Drop the diverged tail from the KV cache (keep [0, reuse)).
+        llama_memory_seq_rm(mem, 0, Int32(reuse), -1)
+
+        var newTokens = Array(promptTokens[reuse...])
+        var prefillStart = Int32(reuse)
+        if newTokens.isEmpty {
+            // Prompt identical to cache: re-decode the final token to refresh logits.
+            llama_memory_seq_rm(mem, 0, Int32(promptTokens.count - 1), -1)
+            newTokens = [promptTokens[promptTokens.count - 1]]
+            prefillStart = Int32(promptTokens.count - 1)
+        }
+        lastPrefillTokenCount = newTokens.count
+        guard decode(newTokens, startPos: prefillStart, logitsLastOnly: true) else { return "" }
+        cachedTokens = promptTokens
+
+        var output = ""
+        var pos = Int32(promptTokens.count)
+        for _ in 0..<maxTokens {
+            let tok = llama_sampler_sample(sampler, ctx, -1)
+            if llama_vocab_is_eog(vocab, tok) { break }
+            llama_sampler_accept(sampler, tok)
+            let text = piece(for: tok)
+            output += text
+            if !onToken(text) { break }
+            cachedTokens.append(tok)
+            guard decode([tok], startPos: pos, logitsLastOnly: true) else { break }
+            pos += 1
+        }
+        return output
+    }
+
+    private func makeSampler(_ specs: [LlamaSamplerSpec]) -> OpaquePointer? {
+        let params = llama_sampler_chain_default_params()
+        guard let chain = llama_sampler_chain_init(params) else { return nil }
+        for spec in specs {
+            let s: OpaquePointer?
+            switch spec {
+            case let .penalties(lastN, rep, freq, present):
+                s = llama_sampler_init_penalties(lastN, rep, freq, present)
+            case let .topK(k):            s = llama_sampler_init_top_k(k)
+            case let .topP(p, minKeep):   s = llama_sampler_init_top_p(p, minKeep)
+            case let .minP(p, minKeep):   s = llama_sampler_init_min_p(p, minKeep)
+            case let .temp(t):            s = llama_sampler_init_temp(t)
+            case let .dist(seed):         s = llama_sampler_init_dist(seed)
+            }
+            if let s { llama_sampler_chain_add(chain, s) }
+        }
+        return chain
+    }
+}
+```
+
+- [ ] **Step 4: Add to project and run the integration test**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodegen generate && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/LlamaCotypingRuntimeTests 2>&1 | tail -30`
+Expected: `Test Suite 'LlamaCotypingRuntimeTests' passed`, 3 tests, 0 failures — OR each test reports `Skipped` if the bundled GGUF isn't resolvable in the test host (acceptable on CI; the code still had to compile + link). If a test *fails* on `seq_id[i]!` being nil, the batch's `n_seq_max` was too small — confirm `llama_batch_init(..., 1)`. If `testKVReuseDecodesOnlySuffix` fails because `secondPrefill == extended.count`, the tokenizer re-added a BOS to the suffix; confirm the test tokenizes the suffix with `addBOS: false` (it does) and that `commonPrefixLength` sees the shared prefix.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot
+git add LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift LokalBotTests/LlamaCotypingRuntimeTests.swift LokalBot.xcodeproj
+git commit -m "feat: add LlamaCotypingRuntime in-process inference actor (KV reuse, warmup)"
+```
+
+---
+
+## Task 5: `LocalLlamaCotypingEngine` — the `CotypingCompleting` seam
+
+Adapt the runtime to the protocol the coordinator already calls. Reuse the existing `CotypingTextNormalizer.normalizeDetailed` + `CotypingDecodeStopPolicy.verdict` unchanged. Honor `Task.isCancelled` so a superseding keystroke stops decode within one token (the coordinator already cancels the in-flight task — see plan note below).
+
+**Files:**
+- Create: `LokalBot/Cotyping/Llama/LocalLlamaCotypingEngine.swift`
+- Test: `LokalBotTests/LlamaCotypingRuntimeTests.swift` (add cases) — or a new `LocalLlamaCotypingEngineTests.swift`.
+
+**Interfaces:**
+- Consumes: `LlamaCotypingRuntime` (Task 4), `LlamaSamplerSpec` (Task 3), `CotypingRequest`/`CotypingNormalizationResult`/`CotypingTextNormalizer`/`CotypingDecodeStopPolicy`/`CotypingCompleting` (existing).
+- Produces: `@MainActor final class LocalLlamaCotypingEngine: CotypingCompleting`, `init(runtime: LlamaCotypingRuntime, modelPath: String)`, plus `func prewarm() async throws`. Used by the selector (Task 7).
+
+> **Cancellation note (no coordinator change):** `CotypingCoordinator.scheduleGeneration()` cancels `debounceTask` and `generate(work:)` runs *inside* that task, so a superseding keystroke cancels the task while it is suspended in `engine.generateStreaming`. Therefore checking `Task.isCancelled` inside the per-token closure halts decode immediately. This is the same mechanism the HTTP engine relies on (it observes `URLError.cancelled`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `LokalBotTests/LlamaCotypingRuntimeTests.swift` a new `@MainActor` test class (the engine is `@MainActor`):
+
+```swift
+@MainActor
+final class LocalLlamaCotypingEngineTests: XCTestCase {
+    private func bundledModelPath() throws -> String {
+        let entry = ModelCatalog.entry(id: ModelCatalog.bundledID)!
+        guard let url = ModelCatalog.localURL(for: entry, storage: StorageManager()) else {
+            throw XCTSkip("Bundled model not present; skipping engine integration test.")
+        }
+        return url.path
+    }
+
+    private func makeRequest() -> CotypingRequest {
+        let field = CotypingField(
+            appName: "Mail", bundleID: "com.apple.mail", processID: 0, role: "AXTextArea",
+            precedingText: "Hi Sarah,\nThanks for sending this over. I wanted to follow",
+            trailingText: "", selectionLength: 0, caretRect: .zero, isSecure: false,
+            caretIsExact: true, windowTitle: "Re: Q3", fieldPlaceholder: nil)
+        return CotypingRequestBuilder.build(
+            field: field, config: .standard,
+            personalization: .none, generation: 1, learnedExamples: [])!
+    }
+
+    func testGenerateReturnsNormalizedResult() async throws {
+        let path = try bundledModelPath()
+        let engine = LocalLlamaCotypingEngine(runtime: LlamaCotypingRuntime(), modelPath: path)
+        let result = try await engine.generate(makeRequest())
+        XCTAssertFalse(result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    func testStreamingFiresPartials() async throws {
+        let path = try bundledModelPath()
+        let engine = LocalLlamaCotypingEngine(runtime: LlamaCotypingRuntime(), modelPath: path)
+        var partials = 0
+        _ = try await engine.generateStreaming(makeRequest()) { _ in partials += 1 }
+        XCTAssertGreaterThan(partials, 0)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/LocalLlamaCotypingEngineTests 2>&1 | tail -15`
+Expected: FAIL — `cannot find 'LocalLlamaCotypingEngine' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `LokalBot/Cotyping/Llama/LocalLlamaCotypingEngine.swift`:
+
+```swift
+import Foundation
+
+/// In-process `CotypingCompleting` conformer. Tokenizes the already-built
+/// prompt, drives `LlamaCotypingRuntime`, and reuses the EXACT same
+/// normalization + decode-stop policy as the HTTP engine so suggestions are
+/// shaped identically. Stops on the stop policy, the token budget, or task
+/// cancellation (superseded keystroke).
+@MainActor
+final class LocalLlamaCotypingEngine: CotypingCompleting {
+    private let runtime: LlamaCotypingRuntime
+    private let modelPath: String
+
+    init(runtime: LlamaCotypingRuntime, modelPath: String) {
+        self.runtime = runtime
+        self.modelPath = modelPath
+    }
+
+    /// Loads + primes the model so the first keystroke isn't cold.
+    func prewarm() async throws {
+        try await runtime.prewarm(modelPath: modelPath)
+    }
+
+    func generate(_ request: CotypingRequest) async throws -> CotypingNormalizationResult {
+        try await run(request) { _ in }
+    }
+
+    func generateStreaming(
+        _ request: CotypingRequest,
+        onPartial: @escaping @Sendable (CotypingNormalizationResult) -> Void
+    ) async throws -> CotypingNormalizationResult {
+        try await run(request, onPartial: onPartial)
+    }
+
+    private func run(
+        _ request: CotypingRequest,
+        onPartial: @escaping @Sendable (CotypingNormalizationResult) -> Void
+    ) async throws -> CotypingNormalizationResult {
+        try await runtime.loadIfNeeded(modelPath: modelPath)
+        let promptTokens = await runtime.tokenize(request.prompt, addBOS: true)
+        guard !promptTokens.isEmpty else {
+            return CotypingNormalizationResult(text: "", suppression: .emptyGeneration)
+        }
+
+        let specs = LlamaSamplerSpec.specs(
+            temperature: Float(request.temperature),
+            topK: Int32(request.topK),
+            topP: Float(request.topP),
+            minP: Float(request.minP),
+            repeatPenalty: Float(request.repeatPenalty),
+            repeatLastN: 64,
+            seed: UInt32(truncatingIfNeeded: request.seed))
+
+        let accumulator = TokenAccumulator()
+        let raw = await runtime.generate(
+            promptTokens: promptTokens,
+            maxTokens: request.maxTokens,
+            samplerSpecs: specs
+        ) { piece in
+            if Task.isCancelled { return false }
+            accumulator.append(piece)
+            let result = CotypingTextNormalizer.normalizeDetailed(accumulator.raw, for: request)
+            onPartial(result)
+            // Native decode-stop at the SAME boundary the HTTP path stops at.
+            if CotypingDecodeStopPolicy.verdict(
+                accumulated: accumulator.raw,
+                tokensGenerated: accumulator.count) != nil {
+                return false
+            }
+            return true
+        }
+
+        if Task.isCancelled { throw CancellationError() }
+        return CotypingTextNormalizer.normalizeDetailed(raw, for: request)
+    }
+}
+
+/// Reference-typed accumulator the decode closure mutates across token calls.
+/// The runtime invokes `onToken` serially on one thread, so no synchronization
+/// is required; marked `@unchecked Sendable` only to cross the actor boundary.
+private final class TokenAccumulator: @unchecked Sendable {
+    private(set) var raw = ""
+    private(set) var count = 0
+    func append(_ piece: String) { raw += piece; count += 1 }
+}
+```
+
+- [ ] **Step 4: Add to project and run the test**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodegen generate && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/LocalLlamaCotypingEngineTests 2>&1 | tail -25`
+Expected: `Test Suite 'LocalLlamaCotypingEngineTests' passed` (or `Skipped` if model absent). If the closure won't compile (`@Sendable` capture of `request`), confirm `CotypingRequest` is `Sendable` (it is) and that `onPartial` is the `@Sendable` parameter.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot
+git add LokalBot/Cotyping/Llama/LocalLlamaCotypingEngine.swift LokalBotTests/LlamaCotypingRuntimeTests.swift LokalBot.xcodeproj
+git commit -m "feat: add LocalLlamaCotypingEngine seam reusing normalizer + stop policy"
+```
+
+---
+
+## Task 6: `AppSettings.cotypingInProcessRuntime` flag (resolves open question #1)
+
+Spec open question #1's recommendation: flag-gated default-on, HTTP fallback one toggle away. Add a persisted bool defaulting `true`, with tolerant decoding so existing saved settings don't break.
+
+**Files:**
+- Modify: `LokalBot/Models/AppSettings.swift`
+- Test: `LokalBotTests/CotypingTests.swift` (the `CotypingSettingsTests` group)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `AppSettings.cotypingInProcessRuntime: Bool` (default `true`). Used by `CotypingEngineSelector.shouldUseLocal` (Task 7).
+
+- [ ] **Step 1: Write the failing test**
+
+In `LokalBotTests/CotypingTests.swift`, add to the `CotypingSettingsTests` class:
+
+```swift
+    func testInProcessRuntimeDefaultsOn() {
+        XCTAssertTrue(AppSettings().cotypingInProcessRuntime)
+    }
+
+    func testInProcessRuntimeRoundTrips() throws {
+        var settings = AppSettings()
+        settings.cotypingInProcessRuntime = false
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+        XCTAssertFalse(decoded.cotypingInProcessRuntime)
+    }
+
+    func testTolerantDecodeDefaultsInProcessRuntimeOn() throws {
+        // A saved blob predating the flag must decode with the default (true).
+        let json = "{}".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: json)
+        XCTAssertTrue(decoded.cotypingInProcessRuntime)
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/CotypingSettingsTests/testInProcessRuntimeDefaultsOn 2>&1 | tail -15`
+Expected: FAIL — `value of type 'AppSettings' has no member 'cotypingInProcessRuntime'`.
+
+- [ ] **Step 3: Add the property with a default**
+
+In `LokalBot/Models/AppSettings.swift`, add the stored property next to the other `cotyping*` fields (e.g. just after `cotypingBuiltInModelID`):
+
+```swift
+    /// When true (default), cotyping uses the in-process `libllama` runtime for
+    /// the built-in GGUF backend on Apple Silicon; false forces the HTTP
+    /// `llama-server` path. The HTTP fallback also covers non-GGUF backends and
+    /// any in-process load failure regardless of this flag.
+    var cotypingInProcessRuntime: Bool = true
+```
+
+`AppSettings` does `Codable` by hand — explicit `CodingKeys`, explicit `encode(to:)`, and a tolerant `init(from:)` (the container is named `c`, defaults come from a local `let defaults = AppSettings()`). Wire the new key into **all three**, mirroring the existing `cotypingBuiltInModelID` lines exactly. Missing the encode line is silent: `encode(to:)` would drop the key and `testInProcessRuntimeRoundTrips` would fail (decode falls back to the `true` default).
+
+1. Add the coding key to the `CodingKeys` enum (next to `case cotypingBuiltInModelID`, ~line 281):
+
+```swift
+        case cotypingInProcessRuntime
+```
+
+2. Add an encode line in `encode(to:)` (after `try c.encode(cotypingBuiltInModelID, forKey: .cotypingBuiltInModelID)`, ~line 354):
+
+```swift
+        try c.encode(cotypingInProcessRuntime, forKey: .cotypingInProcessRuntime)
+```
+
+3. Add a tolerant decode line in `init(from:)` (after the `cotypingBuiltInModelID` decode, ~line 416):
+
+```swift
+        cotypingInProcessRuntime = (try? c.decode(Bool.self, forKey: .cotypingInProcessRuntime)) ?? defaults.cotypingInProcessRuntime
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/CotypingSettingsTests 2>&1 | tail -20`
+Expected: all `CotypingSettingsTests` pass, including the three new cases and the existing `testTolerantDecodeKeepsOtherDefaults`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot
+git add LokalBot/Models/AppSettings.swift LokalBotTests/CotypingTests.swift
+git commit -m "feat: add cotypingInProcessRuntime flag (default on, tolerant decode)"
+```
+
+---
+
+## Task 7: `CotypingEngineSelector` + AppState wiring + prewarm
+
+Route each completion to the local engine when (flag on) ∧ (Apple Silicon) ∧ (built-in model resolves to a GGUF on disk); otherwise the existing HTTP `CotypingEngine`. Fall back to HTTP if the local engine throws a load error (spec §11). Wire it into `AppState` and prewarm on cotyping-enable.
+
+**Files:**
+- Create: `LokalBot/Cotyping/Llama/CotypingEngineSelector.swift`
+- Modify: `LokalBot/LokalBotApp.swift` (the `cotypingEngine` lazy var ~line 430, and the cotyping-enable path)
+- Test: `LokalBotTests/CotypingEngineSelectorTests.swift`
+
+**Interfaces:**
+- Consumes: `CotypingCompleting` (existing HTTP `CotypingEngine`), `LocalLlamaCotypingEngine` (Task 5), `AppSettings` (`cotypingInProcessRuntime`, `cotypingBuiltInModelID`, `customBuiltInModels`), `ModelCatalog`, `StorageManager`, `LlamaRuntimeError` (Task 4).
+- Produces:
+  - `@MainActor final class CotypingEngineSelector: CotypingCompleting`
+  - `init(http: CotypingCompleting, makeLocal: @escaping (String) -> LocalLlamaCotypingEngine, settings: @escaping () -> AppSettings, storage: StorageManager)`
+  - `static func shouldUseLocal(settings: AppSettings, modelURL: URL?, isAppleSilicon: Bool) -> Bool`
+  - `func prewarm() async`
+
+- [ ] **Step 1: Write the failing test (pure decision function)**
+
+Create `LokalBotTests/CotypingEngineSelectorTests.swift`:
+
+```swift
+import XCTest
+@testable import LokalBot
+
+final class CotypingEngineSelectorTests: XCTestCase {
+    private let modelURL = URL(fileURLWithPath: "/models/gemma.gguf")
+
+    func testUsesLocalWhenFlagOnAppleSiliconAndModelResolves() {
+        var s = AppSettings(); s.cotypingInProcessRuntime = true
+        XCTAssertTrue(CotypingEngineSelector.shouldUseLocal(
+            settings: s, modelURL: modelURL, isAppleSilicon: true))
+    }
+
+    func testFallsBackWhenFlagOff() {
+        var s = AppSettings(); s.cotypingInProcessRuntime = false
+        XCTAssertFalse(CotypingEngineSelector.shouldUseLocal(
+            settings: s, modelURL: modelURL, isAppleSilicon: true))
+    }
+
+    func testFallsBackOnIntel() {
+        var s = AppSettings(); s.cotypingInProcessRuntime = true
+        XCTAssertFalse(CotypingEngineSelector.shouldUseLocal(
+            settings: s, modelURL: modelURL, isAppleSilicon: false))
+    }
+
+    func testFallsBackWhenModelMissing() {
+        var s = AppSettings(); s.cotypingInProcessRuntime = true
+        XCTAssertFalse(CotypingEngineSelector.shouldUseLocal(
+            settings: s, modelURL: nil, isAppleSilicon: true))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/CotypingEngineSelectorTests 2>&1 | tail -15`
+Expected: FAIL — `cannot find 'CotypingEngineSelector' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `LokalBot/Cotyping/Llama/CotypingEngineSelector.swift`:
+
+```swift
+import Foundation
+
+/// Per-completion router between the in-process `LocalLlamaCotypingEngine`
+/// (built-in GGUF on Apple Silicon, flag on) and the existing HTTP
+/// `CotypingEngine` (non-GGUF backends, flag off, or in-process load failure).
+/// Conforms to `CotypingCompleting`, so `CotypingCoordinator` is unchanged.
+@MainActor
+final class CotypingEngineSelector: CotypingCompleting {
+    private let http: CotypingCompleting
+    private let makeLocal: (String) -> LocalLlamaCotypingEngine
+    private let settings: () -> AppSettings
+    private let storage: StorageManager
+    private var local: LocalLlamaCotypingEngine?
+    private var localModelPath: String?
+    /// Set after the first in-process failure so the HTTP fallback is logged
+    /// once per failure episode (spec §13), not on every keystroke. Reset on a
+    /// successful local generation or a model-path change.
+    private var didLogLocalFailure = false
+
+    init(
+        http: CotypingCompleting,
+        makeLocal: @escaping (String) -> LocalLlamaCotypingEngine,
+        settings: @escaping () -> AppSettings,
+        storage: StorageManager
+    ) {
+        self.http = http
+        self.makeLocal = makeLocal
+        self.settings = settings
+        self.storage = storage
+    }
+
+    static var isAppleSilicon: Bool {
+        #if arch(arm64)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    static func shouldUseLocal(settings: AppSettings, modelURL: URL?, isAppleSilicon: Bool) -> Bool {
+        settings.cotypingInProcessRuntime && isAppleSilicon && modelURL != nil
+    }
+
+    /// Resolves the built-in cotyping model path the same way `makeTextEngine` does.
+    private func resolvedModelURL(_ s: AppSettings) -> URL? {
+        guard let entry = ModelCatalog.entry(id: s.cotypingBuiltInModelID, custom: s.customBuiltInModels)
+                ?? ModelCatalog.entry(id: ModelCatalog.bundledID) else { return nil }
+        return ModelCatalog.localURL(for: entry, storage: storage)
+    }
+
+    /// Returns the local engine if eligible, lazily (re)building it when the
+    /// resolved model path changes; nil → use HTTP.
+    private func localIfEligible() -> LocalLlamaCotypingEngine? {
+        let s = settings()
+        guard let url = resolvedModelURL(s),
+              Self.shouldUseLocal(settings: s, modelURL: url, isAppleSilicon: Self.isAppleSilicon)
+        else { return nil }
+        if local == nil || localModelPath != url.path {
+            local = makeLocal(url.path)
+            localModelPath = url.path
+            didLogLocalFailure = false
+        }
+        return local
+    }
+
+    func prewarm() async {
+        guard let engine = localIfEligible() else { return }
+        try? await engine.prewarm()
+    }
+
+    func generate(_ request: CotypingRequest) async throws -> CotypingNormalizationResult {
+        guard let engine = localIfEligible() else { return try await http.generate(request) }
+        do {
+            let result = try await engine.generate(request)
+            didLogLocalFailure = false
+            return result
+        } catch let error as LlamaRuntimeError {
+            logLocalFallback(error)
+            return try await http.generate(request)
+        }
+    }
+
+    func generateStreaming(
+        _ request: CotypingRequest,
+        onPartial: @escaping @Sendable (CotypingNormalizationResult) -> Void
+    ) async throws -> CotypingNormalizationResult {
+        guard let engine = localIfEligible() else {
+            return try await http.generateStreaming(request, onPartial: onPartial)
+        }
+        do {
+            let result = try await engine.generateStreaming(request, onPartial: onPartial)
+            didLogLocalFailure = false
+            return result
+        } catch let error as LlamaRuntimeError {
+            logLocalFallback(error)
+            return try await http.generateStreaming(request, onPartial: onPartial)
+        }
+    }
+
+    /// Logs the in-process→HTTP fallback once per failure episode (spec §13).
+    /// The local engine is kept (not torn down) so a transient failure — e.g. a
+    /// memory-pressure unload (Task 8) — recovers on a later completion, and the
+    /// log does not repeat on every keystroke.
+    private func logLocalFallback(_ error: LlamaRuntimeError) {
+        guard !didLogLocalFailure else { return }
+        didLogLocalFailure = true
+        NSLog("Cotyping: in-process runtime unavailable (\(error)); using HTTP fallback (will keep retrying).")
+    }
+}
+```
+
+- [ ] **Step 4: Run the selector unit test**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodegen generate && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/CotypingEngineSelectorTests 2>&1 | tail -15`
+Expected: `Test Suite 'CotypingEngineSelectorTests' passed`, 4 tests, 0 failures.
+
+- [ ] **Step 5: Wire the selector into `AppState`**
+
+In `LokalBot/LokalBotApp.swift`, replace the existing `cotypingEngine` lazy var (currently around line 430):
+
+```swift
+    private(set) lazy var cotypingEngine = CotypingEngine(makeEngine: { [weak self] in
+        guard let self else { throw TextEngineError.unavailable("LokalBot is shutting down.") }
+        return try await self.pipeline.makeTextEngine(
+            self.settings.cotypingTextEngineSettings,
+            server: .cotyping)
+    })
+```
+
+with the selector wrapping that exact HTTP engine as its fallback:
+
+```swift
+    private(set) lazy var cotypingEngine = CotypingEngineSelector(
+        http: CotypingEngine(makeEngine: { [weak self] in
+            guard let self else { throw TextEngineError.unavailable("LokalBot is shutting down.") }
+            return try await self.pipeline.makeTextEngine(
+                self.settings.cotypingTextEngineSettings,
+                server: .cotyping)
+        }),
+        makeLocal: { modelPath in
+            LocalLlamaCotypingEngine(runtime: LlamaCotypingRuntime(), modelPath: modelPath)
+        },
+        settings: { [weak self] in self?.settings ?? AppSettings() },
+        storage: storage)
+```
+
+`CotypingCoordinator(engine: cotypingEngine, ...)` is unchanged — `CotypingEngineSelector` is a `CotypingCompleting`. The property type changes from `CotypingEngine` to `CotypingEngineSelector`; both satisfy the coordinator's `CotypingCompleting` parameter.
+
+- [ ] **Step 6: Prewarm on cotyping-enable**
+
+`cotyping.applySettings()` is the single propagation point, called from two places in `LokalBotApp.swift`: the `settings.didSet` (~line 388, `if interactive { cotyping.applySettings() }`) and app startup (~line 620). Add an idempotent prewarm kick after each, guarded by `settings.cotypingEnabled` — `prewarm()` early-returns when not eligible or already loaded.
+
+At ~line 388, change:
+
+```swift
+            if interactive { cotyping.applySettings() }
+```
+
+to:
+
+```swift
+            if interactive {
+                cotyping.applySettings()
+                if settings.cotypingEnabled { Task { await cotypingEngine.prewarm() } }
+            }
+```
+
+At ~line 620, after the startup `cotyping.applySettings()`:
+
+```swift
+        cotyping.applySettings()
+        if settings.cotypingEnabled { Task { await cotypingEngine.prewarm() } }
+```
+
+`cotypingEngine` is now the `CotypingEngineSelector` (Step 5), whose `prewarm()` is `@MainActor async`; each `Task {}` inherits the main actor.
+
+- [ ] **Step 7: Build the app and run the full cotyping + new suites**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodegen generate && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/CotypingEngineSelectorTests -only-testing:LokalBotTests/CotypingSettingsTests -only-testing:LokalBotTests/CotypingTests 2>&1 | tail -25`
+Expected: the app target compiles (selector wired in) and all listed suites pass. A compile error here usually means the `cotypingEngine` property type change broke a reference — grep `LokalBotApp.swift` for other uses of `cotypingEngine` and confirm they only rely on `CotypingCompleting`/`prewarm`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot
+git add LokalBot/Cotyping/Llama/CotypingEngineSelector.swift LokalBot/LokalBotApp.swift LokalBotTests/CotypingEngineSelectorTests.swift LokalBot.xcodeproj
+git commit -m "feat: route cotyping to in-process engine with HTTP fallback + prewarm"
+```
+
+---
+
+## Task 8: Memory-pressure unload (spec §11, load-bearing per risk table)
+
+The default cotyping model is now Gemma 4 E4B Q5 XL (~5 GB resident), so the memory-pressure unload is load-bearing, not optional. Add a `DISPATCH_SOURCE_TYPE_MEMORYPRESSURE` source that unloads the in-process model on warning; the next completion lazily reloads (or, if reload fails, the selector's `LlamaRuntimeError` path routes to HTTP).
+
+**Files:**
+- Modify: `LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift` (add `handleMemoryPressure()` + `isLoaded` already exists)
+- Modify: `LokalBot/Cotyping/Llama/LocalLlamaCotypingEngine.swift` (own the dispatch source; call runtime on warning)
+- Test: `LokalBotTests/LlamaCotypingRuntimeTests.swift` (add an unload test that does not need the model)
+
+**Interfaces:**
+- Consumes: `LlamaCotypingRuntime.unload()` / `isLoaded` (Task 4).
+- Produces: `LlamaCotypingRuntime.handleMemoryPressure()` (calls `unload()`); `LocalLlamaCotypingEngine` installs a memory-pressure dispatch source at init.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `LlamaCotypingRuntimeTests` (does not require the model — exercises the unload path directly):
+
+```swift
+    func testMemoryPressureUnloadsWhenNotLoaded() async {
+        let runtime = LlamaCotypingRuntime()
+        let before = await runtime.isLoaded
+        XCTAssertFalse(before)
+        await runtime.handleMemoryPressure()   // safe no-op when nothing is loaded
+        let after = await runtime.isLoaded
+        XCTAssertFalse(after)
+    }
+```
+
+(A loaded→unloaded assertion would require the GGUF; the deterministic part we can always run is that `handleMemoryPressure` is callable and leaves an unloaded runtime unloaded. The load→unload transition is covered when the gated model is present via `testLoadsAndGeneratesDeterministically` + a follow-up `handleMemoryPressure` call below.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/LlamaCotypingRuntimeTests/testMemoryPressureUnloadsWhenNotLoaded 2>&1 | tail -15`
+Expected: FAIL — `value of type 'LlamaCotypingRuntime' has no member 'handleMemoryPressure'`.
+
+- [ ] **Step 3: Add `handleMemoryPressure` to the runtime**
+
+In `LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift`, add:
+
+```swift
+    /// Frees the model + context under memory pressure. The next `generate`
+    /// call lazily reloads via `loadIfNeeded` (or the engine routes to HTTP if
+    /// reload fails). Keeps cotyping from OOMing the app under a large model.
+    func handleMemoryPressure() {
+        unload()
+    }
+```
+
+- [ ] **Step 4: Install the dispatch source in the engine**
+
+In `LokalBot/Cotyping/Llama/LocalLlamaCotypingEngine.swift`, add a stored `memoryPressureSource` and install it in `init`:
+
+```swift
+    private var memoryPressureSource: DispatchSourceMemoryPressure?
+```
+
+At the end of `init(runtime:modelPath:)`:
+
+```swift
+        let source = DispatchSource.makeMemoryPressureSource(
+            eventMask: [.warning, .critical], queue: .global(qos: .utility))
+        source.setEventHandler { [runtime] in
+            Task { await runtime.handleMemoryPressure() }
+        }
+        source.resume()
+        self.memoryPressureSource = source
+```
+
+And cancel it on deinit:
+
+```swift
+    deinit { memoryPressureSource?.cancel() }
+```
+
+(`runtime` is captured directly — it's an actor, safely `Sendable`. The handler hops onto the actor via `Task`.)
+
+- [ ] **Step 5: Run the test + confirm the engine still builds**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodegen generate && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/LlamaCotypingRuntimeTests/testMemoryPressureUnloadsWhenNotLoaded 2>&1 | tail -15`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot
+git add LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift LokalBot/Cotyping/Llama/LocalLlamaCotypingEngine.swift LokalBotTests/LlamaCotypingRuntimeTests.swift
+git commit -m "feat: unload in-process cotyping model under memory pressure"
+```
+
+---
+
+## Task 9: A/B benchmark (local vs HTTP) + parity-doc update (spec §14, §16)
+
+Extend the benchmark to record TTFT and run both engines on the existing default scenarios, producing a comparison that substantiates the latency claim in `CotypingParityQA.md`. The summary math is unit-tested with synthetic results (no model needed); the live A/B is exposed for manual runs.
+
+**Files:**
+- Modify: `LokalBot/Cotyping/CotypingBenchmark.swift`
+- Modify: `Docs/CotypingParityQA.md`
+- Test: `LokalBotTests/CotypingABBenchmarkTests.swift`
+
+**Interfaces:**
+- Consumes: `CotypingBenchmarkRunner.run(...)`, `CotypingBenchmarkSummary` (existing), `CotypingCompleting`.
+- Produces:
+  - `struct CotypingABComparison: Equatable, Sendable { let local: CotypingBenchmarkSummary; let http: CotypingBenchmarkSummary; var ttftDeltaMs: Int?; var p95DeltaMs: Int? }`
+  - `static func CotypingBenchmarkRunner.runAB(local:http:config:personalization:learnedExamples:) async -> CotypingABComparison`
+
+- [ ] **Step 1: Write the failing test (pure comparison math)**
+
+Create `LokalBotTests/CotypingABBenchmarkTests.swift`:
+
+```swift
+import XCTest
+@testable import LokalBot
+
+final class CotypingABBenchmarkTests: XCTestCase {
+    private func summary(latency: Int, ttft: Int) -> CotypingBenchmarkSummary {
+        CotypingBenchmarkSummary(results: [
+            CotypingBenchmarkCaseResult(
+                scenarioID: "s", name: "s", text: "hello", latencyMs: latency,
+                firstVisibleLatencyMs: ttft, expectedTermHits: 0, expectedTermCount: 0,
+                suppression: nil, error: nil, expectedVisibleSuggestion: true,
+                allowedSuppression: false, latencyTargetMs: 2000),
+        ])
+    }
+
+    func testComparisonComputesDeltas() {
+        let comparison = CotypingABComparison(
+            local: summary(latency: 300, ttft: 120),
+            http: summary(latency: 1100, ttft: 600))
+        XCTAssertEqual(comparison.p95DeltaMs, 800)    // http p95 - local p95
+        XCTAssertEqual(comparison.ttftDeltaMs, 480)   // http ttft - local ttft (local is faster)
+    }
+
+    func testComparisonHandlesMissingTTFT() {
+        let comparison = CotypingABComparison(
+            local: summary(latency: 300, ttft: 120),
+            http: CotypingBenchmarkSummary(results: []))
+        XCTAssertNil(comparison.p95DeltaMs)
+        XCTAssertNil(comparison.ttftDeltaMs)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/CotypingABBenchmarkTests 2>&1 | tail -15`
+Expected: FAIL — `cannot find 'CotypingABComparison' in scope`.
+
+- [ ] **Step 3: Add the comparison type + AB runner**
+
+Append to `LokalBot/Cotyping/CotypingBenchmark.swift`:
+
+```swift
+/// Result of running both cotyping engines over the same scenarios. Deltas are
+/// `http − local`, so a positive value means the in-process engine is faster.
+struct CotypingABComparison: Equatable, Sendable {
+    let local: CotypingBenchmarkSummary
+    let http: CotypingBenchmarkSummary
+
+    /// p95 end-to-end latency improvement (ms), or nil if either side has no data.
+    var p95DeltaMs: Int? {
+        guard let l = local.p95LatencyMs, let h = http.p95LatencyMs else { return nil }
+        return h - l
+    }
+
+    /// Time-to-first-visible-token improvement (ms), or nil if either side lacks it.
+    var ttftDeltaMs: Int? {
+        guard let l = local.averageFirstVisibleLatencyMs,
+              let h = http.averageFirstVisibleLatencyMs else { return nil }
+        return h - l
+    }
+}
+
+extension CotypingBenchmarkRunner {
+    /// Runs the default scenarios through both engines (streaming on, so TTFT is
+    /// captured) and returns the comparison. For manual latency validation.
+    static func runAB(
+        local: CotypingCompleting,
+        http: CotypingCompleting,
+        config: CotypingConfiguration,
+        personalization: CotypingPersonalization,
+        learnedExamples: @escaping (CotypingField) -> [String] = { _ in [] }
+    ) async -> CotypingABComparison {
+        let localSummary = await run(
+            engine: local, config: config, personalization: personalization,
+            streamPartials: true, learnedExamples: learnedExamples)
+        let httpSummary = await run(
+            engine: http, config: config, personalization: personalization,
+            streamPartials: true, learnedExamples: learnedExamples)
+        return CotypingABComparison(local: localSummary, http: httpSummary)
+    }
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests/CotypingABBenchmarkTests 2>&1 | tail -15`
+Expected: `Test Suite 'CotypingABBenchmarkTests' passed`, 2 tests, 0 failures.
+
+- [ ] **Step 5: Update `Docs/CotypingParityQA.md`**
+
+Open `Docs/CotypingParityQA.md`. Find the line that names the runtime as the known-incomplete parity item (it calls the HTTP runtime the one outstanding gap). Update it to reflect that the in-process runtime has landed, and add a short "how to measure" note. Replace the runtime-gap sentence with:
+
+```markdown
+- **Generation runtime — DONE.** Cotyping now decodes the built-in GGUF model
+  in-process via `libllama` (`b9789`), holding a persistent KV cache and
+  re-prefilling only the typed suffix (`LocalLlamaCotypingEngine` →
+  `LlamaCotypingRuntime`). The HTTP `llama-server` path remains as the fallback
+  for non-GGUF backends, when the in-process runtime is toggled off
+  (`cotypingInProcessRuntime`), or on load failure. A/B latency is measured by
+  `CotypingBenchmarkRunner.runAB(local:http:...)` over the default scenarios
+  (TTFT + p95 deltas).
+```
+
+(If the doc lists the runtime under a "known gaps" / "outstanding" heading, move the item to the "done / parity achieved" section instead of leaving it under gaps.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot
+git add LokalBot/Cotyping/CotypingBenchmark.swift LokalBotTests/CotypingABBenchmarkTests.swift Docs/CotypingParityQA.md
+git commit -m "feat: A/B cotyping benchmark (in-process vs HTTP) + parity doc update"
+```
+
+---
+
+## Task 10: Settings toggle + full regression run
+
+Expose the runtime flag in Settings (so the fallback is "one toggle away" per open question #1) and run the complete test suite to confirm no regression.
+
+**Files:**
+- Modify: `LokalBot/Views/SettingsView.swift` (the Cotyping section)
+- Test: full `LokalBotTests` run.
+
+**Interfaces:**
+- Consumes: `AppSettings.cotypingInProcessRuntime` (Task 6).
+- Produces: a user-visible toggle bound to it. No new symbols.
+
+- [ ] **Step 1: Add the toggle**
+
+In `LokalBot/Views/SettingsView.swift`, in the Cotyping settings section (search for an existing `cotyping*` binding such as `cotypingDebounceMs` or `cotypingStreamSuggestionsWhileGenerating` to find the section and copy its `Toggle`/binding idiom), add:
+
+```swift
+                Toggle("Use the fast in-process runtime (recommended)", isOn: $settings.cotypingInProcessRuntime)
+                Text("Decodes the built-in model in-process for lower latency. Turn off to use the background llama-server. Non-built-in backends always use the server.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+```
+
+(Match the surrounding binding pattern exactly — if the view binds through a view model or `@Bindable settings` rather than `$settings`, use that. Place it near the other cotyping performance toggles.)
+
+- [ ] **Step 2: Build to confirm the view compiles**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodebuild build -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' 2>&1 | tail -15`
+Expected: `** BUILD SUCCEEDED **`. A binding-type error means the settings access pattern differs — match the neighboring toggle.
+
+- [ ] **Step 3: Run the FULL test suite (regression gate)**
+
+Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && xcodebuild test -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' -only-testing:LokalBotTests 2>&1 | tail -30`
+Expected: `** TEST SUCCEEDED **`. All pre-existing tests (the 21 cotyping/catalog tests plus the rest of `LokalBotTests`) still pass; new suites pass or `Skipped` (model-gated). If any *pre-existing* test fails, the seam wiring regressed something — bisect against the Task 7 commit.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot
+git add LokalBot/Views/SettingsView.swift
+git commit -m "feat: add Settings toggle for the in-process cotyping runtime"
+```
+
+---
+
+## Manual verification (post-implementation, not a code task)
+
+From spec §5/§14 — run these by hand once the plan is implemented:
+
+- **TTFT / p95:** with the bundled `Qwen3.5-0.8B-Q4_K_M`, trigger `CotypingBenchmarkRunner.runAB(...)` (or the existing `Scripts/compare-cotyping.sh`) and confirm first ghost token < ~200–300 ms post-warmup and p95 well under 2000 ms, beating the HTTP summary.
+- **No main-thread hitch:** Instruments (Time Profiler) while typing into a real text field with a generation in flight — the main thread must stay responsive.
+- **Instant cancellation:** type quickly; superseding keystrokes must not paint stale ghosts (the generation-id guard + `Task.isCancelled` drop them).
+- **Fallback:** toggle `cotypingInProcessRuntime` off → confirm suggestions still come from `llama-server`; switch the cotyping model to a non-GGUF backend (if configured) → confirm HTTP path; simulate load failure (rename the GGUF) → confirm graceful fallback, no crash.

--- a/Docs/superpowers/plans/2026-06-29-inprocess-cotyping-runtime.md
+++ b/Docs/superpowers/plans/2026-06-29-inprocess-cotyping-runtime.md
@@ -162,7 +162,9 @@ settings:
       - $(SRCROOT)/Vendor/llama-cpp/include
 ```
 
-**(b)** Add the link flags to the **`LokalBotApp` template's** existing `settings.base` (around line 124, alongside `SWIFT_VERSION`/`DEVELOPMENT_TEAM`), so all three app targets link the dylib and get the runtime search path — but the test bundle does not (it resolves libllama symbols through its `TEST_HOST` app at runtime):
+**(b)** Add the link flags to the **`LokalBotApp` template's** existing `settings.base` (around line 124, alongside `SWIFT_VERSION`/`DEVELOPMENT_TEAM`), so all three app targets link the dylib and get the runtime search path:
+
+> **Build-spike correction (Task 1, applied):** the `LokalBotTests` target ALSO needs these link flags. `-bundle_loader`/`TEST_HOST` only resolves symbols *defined in* the host executable, and the `llama_*` symbols live in `libllama.dylib` (which the host merely *loads*), so the test bundle must link `-lllama` itself with its own rpath (`@executable_path/../Resources/llama-cpp` and `@loader_path/../../../../Resources/llama-cpp`, both reaching the host app's `Contents/Resources/llama-cpp`). Task 1 wired this on the `LokalBotTests` target. **Consequence for later tasks:** every subsequent `import LlamaCore` test file (`LlamaCotypingRuntimeTests`, `LocalLlamaCotypingEngineTests`, `CotypingABBenchmarkTests`) inherits this target-level wiring automatically — do NOT re-edit `project.yml` to link them.
 
 ```yaml
         LIBRARY_SEARCH_PATHS:

--- a/Docs/superpowers/plans/2026-06-29-inprocess-cotyping-runtime.md
+++ b/Docs/superpowers/plans/2026-06-29-inprocess-cotyping-runtime.md
@@ -38,7 +38,6 @@ Swift bridging notes: opaque `struct *` arrive as `OpaquePointer?`; `llama_token
 ## File Structure
 
 **Create:**
-- `Vendor/llama-cpp/include/module.modulemap` — declares the `LlamaCore` Clang module (headers fetched by the build script alongside it).
 - `LokalBot/Cotyping/Llama/IncrementalPrefill.swift` — pure common-prefix helper (the latency heart).
 - `LokalBot/Cotyping/Llama/LlamaSamplerSpec.swift` — pure config→sampler-chain descriptor mapping.
 - `LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift` — the inference actor (model/context/KV/decode).
@@ -51,7 +50,7 @@ Swift bridging notes: opaque `struct *` arrive as `OpaquePointer?`; `llama_token
 - `LokalBotTests/CotypingABBenchmarkTests.swift`
 
 **Modify:**
-- `Scripts/fetch-llama.sh` — also fetch `b9789` headers into `Vendor/llama-cpp/include/`.
+- `Scripts/fetch-llama.sh` — also fetch `b9789` headers into `Vendor/llama-cpp/include/` and generate the `module.modulemap` there (both gitignored, script-reproduced — `Vendor/` stays fully generated).
 - `project.yml` — header search path + `SWIFT_INCLUDE_PATHS` (module map) + link `-lllama` + `LD_RUNPATH_SEARCH_PATHS`.
 - `LokalBot/Models/AppSettings.swift` — add `cotypingInProcessRuntime: Bool` (default `true`), tolerant decode.
 - `LokalBot/LokalBotApp.swift` — `cotypingEngine` becomes a `CotypingEngineSelector`; prewarm on cotyping-enable.
@@ -66,8 +65,7 @@ Swift bridging notes: opaque `struct *` arrive as `OpaquePointer?`; `llama_token
 The riskiest piece (spec risk: "Link / `@rpath` issues"; open question #2: exact header set). Prove the module imports, the dylib links, `@rpath` resolves at runtime, and a real C call executes — before any runtime code is written. Fold header fetch + module map + project wiring into this one task; its deliverable is a passing test that calls into `libllama`.
 
 **Files:**
-- Modify: `Scripts/fetch-llama.sh`
-- Create: `Vendor/llama-cpp/include/module.modulemap`
+- Modify: `Scripts/fetch-llama.sh` (fetch headers **and** generate `Vendor/llama-cpp/include/module.modulemap` — both gitignored, script-reproduced)
 - Modify: `project.yml`
 - Test: `LokalBotTests/LlamaCoreSmokeTests.swift` (create)
 
@@ -101,21 +99,38 @@ for h in "${HEADERS[@]}"; do
     curl -fsSL "$RAW_BASE/$h" -o "$dest"
   fi
 done
+
+# Declare the LlamaCore Clang module over the fetched headers. Generated here
+# (not committed) so the whole Vendor/ tree stays reproducible and gitignored,
+# matching the dylibs/model. Rewritten every run so it tracks any HEADERS edit.
+cat > "$INCLUDE_DIR/module.modulemap" <<'EOF'
+module LlamaCore {
+    header "llama.h"
+    header "ggml.h"
+    header "ggml-backend.h"
+    header "ggml-alloc.h"
+    header "ggml-cpu.h"
+    export *
+}
+EOF
 ```
 
-- [ ] **Step 2: Run the script and confirm headers land**
+- [ ] **Step 2: Run the script and confirm headers + module map land**
 
 Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && bash Scripts/fetch-llama.sh && ls Vendor/llama-cpp/include`
-Expected: lists `llama.h ggml.h ggml-backend.h ggml-alloc.h ggml-cpu.h ggml-metal.h` (and no error). If `curl` 404s on a header, that header moved at this tag — open the tag tree at `https://github.com/ggml-org/llama.cpp/tree/b9789/ggml/include` to find its path and fix the `HEADERS` entry. This is the open-question-#2 resolution: confirm the transitive set compiles in Step 6 and trim/extend here.
+Expected: lists `llama.h ggml.h ggml-backend.h ggml-alloc.h ggml-cpu.h ggml-metal.h module.modulemap` (and no error). If `curl` 404s on a header, that header moved at this tag — open the tag tree at `https://github.com/ggml-org/llama.cpp/tree/b9789/ggml/include` to find its path and fix the `HEADERS` entry. This is the open-question-#2 resolution: confirm the transitive set compiles in Step 6 and trim/extend here. (`llama.h` was already verified present at this tag — `raw.githubusercontent.com/ggml-org/llama.cpp/b9789/include/llama.h` returns HTTP 200.)
 
 - [ ] **Step 3: Confirm the dylib install name + that the needed symbols exist**
 
 Run: `cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot && otool -D Vendor/llama-cpp/libllama.dylib && nm -gU Vendor/llama-cpp/libllama.dylib | grep -E '_llama_(backend_init|model_default_params|model_load_from_file|init_from_model|get_memory|memory_seq_rm|tokenize|decode|sampler_sample)$' | sort`
 Expected: `otool -D` prints an install name (e.g. `@rpath/libllama.0.0.9789.dylib` or `@rpath/libllama.dylib`); the `nm` grep lists all nine symbols. Note the `@rpath` value — Step 5 must make that rpath resolve.
 
-- [ ] **Step 4: Create the `LlamaCore` module map**
+- [ ] **Step 4: Confirm the generated `LlamaCore` module map**
 
-Create `Vendor/llama-cpp/include/module.modulemap`:
+Step 1's heredoc wrote `Vendor/llama-cpp/include/module.modulemap` when the script ran in Step 2 — it is NOT a hand-committed file (the whole `Vendor/` tree is gitignored and script-generated). Confirm its content:
+
+Run: `cat /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot/Vendor/llama-cpp/include/module.modulemap`
+Expected:
 
 ```
 module LlamaCore {
@@ -128,7 +143,7 @@ module LlamaCore {
 }
 ```
 
-(If Step 6 reports a missing header that `llama.h` transitively includes, add a `header "..."` line for it here and a corresponding entry in the script's `HEADERS` array, then re-run Step 2.)
+(If Step 6 reports a missing header that `llama.h` transitively includes, add a `header "..."` line to the **heredoc in `Scripts/fetch-llama.sh`** AND a corresponding entry in that script's `HEADERS` array, then re-run Step 2. Do not hand-edit the generated file — the script overwrites it.)
 
 - [ ] **Step 5: Wire `project.yml` — header path, module, link, rpath**
 
@@ -198,11 +213,11 @@ Expected: `Test Suite 'LlamaCoreSmokeTests' passed`, `** TEST SUCCEEDED **`. If 
 
 ```bash
 cd /Users/0xmithrandir/Documents/GitHub/lokalbotfable/LokalBot
-git add Scripts/fetch-llama.sh Vendor/llama-cpp/include/module.modulemap project.yml LokalBot.xcodeproj LokalBotTests/LlamaCoreSmokeTests.swift
+git add Scripts/fetch-llama.sh project.yml LokalBot.xcodeproj LokalBotTests/LlamaCoreSmokeTests.swift
 git commit -m "build: link in-process libllama via LlamaCore module (b9789)"
 ```
 
-(If `Vendor/llama-cpp/include/*.h` are tracked rather than `.gitignore`d like the dylibs, `git add` them too; match whatever the existing `Vendor/llama-cpp` dylibs do — check `git check-ignore Vendor/llama-cpp/libllama.dylib` first.)
+Note: nothing under `Vendor/` is committed — `.gitignore` ignores the whole tree (confirmed: `git check-ignore Vendor/llama-cpp/include/module.modulemap` matches `Vendor/`). The module map and headers are regenerated/fetched by `Scripts/fetch-llama.sh` on every build (it is a pre-build phase), so a fresh clone and CI reconstruct them. Do NOT `git add -f` the module map or headers.
 
 ---
 

--- a/Docs/superpowers/specs/2026-06-29-inprocess-cotyping-runtime-design.md
+++ b/Docs/superpowers/specs/2026-06-29-inprocess-cotyping-runtime-design.md
@@ -182,7 +182,7 @@ Each unit below states *what it does*, *its interface*, and *what it depends on*
   otherwise the existing HTTP `CotypingEngine`. Resolved per-completion (mirrors
   today's `makeEngine` closure) so a settings change applies live.
 - **Depends on:** `AppSettings` (`cotypingTextEngineSettings`,
-  `cotypingUseSeparateModel`), `ModelCatalog`.
+  `cotypingBuiltInModelID`), `ModelCatalog`.
 
 ## 9. Data flow (per keystroke)
 

--- a/Docs/superpowers/specs/2026-06-29-inprocess-cotyping-runtime-design.md
+++ b/Docs/superpowers/specs/2026-06-29-inprocess-cotyping-runtime-design.md
@@ -1,0 +1,301 @@
+# In-process `libllama` cotyping runtime — design
+
+- **Date:** 2026-06-29
+- **Status:** Draft for review
+- **Author:** stevyhacker (with Claude)
+- **Scope:** Cotyping (inline autocomplete) generation runtime only — "Root A"
+
+## 1. Context
+
+LokalBot's Cotyping subsystem is a faithful port of Cotabby's suggestion pipeline
+(focus → debounce → generation → ghost overlay → accept), but it generates
+completions over HTTP against a bundled `llama-server` subprocess
+(`/v1/completions`, SSE) — see `CotypingEngine`, `TextEngine`, and `LlamaServer`.
+Cotypist and Cotabby instead run llama.cpp **in-process**, holding a persistent
+context + KV cache, decoding only the newly typed suffix per keystroke, streaming
+tokens straight into the ghost, and stopping inside the decode loop.
+
+Side-by-side, LokalBot feels a half-step behind on all four axes the user
+identified: latency, suggestion quality, inline visual feel, and accept/coverage.
+The latency and decode-stop-fidelity axes trace directly to the HTTP runtime; the
+other two are separate roots (see §15). `Docs/CotypingParityQA.md` already names
+the runtime as the one known-incomplete parity item.
+
+The pipeline already abstracts generation behind the `CotypingCompleting`
+protocol, so the runtime can be swapped without touching orchestration, prompting,
+normalization, the overlay, or acceptance.
+
+## 2. Problem
+
+For the built-in GGUF backend, replace the per-keystroke
+HTTP → `llama-server` → SSE path with an in-process `libllama` runtime that:
+
+1. Holds a persistent `llama_context` + KV cache across keystrokes.
+2. Re-prefills **only** the diverged suffix of the prompt (incremental prefill).
+3. Streams tokens to the ghost and stops natively at the same boundary
+   `CotypingDecodeStopPolicy` already defines.
+4. Cancels in-flight generation instantly when a keystroke supersedes it.
+5. Never blocks the main thread while the user types.
+
+…without regressing the non-GGUF backends (Ollama / OpenAI-compatible / Apple
+Intelligence), which must keep working over the existing HTTP path.
+
+## 3. Goals
+
+- True Cotypist-class runtime for the built-in model: in-process decode, KV reuse,
+  native streaming + stop, instant cancellation.
+- Contained blast radius: one new `CotypingCompleting` conformer + an engine
+  selector. No changes to `CotypingCoordinator`, `CotypingPromptRenderer`,
+  `CotypingTextNormalizer`, `CotypingOverlayController`, accept logic, the learning
+  store, or the debounce policy.
+- Reuse the dylibs and GGUF models already shipped — one model format, version
+  locked to the bundled `llama-server` (`b9789`).
+- Measurable latency improvement, proven by an A/B benchmark against the HTTP path.
+
+## 4. Non-goals
+
+- Migrating summarization / chat / embeddings off `llama-server` (separate, larger
+  effort; the in-process runtime here is cotyping-only).
+- Removing the HTTP `CotypingEngine` (it stays as the fallback and the non-GGUF
+  backend path — see §11).
+- Root B (model-default quality) and Root C (overlay/accept polish). These are
+  sequenced fast-follows with their own specs (§15).
+- Speculative decoding / draft models. The architecture allows it later; it is not
+  part of this spec.
+
+## 5. Success criteria
+
+- **First ghost token < ~200–300 ms** after warmup on the bundled small model
+  (`Qwen3.5-0.8B-Q4_K_M`), measured from generation start (post-debounce).
+- **End-to-end p95 well under the current 2000 ms** target in
+  `CotypingParityQA.md`, on the same model and prompts.
+- **KV reuse proven**: a second generation whose prompt extends the first decodes
+  only the suffix (asserted by a token-count probe in tests).
+- **Instant cancellation**: superseding a generation stops decode within one token
+  iteration; no orphaned work.
+- **No main-thread hitch**: typing latency unaffected while a generation runs
+  (manual + instruments check).
+- **No regression**: non-GGUF backends and the HTTP fallback path behave exactly as
+  before.
+
+## 6. Decisions (resolved during brainstorming)
+
+| Decision | Choice | Rationale |
+| --- | --- | --- |
+| Runtime path | In-process now (not incremental-only / not measure-first) | User wants real Cotypist parity; HTTP is the ceiling on the felt latency. |
+| Integration mechanism | Direct C-interop with vendored `libllama.dylib` via a Clang module map | Reuses exact dylibs + GGUF models already shipped; version-locked to `b9789`; stable public C API. Rejected: Obj-C++ over `common` (unstable internal API, headers not vendored); MLX (forks the model format into a second ecosystem). |
+| HTTP engine | Keep as live fallback | It is also the non-GGUF backend path; removing it would regress Ollama / OpenAI-compatible / Apple Intelligence and remove the safety net. |
+| Spec scope | Root A (runtime) only | Coherent, single-plan-sized. B and C are independent and sequenced. |
+
+## 7. Architecture overview — the seam
+
+The coordinator depends only on `CotypingCompleting`
+(`generate` / `generateStreaming`). The change is additive:
+
+- **New:** `LocalLlamaCotypingEngine: CotypingCompleting`, backed by an
+  `LlamaCotypingRuntime` actor and the `LlamaCore` C-interop module.
+- **Changed:** `AppState.cotypingEngine` becomes a small selector that returns the
+  local engine for the built-in GGUF backend on Apple Silicon, else the existing
+  HTTP `CotypingEngine`.
+- **Unchanged:** everything else in `LokalBot/Cotyping/*` and `LlamaServer`.
+
+```
+CotypingCoordinator
+        │  (CotypingCompleting protocol — unchanged)
+        ▼
+CotypingEngineSelector
+   ├── built-in GGUF + Apple Silicon → LocalLlamaCotypingEngine ──► LlamaCotypingRuntime (actor) ──► LlamaCore (libllama)
+   └── Ollama / OpenAI-compat / AI    → CotypingEngine (HTTP, existing)
+```
+
+## 8. Components
+
+Each unit below states *what it does*, *its interface*, and *what it depends on*.
+
+### 8.1 `LlamaCore` — C-interop module
+- **Does:** exposes the pinned llama.cpp C API to Swift.
+- **Interface:** `import LlamaCore` → `llama.h` / `ggml.h` symbols.
+- **Depends on:** vendored `b9789` headers in `Vendor/llama-cpp/include/` + a
+  `module.modulemap`; links the already-vendored `libllama.dylib` (+ `libggml*.dylib`).
+- **Notes:** exact symbol names (e.g. `llama_model_load_from_file`,
+  `llama_init_from_model`, `llama_get_memory` / `llama_memory_seq_rm`,
+  `llama_sampler_*`) are pinned by the vendored header — confirm against it rather
+  than from memory, since the C API evolved (the old `llama_kv_cache_*` and
+  `llama_new_context_with_model` names were renamed/deprecated before `b9789`).
+
+### 8.2 `LlamaCotypingRuntime` — inference actor
+- **Does:** owns the model + context + KV state; runs incremental prefill and the
+  decode loop; serializes all inference.
+- **State:**
+  - `llama_model` loaded once from the configured GGUF path (reuse
+    `ModelCatalog` / download manager to resolve the path).
+  - `llama_context` with `n_ctx = 2048` (matches `LlamaServer.cotyping`),
+    `n_gpu_layers = 99` (full Metal offload, matching the server's `-ngl 99`),
+    tuned `n_threads`.
+  - Reusable `llama_batch`.
+  - Sampler chain from `CotypingConfiguration.standard` (temp 0.1, top_k 20,
+    top_p 0.7, min_p 0.08, repeat_penalty 1.05, seed `0x00C0FFEE`).
+  - `cachedTokens: [llama_token]` — the sequence currently resident in the KV
+    cache (basis for incremental prefill).
+- **Interface (sketch):**
+  ```
+  func load(modelPath: String) throws        // also primes Metal (warmup decode)
+  func unload()
+  func generate(promptTokens: [Int32],
+                maxTokens: Int,
+                onToken: (String) -> Bool,    // return false to stop (cancel/stop policy)
+  ) async -> String
+  ```
+- **Depends on:** `LlamaCore`, `CotypingConfiguration`.
+
+### 8.3 `IncrementalPrefill` — pure helper (the latency heart)
+- **Does:** given `cachedTokens` and the new `promptTokens`, returns the common
+  prefix length `p`. The runtime then drops the diverged tail
+  (`llama_memory_seq_rm(mem, 0, p, -1)`), decodes tokens `p ..< promptTokens.count`
+  as the prefill batch (logits only on the final token), and stores `promptTokens`
+  as the new `cachedTokens`.
+- **Interface:** `static func commonPrefixLength(_ a: [Int32], _ b: [Int32]) -> Int`.
+- **Depends on:** nothing (pure) → fully unit-testable.
+- **Why it matters:** as the user types forward, the conditioning preface +
+  earlier text are a stable, growing prefix, so `p` is large and only a few new
+  tokens are prefilled each keystroke. This is the mechanism the HTTP path can only
+  approximate via `llama-server` slot caching (which the current request body does
+  not even opt into).
+
+### 8.4 `LocalLlamaCotypingEngine: CotypingCompleting` — the seam
+- **Does:** adapts the runtime to the protocol the coordinator already calls.
+- **Flow:** tokenize `request.prompt` → call the runtime → in the decode loop,
+  after each token, detokenize incrementally and run the **existing**
+  `CotypingTextNormalizer.normalizeDetailed` + `CotypingDecodeStopPolicy.verdict`
+  on the accumulated raw text → `onPartial` → stop on policy verdict, word/token
+  budget, or cancellation. Returns the same `CotypingNormalizationResult` the HTTP
+  engine returns.
+- **Cancellation:** honors `Task.isCancelled` (the coordinator supersedes by
+  generation id); the runtime's `onToken` returns `false` → decode loop exits next
+  iteration. No network teardown.
+- **Depends on:** `LlamaCotypingRuntime`, `CotypingTextNormalizer`,
+  `CotypingDecodeStopPolicy` (both reused unchanged).
+
+### 8.5 Engine selector — `AppState.cotypingEngine`
+- **Does:** chooses the conformer per the active cotyping backend setting.
+- **Rule:** built-in GGUF model + Apple Silicon → `LocalLlamaCotypingEngine`;
+  otherwise the existing HTTP `CotypingEngine`. Resolved per-completion (mirrors
+  today's `makeEngine` closure) so a settings change applies live.
+- **Depends on:** `AppSettings` (`cotypingTextEngineSettings`,
+  `cotypingUseSeparateModel`), `ModelCatalog`.
+
+## 9. Data flow (per keystroke)
+
+```
+focus → debounce → coordinator.generate → build CotypingRequest (unchanged)
+      → LocalLlamaCotypingEngine.generateStreaming
+            → runtime: tokenize prompt
+                     → incremental prefill (decode ONLY tokens after common prefix)
+                     → decode loop { sample → detok → normalize → onPartial
+                                     → CotypingDecodeStopPolicy check → cancel check }
+      → CotypingNormalizationResult → overlay.show (unchanged)
+```
+
+## 10. Concurrency, threading, cancellation
+
+- The actor serializes inference; one generation at a time.
+- `llama_decode` runs **off the main actor** (actor executor on a background
+  thread). Token callbacks hop to MainActor only to paint the ghost.
+- Supersession cancels the in-flight generation cooperatively (flag checked each
+  decode iteration). Because there is no socket, cancellation is effectively
+  instant — this removes the "doomed in-flight HTTP request" lag the current path
+  pays on fast typing.
+
+## 11. Lifecycle, memory, fallback
+
+- **Load = warmup.** Load the model on cotyping-enable and run one priming decode
+  so Metal pipelines are hot before the first real keystroke. (Today only
+  transcription models are prewarmed; cotyping pays a cold first hit.)
+- **Unload** on cotyping-disable.
+- **Memory pressure:** a `DISPATCH_SOURCE_TYPE_MEMORYPRESSURE` source unloads the
+  model on warning and lazily reloads (or temporarily routes to the HTTP path), so
+  cotyping never OOMs the app. `Qwen3.5-0.8B-Q4_K_M` ≈ 0.6 GB (negligible); Gemma
+  E4B Q5 ≈ 3–4 GB stays gated behind the existing "separate / high-quality" model
+  flow.
+- **Coexistence:** the summarizer `LlamaServer.shared` is untouched; the in-process
+  cotyping model is separate and small.
+- **Fallback:** model-load failure, header/link mismatch, or unsupported hardware
+  routes to the existing HTTP `CotypingEngine`, surfaced via the current
+  `CotypingState.failed`. No regression.
+
+## 12. Build & packaging
+
+- **`Scripts/fetch-llama.sh`:** additionally fetch the `b9789` headers
+  (`llama.h`, `ggml.h`, and the ggml-backend/alloc headers the public API pulls in)
+  into `Vendor/llama-cpp/include/`. Same `TAG`, idempotent, runs as the existing
+  pre-build phase.
+- **`project.yml`:** add the module map + header search path; move
+  `libllama.dylib` (+ `libggml*.dylib`) into the target's **Link Binary With
+  Libraries** phase (today they are resources only). Verify the app binary's
+  `@rpath` resolves to the bundled `Vendor/llama-cpp` at runtime — `llama-server`
+  already loads these signed dylibs, so code signing / hardened-runtime
+  entitlements are unchanged.
+- No new third-party dependency, no new binary in the bundle.
+
+## 13. Error handling
+
+- Tokenization / decode errors → fail the single generation, surface
+  `CotypingState.failed`, leave the field untouched (consistent with the HTTP
+  path's error handling in `CotypingCoordinator.generate`).
+- Context overflow (prompt + budget > `n_ctx`) → the prefix window already caps at
+  150 words / 2500 chars (`CotypingPrefixWindow`), comfortably under 2048 tokens;
+  add a defensive clamp before decode.
+- Load failure → fallback engine (§11), logged once.
+
+## 14. Testing strategy
+
+- **Unit:** `IncrementalPrefill.commonPrefixLength` (pure, exhaustive edge cases:
+  empty, identical, divergent-at-0, one-is-prefix-of-other). Sampler-config
+  mapping from `CotypingConfiguration` to the llama sampler chain.
+- **Integration (gated on the bundled model being present):** load
+  `Qwen3.5-0.8B-Q4_K_M`, generate from a fixed prompt + seed → assert deterministic
+  output; issue a second generation with an extended prefix and assert only the
+  suffix is decoded (token-count probe) → proves KV reuse.
+- **Benchmark:** extend `CotypingBenchmark` to record TTFT / prefill ms / decode ms
+  for the in-process engine and A/B against the HTTP engine on the existing default
+  scenarios (email follow-up, chat ownership, browser prose, mid-word). This closes
+  the "measure the budget" gap and substantiates the parity claim in
+  `CotypingParityQA.md`.
+- **Manual:** the existing `Scripts/compare-cotyping.sh` side-by-side vs Cotypist,
+  plus an Instruments pass confirming no main-thread stalls while typing.
+
+## 15. Out of scope — sequenced fast-follows
+
+These were identified as separate roots and are **not** in this spec:
+
+- **Root B — suggestion quality.** *Partially landed (2026-06-29):* cotyping now
+  always runs its own dedicated model, defaulting to Gemma 4 E4B Q5 XL, with the
+  opt-in "separate model" toggle removed — strict, with no fallback to the bundled
+  tiny model and no cross-app (Cotypist) model reuse. Still pending: turning the
+  good context features (app context, learning) on by default, and validating a
+  base/continuation model against the instruction-tuned default. The in-process
+  runtime makes a stronger model affordable (cheap incremental prefill).
+- **Root C — inline visual feel + accept/coverage.** Overlay font/baseline/color
+  blend, reducing popup fallback by improving caret-rect resolution, killing
+  re-anchor flicker, and auditing the inserter across the apps Cotypist supports.
+  The runtime's instant cancellation + native streaming already reduces flicker,
+  but the blend/coverage work is separate.
+
+## 16. Risks & mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| C API drift vs memory of it | Pin headers to `b9789`; code against the vendored header, not recollection. |
+| Two model copies in RAM (cotyping + summarizer) when both active | Cotyping now defaults to Gemma 4 E4B Q5 XL (~5 GB resident), so memory-pressure unload (§11) is load-bearing, not optional. On <16 GB Macs, steer to a smaller cotyping model (Qwen3.5 2B / LFM2.5 1.2B). |
+| Main-thread stalls from decode | Inference strictly off the main actor; only paint hops to MainActor. |
+| Link / `@rpath` issues with in-process dylibs | The dylibs are already shipped + signed for the server; verify link phase + rpath in an early build spike. |
+| Determinism / sampler parity vs HTTP | Same `CotypingConfiguration` + fixed seed; benchmark A/B asserts comparable output. |
+
+## 17. Open questions
+
+- Should the in-process runtime become the default for the built-in backend
+  immediately, or ship behind a flag for one release while the benchmark validates
+  the latency win? (Recommendation: flag-gated default-on, with the HTTP fallback
+  one toggle away.)
+- Confirm the exact set of public headers `llama.h` transitively requires at
+  `b9789` so `fetch-llama.sh` pulls all of them (resolve during the build spike).

--- a/LokalBot/Cotyping/CotypingBenchmark.swift
+++ b/LokalBot/Cotyping/CotypingBenchmark.swift
@@ -239,3 +239,43 @@ enum CotypingBenchmarkRunner {
         }
     }
 }
+
+/// Result of running both cotyping engines over the same scenarios. Deltas are
+/// `http − local`, so a positive value means the in-process engine is faster.
+struct CotypingABComparison: Equatable, Sendable {
+    let local: CotypingBenchmarkSummary
+    let http: CotypingBenchmarkSummary
+
+    /// p95 end-to-end latency improvement (ms), or nil if either side has no data.
+    var p95DeltaMs: Int? {
+        guard let l = local.p95LatencyMs, let h = http.p95LatencyMs else { return nil }
+        return h - l
+    }
+
+    /// Time-to-first-visible-token improvement (ms), or nil if either side lacks it.
+    var ttftDeltaMs: Int? {
+        guard let l = local.averageFirstVisibleLatencyMs,
+              let h = http.averageFirstVisibleLatencyMs else { return nil }
+        return h - l
+    }
+}
+
+extension CotypingBenchmarkRunner {
+    /// Runs the default scenarios through both engines (streaming on, so TTFT is
+    /// captured) and returns the comparison. For manual latency validation.
+    static func runAB(
+        local: CotypingCompleting,
+        http: CotypingCompleting,
+        config: CotypingConfiguration,
+        personalization: CotypingPersonalization,
+        learnedExamples: @escaping (CotypingField) -> [String] = { _ in [] }
+    ) async -> CotypingABComparison {
+        let localSummary = await run(
+            engine: local, config: config, personalization: personalization,
+            streamPartials: true, learnedExamples: learnedExamples)
+        let httpSummary = await run(
+            engine: http, config: config, personalization: personalization,
+            streamPartials: true, learnedExamples: learnedExamples)
+        return CotypingABComparison(local: localSummary, http: httpSummary)
+    }
+}

--- a/LokalBot/Cotyping/CotypingEngine.swift
+++ b/LokalBot/Cotyping/CotypingEngine.swift
@@ -81,6 +81,16 @@ protocol CotypingCompleting: AnyObject {
     /// arrive. Default (below) is non-streaming.
     func generateStreaming(_ request: CotypingRequest,
                            onPartial: @escaping @Sendable (CotypingNormalizationResult) -> Void) async throws -> CotypingNormalizationResult
+    /// Loads + primes any in-process model so the first completion isn't cold.
+    /// Default is a no-op: only the in-process `LocalLlamaCotypingEngine` has a
+    /// model to prewarm; the HTTP engine boots its server lazily.
+    func prewarm() async throws
+    /// Frees any in-process resources the engine holds. Default is a no-op:
+    /// only the in-process `LocalLlamaCotypingEngine` holds a loaded model; the
+    /// HTTP engine has nothing to free. The `CotypingEngineSelector` calls this
+    /// when it routes away from the local engine so the model's weights don't
+    /// stay resident while completions go to HTTP.
+    func unload() async
 }
 
 extension CotypingCompleting {
@@ -90,6 +100,10 @@ extension CotypingCompleting {
         onPartial(result)
         return result
     }
+
+    func prewarm() async throws {}
+
+    func unload() async {}
 }
 
 /// Production engine: resolves LokalBot's configured `TextEngine` (the very same

--- a/LokalBot/Cotyping/CotypingModelPreparation.swift
+++ b/LokalBot/Cotyping/CotypingModelPreparation.swift
@@ -74,8 +74,7 @@ enum CotypingModelPreparer {
     }
 
     static func recommendedIsActive(settings: AppSettings) -> Bool {
-        settings.cotypingUseSeparateModel
-            && settings.cotypingBuiltInModelID == ModelCatalog.recommendedCotypingID
+        settings.cotypingBuiltInModelID == ModelCatalog.recommendedCotypingID
     }
 
     static func action(localURL: URL?, isDownloading: Bool) -> CotypingModelPreparationAction {
@@ -93,7 +92,6 @@ enum CotypingModelPreparer {
         let localURL = ModelCatalog.localURL(for: entry, storage: storage)
         switch action(localURL: localURL, isDownloading: downloads.progress[entry.id] != nil) {
         case .activate:
-            settings.cotypingUseSeparateModel = true
             settings.cotypingBuiltInModelID = entry.id
         case .download:
             downloads.download(entry, storage: storage)

--- a/LokalBot/Cotyping/Llama/CotypingEngineSelector.swift
+++ b/LokalBot/Cotyping/Llama/CotypingEngineSelector.swift
@@ -7,10 +7,10 @@ import Foundation
 @MainActor
 final class CotypingEngineSelector: CotypingCompleting {
     private let http: CotypingCompleting
-    private let makeLocal: (String) -> LocalLlamaCotypingEngine
+    private let makeLocal: (String) -> CotypingCompleting
     private let settings: () -> AppSettings
     private let storage: StorageManager
-    private var local: LocalLlamaCotypingEngine?
+    private var local: CotypingCompleting?
     private var localModelPath: String?
     /// Set after the first in-process failure so the HTTP fallback is logged
     /// once per failure episode (spec §13), not on every keystroke. Reset on a
@@ -19,7 +19,7 @@ final class CotypingEngineSelector: CotypingCompleting {
 
     init(
         http: CotypingCompleting,
-        makeLocal: @escaping (String) -> LocalLlamaCotypingEngine,
+        makeLocal: @escaping (String) -> CotypingCompleting,
         settings: @escaping () -> AppSettings,
         storage: StorageManager
     ) {
@@ -50,23 +50,38 @@ final class CotypingEngineSelector: CotypingCompleting {
 
     /// Returns the local engine if eligible, lazily (re)building it when the
     /// resolved model path changes; nil → use HTTP.
-    private func localIfEligible() -> LocalLlamaCotypingEngine? {
+    private func localIfEligible() -> CotypingCompleting? {
         let s = settings()
         // Short-circuit the cheap gating conditions before the synchronous GGUF
         // disk read in `resolvedModelURL`: a built-in-backend user with the runtime
         // toggle off (or on Intel) would otherwise pay that read for nothing. This
         // is behavior-identical to gating in `shouldUseLocal` — which still returns
         // false in exactly these cases — we just avoid resolving the path first.
-        guard s.cotypingInProcessRuntime, Self.isAppleSilicon else { return nil }
+        guard s.cotypingInProcessRuntime, Self.isAppleSilicon else { dropLocalEngine(); return nil }
         guard let url = resolvedModelURL(s),
               Self.shouldUseLocal(settings: s, modelURL: url, isAppleSilicon: Self.isAppleSilicon)
-        else { return nil }
+        else { dropLocalEngine(); return nil }
         if local == nil || localModelPath != url.path {
             local = makeLocal(url.path)
             localModelPath = url.path
             didLogLocalFailure = false
         }
         return local
+    }
+
+    /// Drops the cached in-process engine and frees its loaded model when the
+    /// selector routes away from local (flag toggled off, Intel, or the model
+    /// stops resolving). Self-limiting: a no-op once already dropped, so it's
+    /// safe to call on every ineligible `localIfEligible()` pass. Setting
+    /// `local = nil` alone is NOT enough — the runtime actor's deinit is async
+    /// and may not run promptly, so we explicitly unload. When the flag flips
+    /// back on and the model resolves, `localIfEligible()` rebuilds a fresh
+    /// engine via `makeLocal` (cold reload on the next generate).
+    private func dropLocalEngine() {
+        guard let engine = local else { return }
+        local = nil
+        localModelPath = nil
+        Task { await engine.unload() }
     }
 
     func prewarm() async {

--- a/LokalBot/Cotyping/Llama/CotypingEngineSelector.swift
+++ b/LokalBot/Cotyping/Llama/CotypingEngineSelector.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Per-completion router between the in-process `LocalLlamaCotypingEngine`
+/// (built-in GGUF on Apple Silicon, flag on) and the existing HTTP
+/// `CotypingEngine` (non-GGUF backends, flag off, or in-process load failure).
+/// Conforms to `CotypingCompleting`, so `CotypingCoordinator` is unchanged.
+@MainActor
+final class CotypingEngineSelector: CotypingCompleting {
+    private let http: CotypingCompleting
+    private let makeLocal: (String) -> LocalLlamaCotypingEngine
+    private let settings: () -> AppSettings
+    private let storage: StorageManager
+    private var local: LocalLlamaCotypingEngine?
+    private var localModelPath: String?
+    /// Set after the first in-process failure so the HTTP fallback is logged
+    /// once per failure episode (spec §13), not on every keystroke. Reset on a
+    /// successful local generation or a model-path change.
+    private var didLogLocalFailure = false
+
+    init(
+        http: CotypingCompleting,
+        makeLocal: @escaping (String) -> LocalLlamaCotypingEngine,
+        settings: @escaping () -> AppSettings,
+        storage: StorageManager
+    ) {
+        self.http = http
+        self.makeLocal = makeLocal
+        self.settings = settings
+        self.storage = storage
+    }
+
+    static var isAppleSilicon: Bool {
+        #if arch(arm64)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    nonisolated static func shouldUseLocal(settings: AppSettings, modelURL: URL?, isAppleSilicon: Bool) -> Bool {
+        settings.cotypingInProcessRuntime && isAppleSilicon && modelURL != nil
+    }
+
+    /// Resolves the built-in cotyping model path the same way `makeTextEngine` does.
+    private func resolvedModelURL(_ s: AppSettings) -> URL? {
+        guard let entry = ModelCatalog.entry(id: s.cotypingBuiltInModelID, custom: s.customBuiltInModels)
+                ?? ModelCatalog.entry(id: ModelCatalog.bundledID) else { return nil }
+        return ModelCatalog.localURL(for: entry, storage: storage)
+    }
+
+    /// Returns the local engine if eligible, lazily (re)building it when the
+    /// resolved model path changes; nil → use HTTP.
+    private func localIfEligible() -> LocalLlamaCotypingEngine? {
+        let s = settings()
+        guard let url = resolvedModelURL(s),
+              Self.shouldUseLocal(settings: s, modelURL: url, isAppleSilicon: Self.isAppleSilicon)
+        else { return nil }
+        if local == nil || localModelPath != url.path {
+            local = makeLocal(url.path)
+            localModelPath = url.path
+            didLogLocalFailure = false
+        }
+        return local
+    }
+
+    func prewarm() async {
+        guard let engine = localIfEligible() else { return }
+        try? await engine.prewarm()
+    }
+
+    func generate(_ request: CotypingRequest) async throws -> CotypingNormalizationResult {
+        guard let engine = localIfEligible() else { return try await http.generate(request) }
+        do {
+            let result = try await engine.generate(request)
+            didLogLocalFailure = false
+            return result
+        } catch let error as LlamaRuntimeError {
+            logLocalFallback(error)
+            return try await http.generate(request)
+        }
+    }
+
+    func generateStreaming(
+        _ request: CotypingRequest,
+        onPartial: @escaping @Sendable (CotypingNormalizationResult) -> Void
+    ) async throws -> CotypingNormalizationResult {
+        guard let engine = localIfEligible() else {
+            return try await http.generateStreaming(request, onPartial: onPartial)
+        }
+        do {
+            let result = try await engine.generateStreaming(request, onPartial: onPartial)
+            didLogLocalFailure = false
+            return result
+        } catch let error as LlamaRuntimeError {
+            logLocalFallback(error)
+            return try await http.generateStreaming(request, onPartial: onPartial)
+        }
+    }
+
+    /// Logs the in-process→HTTP fallback once per failure episode (spec §13).
+    /// The local engine is kept (not torn down) so a transient failure — e.g. a
+    /// memory-pressure unload (Task 8) — recovers on a later completion, and the
+    /// log does not repeat on every keystroke.
+    private func logLocalFallback(_ error: LlamaRuntimeError) {
+        guard !didLogLocalFailure else { return }
+        didLogLocalFailure = true
+        NSLog("Cotyping: in-process runtime unavailable (\(error)); using HTTP fallback (will keep retrying).")
+    }
+}

--- a/LokalBot/Cotyping/Llama/CotypingEngineSelector.swift
+++ b/LokalBot/Cotyping/Llama/CotypingEngineSelector.swift
@@ -52,6 +52,12 @@ final class CotypingEngineSelector: CotypingCompleting {
     /// resolved model path changes; nil → use HTTP.
     private func localIfEligible() -> LocalLlamaCotypingEngine? {
         let s = settings()
+        // Short-circuit the cheap gating conditions before the synchronous GGUF
+        // disk read in `resolvedModelURL`: a built-in-backend user with the runtime
+        // toggle off (or on Intel) would otherwise pay that read for nothing. This
+        // is behavior-identical to gating in `shouldUseLocal` — which still returns
+        // false in exactly these cases — we just avoid resolving the path first.
+        guard s.cotypingInProcessRuntime, Self.isAppleSilicon else { return nil }
         guard let url = resolvedModelURL(s),
               Self.shouldUseLocal(settings: s, modelURL: url, isAppleSilicon: Self.isAppleSilicon)
         else { return nil }

--- a/LokalBot/Cotyping/Llama/IncrementalPrefill.swift
+++ b/LokalBot/Cotyping/Llama/IncrementalPrefill.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Pure helper for KV-cache reuse. Given the token sequence currently resident
+/// in the llama context (`cached`) and the freshly tokenized prompt (`next`),
+/// returns the number of leading tokens they share. The runtime keeps that
+/// prefix in the KV cache and re-prefills only `next[p...]`, which is what makes
+/// per-keystroke decode cheap as the user types forward.
+enum IncrementalPrefill {
+    static func commonPrefixLength(_ a: [Int32], _ b: [Int32]) -> Int {
+        let limit = min(a.count, b.count)
+        var p = 0
+        while p < limit && a[p] == b[p] { p += 1 }
+        return p
+    }
+}

--- a/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
+++ b/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
@@ -179,7 +179,7 @@ actor LlamaCotypingRuntime {
         maxTokens: Int,
         samplerSpecs: [LlamaSamplerSpec],
         onToken: @Sendable (String) -> Bool
-    ) -> String {
+    ) throws -> String {
         guard let ctx, let vocab, !promptTokens.isEmpty else { return "" }
         guard let sampler = makeSampler(samplerSpecs) else { return "" }
         defer { llama_sampler_free(sampler) }
@@ -209,14 +209,14 @@ actor LlamaCotypingRuntime {
             // `else` branch. DO NOT remove that fallback — partial reuse is only
             // safe when seq_rm confirms the kept prefix is still resident.
             guard decode(Array(promptTokens[reuse...]), startPos: Int32(reuse),
-                         logitsLastOnly: true) else { return "" }
+                         logitsLastOnly: true) else { throw LlamaRuntimeError.decodeFailed }
         } else {
             // Recurrent/hybrid model (SSM/Mamba) cannot partially rewind its rolling
             // state, or a partial seq_rm above was not honored. Reset and prefill the
             // whole prompt from position 0. `reuse` above is still the meaningful
             // KV-reuse *signal* callers read via lastPrefillTokenCount.
             llama_memory_seq_rm(mem, 0, 0, -1)
-            guard decode(promptTokens, startPos: 0, logitsLastOnly: true) else { return "" }
+            guard decode(promptTokens, startPos: 0, logitsLastOnly: true) else { throw LlamaRuntimeError.decodeFailed }
         }
         lastPrefillTokenCount = promptTokens.count - reuse
         cachedTokens = promptTokens
@@ -230,7 +230,10 @@ actor LlamaCotypingRuntime {
             let text = piece(for: tok)
             output += text
             if !onToken(text) { break }
-            guard decode([tok], startPos: pos, logitsLastOnly: true) else { break }
+            // A mid-generation decode failure discards the partial output and
+            // propagates so the selector falls back to HTTP, rather than
+            // surfacing a truncated ghost as if it were a complete suggestion.
+            guard decode([tok], startPos: pos, logitsLastOnly: true) else { throw LlamaRuntimeError.decodeFailed }
             pos += 1
         }
         return output

--- a/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
+++ b/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
@@ -104,6 +104,13 @@ actor LlamaCotypingRuntime {
         supportsPartialReuse = false
     }
 
+    /// Frees the model + context under memory pressure. The next `generate`
+    /// call lazily reloads via `loadIfNeeded` (or the engine routes to HTTP if
+    /// reload fails). Keeps cotyping from OOMing the app under a large model.
+    func handleMemoryPressure() {
+        unload()
+    }
+
     /// Runs one priming decode so Metal pipelines are hot before the first real
     /// keystroke, then clears the KV so generation starts from a clean cache.
     private func warmup() {

--- a/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
+++ b/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
@@ -35,7 +35,13 @@ actor LlamaCotypingRuntime {
     /// models cannot rewind their rolling state to a prefix, so they full-reprefill.
     private var supportsPartialReuse = false
 
-    private static var backendReady = false
+    /// Initializes the llama backend exactly once across ALL instances. Swift
+    /// guarantees a static `let` initializer runs once and is thread-safe, which
+    /// removes the cross-instance check-then-set race a `static var` flag would have
+    /// (actor isolation does not protect static storage).
+    private static let backendReady: Void = {
+        llama_backend_init()
+    }()
 
     var isLoaded: Bool { model != nil && ctx != nil }
 
@@ -45,10 +51,7 @@ actor LlamaCotypingRuntime {
         if isLoaded, loadedModelPath == modelPath { return }
         unload()
 
-        if !Self.backendReady {
-            llama_backend_init()
-            Self.backendReady = true
-        }
+        _ = Self.backendReady   // forces the run-once backend init (idempotent)
 
         var mparams = llama_model_default_params()
         mparams.n_gpu_layers = 99   // full Metal offload (matches LlamaServer's -ngl 99)
@@ -183,16 +186,22 @@ actor LlamaCotypingRuntime {
         let shared = IncrementalPrefill.commonPrefixLength(cachedTokens, promptTokens)
         let reuse = min(shared, promptTokens.count - 1)
 
-        if supportsPartialReuse, reuse > 0 {
-            // Attention model: keep the shared prefix KV, re-decode only the suffix.
-            // seq_rm drops [reuse, end) — the diverged tail plus any stale tokens the
-            // previous generation appended past the prompt.
-            llama_memory_seq_rm(mem, 0, Int32(reuse), -1)
+        if supportsPartialReuse, reuse > 0,
+           llama_memory_seq_rm(mem, 0, Int32(reuse), -1) {
+            // Attention model: the shared prefix KV is kept and only the diverged
+            // suffix is re-decoded. seq_rm dropped [reuse, end) — the diverged tail
+            // plus any stale tokens the previous generation appended past the prompt.
+            //
+            // Safe because cotyping prompts are capped (~150 words, well under the
+            // production Gemma4 model's 512-token sliding window), so the kept prefix
+            // [0, reuse) is still resident. seq_rm returns false if the partial removal
+            // can't be honored (e.g. positions aged out of the SWA window on a longer
+            // prompt); we then fall through to the full re-prefill below.
             guard decode(Array(promptTokens[reuse...]), startPos: Int32(reuse),
                          logitsLastOnly: true) else { return "" }
         } else {
             // Recurrent/hybrid model (SSM/Mamba) cannot partially rewind its rolling
-            // state, so a non-zero-p0 seq_rm is unsupported — reset and prefill the
+            // state, or a partial seq_rm above was not honored. Reset and prefill the
             // whole prompt from position 0. `reuse` above is still the meaningful
             // KV-reuse *signal* callers read via lastPrefillTokenCount.
             llama_memory_seq_rm(mem, 0, 0, -1)

--- a/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
+++ b/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
@@ -1,0 +1,216 @@
+import Foundation
+import LlamaCore
+
+enum LlamaRuntimeError: Error, Equatable {
+    case modelLoadFailed(String)
+    case contextInitFailed
+    case decodeFailed
+}
+
+/// In-process llama.cpp runtime for cotyping. Owns the model, a persistent
+/// context + memory, and serializes all inference on the actor's executor
+/// (off the main actor).
+///
+/// The KV-reuse probe (`IncrementalPrefill`) reports how much of each prompt
+/// overlaps the previous one. The bundled Qwen3.5 is a hybrid SSM/attention
+/// model whose recurrent state cannot be partially rewound to a prefix, so the
+/// prompt is re-prefilled in full on every call; `lastPrefillTokenCount` still
+/// surfaces the diverged-suffix length as the meaningful reuse signal. On a
+/// pure-attention model the same probe would drive true partial-prefix reuse.
+///
+/// Pinned to llama.cpp `b9789`; symbols verified against the vendored dylib.
+actor LlamaCotypingRuntime {
+    private var model: OpaquePointer?
+    private var ctx: OpaquePointer?
+    private var vocab: OpaquePointer?
+    private var loadedModelPath: String?
+    /// The prompt most recently prefilled into the context (basis for the
+    /// incremental KV-reuse probe against the next prompt).
+    private var cachedTokens: [Int32] = []
+    private(set) var lastPrefillTokenCount: Int = 0
+
+    private static var backendReady = false
+
+    var isLoaded: Bool { model != nil && ctx != nil }
+
+    // MARK: - Lifecycle
+
+    func loadIfNeeded(modelPath: String) throws {
+        if isLoaded, loadedModelPath == modelPath { return }
+        unload()
+
+        if !Self.backendReady {
+            llama_backend_init()
+            Self.backendReady = true
+        }
+
+        var mparams = llama_model_default_params()
+        mparams.n_gpu_layers = 99   // full Metal offload (matches LlamaServer's -ngl 99)
+        guard let m = llama_model_load_from_file(modelPath, mparams) else {
+            throw LlamaRuntimeError.modelLoadFailed(modelPath)
+        }
+
+        var cparams = llama_context_default_params()
+        cparams.n_ctx = 2048        // matches LlamaServer.cotyping.contextTokens
+        cparams.n_batch = 2048
+        let threads = Int32(max(1, ProcessInfo.processInfo.activeProcessorCount - 2))
+        cparams.n_threads = threads
+        cparams.n_threads_batch = threads
+        guard let c = llama_init_from_model(m, cparams) else {
+            llama_model_free(m)
+            throw LlamaRuntimeError.contextInitFailed
+        }
+
+        model = m
+        ctx = c
+        vocab = llama_model_get_vocab(m)
+        loadedModelPath = modelPath
+        cachedTokens = []
+        lastPrefillTokenCount = 0
+        warmup()
+    }
+
+    /// Frees the llama context + model when the actor is deallocated. Without
+    /// this the Metal backend's residency set is still live at process exit,
+    /// which trips a teardown assertion in the vendored ggml-metal build.
+    deinit {
+        if let c = ctx { llama_free(c) }
+        if let m = model { llama_model_free(m) }
+    }
+
+    /// Prewarm == load + the priming decode `loadIfNeeded` already performs.
+    func prewarm(modelPath: String) throws { try loadIfNeeded(modelPath: modelPath) }
+
+    func unload() {
+        if let c = ctx { llama_free(c) }
+        if let m = model { llama_model_free(m) }
+        ctx = nil
+        model = nil
+        vocab = nil
+        loadedModelPath = nil
+        cachedTokens = []
+    }
+
+    /// Runs one priming decode so Metal pipelines are hot before the first real
+    /// keystroke, then clears the KV so generation starts from a clean cache.
+    private func warmup() {
+        guard let vocab, let ctx else { return }
+        let bos = llama_vocab_bos(vocab)
+        _ = decode([bos], startPos: 0, logitsLastOnly: true)
+        llama_memory_clear(llama_get_memory(ctx), true)
+        cachedTokens = []
+    }
+
+    // MARK: - Tokenize / detokenize
+
+    func tokenize(_ text: String, addBOS: Bool) -> [Int32] {
+        guard let vocab else { return [] }
+        return text.withCString { cstr -> [Int32] in
+            let textLen = Int32(strlen(cstr))
+            var capacity = textLen + (addBOS ? 1 : 0) + 8
+            var tokens = [Int32](repeating: 0, count: Int(capacity))
+            var n = llama_tokenize(vocab, cstr, textLen, &tokens, capacity, addBOS, true)
+            if n < 0 {                      // buffer too small: -n is required size
+                capacity = -n
+                tokens = [Int32](repeating: 0, count: Int(capacity))
+                n = llama_tokenize(vocab, cstr, textLen, &tokens, capacity, addBOS, true)
+            }
+            return Array(tokens.prefix(Int(max(0, n))))
+        }
+    }
+
+    private func piece(for token: Int32) -> String {
+        guard let vocab else { return "" }
+        var buf = [CChar](repeating: 0, count: 64)
+        var n = llama_token_to_piece(vocab, token, &buf, Int32(buf.count), 0, false)
+        if n < 0 {
+            buf = [CChar](repeating: 0, count: Int(-n))
+            n = llama_token_to_piece(vocab, token, &buf, Int32(buf.count), 0, false)
+        }
+        guard n > 0 else { return "" }
+        let bytes = buf.prefix(Int(n)).map { UInt8(bitPattern: $0) }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+
+    // MARK: - Decode
+
+    /// Decodes `tokens` starting at `startPos` in sequence 0. When
+    /// `logitsLastOnly` is true only the final token requests logits (prefill).
+    @discardableResult
+    private func decode(_ tokens: [Int32], startPos: Int32, logitsLastOnly: Bool) -> Bool {
+        guard let ctx, !tokens.isEmpty else { return true }
+        var batch = llama_batch_init(Int32(tokens.count), 0, 1)
+        defer { llama_batch_free(batch) }
+        for i in 0..<tokens.count {
+            batch.token[i] = tokens[i]
+            batch.pos[i] = startPos + Int32(i)
+            batch.n_seq_id[i] = 1
+            batch.seq_id[i]![0] = 0
+            batch.logits[i] = (logitsLastOnly ? (i == tokens.count - 1) : true) ? 1 : 0
+        }
+        batch.n_tokens = Int32(tokens.count)
+        return llama_decode(ctx, batch) == 0
+    }
+
+    // MARK: - Generate
+
+    func generate(
+        promptTokens: [Int32],
+        maxTokens: Int,
+        samplerSpecs: [LlamaSamplerSpec],
+        onToken: @Sendable (String) -> Bool
+    ) -> String {
+        guard let ctx, let vocab, !promptTokens.isEmpty else { return "" }
+        guard let sampler = makeSampler(samplerSpecs) else { return "" }
+        defer { llama_sampler_free(sampler) }
+
+        let mem = llama_get_memory(ctx)
+        // KV-reuse probe: how many leading tokens this prompt shares with the one
+        // resident in the cache. The bundled Qwen3.5 is a hybrid SSM/attention
+        // model whose recurrent state cannot be partially rewound, so we cannot
+        // physically keep only the shared prefix; we rebuild the full prompt each
+        // call. `lastPrefillTokenCount` still reports the *new* (diverged-suffix)
+        // tokens, which is the meaningful KV-reuse signal for callers.
+        let reuse = IncrementalPrefill.commonPrefixLength(cachedTokens, promptTokens)
+        lastPrefillTokenCount = promptTokens.count - reuse
+
+        // Recurrent state has no per-position cells to evict, so reset and
+        // prefill the whole prompt from position 0 for a clean, contiguous state.
+        llama_memory_seq_rm(mem, 0, 0, -1)
+        guard decode(promptTokens, startPos: 0, logitsLastOnly: true) else { return "" }
+        cachedTokens = promptTokens
+
+        var output = ""
+        var pos = Int32(promptTokens.count)
+        for _ in 0..<maxTokens {
+            let tok = llama_sampler_sample(sampler, ctx, -1)
+            if llama_vocab_is_eog(vocab, tok) { break }
+            llama_sampler_accept(sampler, tok)
+            let text = piece(for: tok)
+            output += text
+            if !onToken(text) { break }
+            guard decode([tok], startPos: pos, logitsLastOnly: true) else { break }
+            pos += 1
+        }
+        return output
+    }
+
+    private func makeSampler(_ specs: [LlamaSamplerSpec]) -> UnsafeMutablePointer<llama_sampler>? {
+        let params = llama_sampler_chain_default_params()
+        guard let chain = llama_sampler_chain_init(params) else { return nil }
+        for spec in specs {
+            let s: UnsafeMutablePointer<llama_sampler>?
+            switch spec {
+            case let .penalties(lastN, rep, freq, present):
+                s = llama_sampler_init_penalties(lastN, rep, freq, present)
+            case let .topK(k):            s = llama_sampler_init_top_k(k)
+            case let .topP(p, minKeep):   s = llama_sampler_init_top_p(p, minKeep)
+            case let .minP(p, minKeep):   s = llama_sampler_init_min_p(p, minKeep)
+            case let .temp(t):            s = llama_sampler_init_temp(t)
+            case let .dist(seed):         s = llama_sampler_init_dist(seed)
+            }
+            if let s { llama_sampler_chain_add(chain, s) }
+        }
+        return chain
+    }
+}

--- a/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
+++ b/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
@@ -199,11 +199,15 @@ actor LlamaCotypingRuntime {
             // suffix is re-decoded. seq_rm dropped [reuse, end) — the diverged tail
             // plus any stale tokens the previous generation appended past the prompt.
             //
-            // Safe because cotyping prompts are capped (~150 words, well under the
-            // production Gemma4 model's 512-token sliding window), so the kept prefix
-            // [0, reuse) is still resident. seq_rm returns false if the partial removal
-            // can't be honored (e.g. positions aged out of the SWA window on a longer
-            // prompt); we then fall through to the full re-prefill below.
+            // Cotyping prompts are NOT guaranteed to stay inside the production
+            // Gemma4 model's 512-token sliding window: worst case is ~850–1100
+            // tokens (a 150-word prefix + the ~900-char preface + up to 2500 prefix
+            // chars). The load-bearing guard is the `llama_memory_seq_rm` return
+            // value below: it returns false when the partial removal can't be
+            // honored (e.g. the kept prefix [0, reuse) aged out of the SWA window on
+            // a long prompt), and we then fall through to the full re-prefill in the
+            // `else` branch. DO NOT remove that fallback — partial reuse is only
+            // safe when seq_rm confirms the kept prefix is still resident.
             guard decode(Array(promptTokens[reuse...]), startPos: Int32(reuse),
                          logitsLastOnly: true) else { return "" }
         } else {

--- a/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
+++ b/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
@@ -12,11 +12,13 @@ enum LlamaRuntimeError: Error, Equatable {
 /// (off the main actor).
 ///
 /// The KV-reuse probe (`IncrementalPrefill`) reports how much of each prompt
-/// overlaps the previous one. The bundled Qwen3.5 is a hybrid SSM/attention
-/// model whose recurrent state cannot be partially rewound to a prefix, so the
-/// prompt is re-prefilled in full on every call; `lastPrefillTokenCount` still
-/// surfaces the diverged-suffix length as the meaningful reuse signal. On a
-/// pure-attention model the same probe would drive true partial-prefix reuse.
+/// overlaps the previous one. On a pure-attention model this drives true
+/// partial-prefix reuse: the shared prefix KV is kept and only the diverged
+/// suffix is re-decoded. The bundled Qwen3.5 is a hybrid SSM/attention model
+/// whose recurrent state cannot be partially rewound to a prefix, so it falls
+/// back to a full re-prefill on every call; `lastPrefillTokenCount` still
+/// surfaces the diverged-suffix length as the meaningful reuse signal either
+/// way. The capability is cached once at load (`supportsPartialReuse`).
 ///
 /// Pinned to llama.cpp `b9789`; symbols verified against the vendored dylib.
 actor LlamaCotypingRuntime {
@@ -28,6 +30,10 @@ actor LlamaCotypingRuntime {
     /// incremental KV-reuse probe against the next prompt).
     private var cachedTokens: [Int32] = []
     private(set) var lastPrefillTokenCount: Int = 0
+    /// True only for pure-attention models, whose per-position KV cells can be
+    /// partially evicted (`seq_rm` at a non-zero p0). Recurrent/hybrid (SSM/Mamba)
+    /// models cannot rewind their rolling state to a prefix, so they full-reprefill.
+    private var supportsPartialReuse = false
 
     private static var backendReady = false
 
@@ -67,6 +73,9 @@ actor LlamaCotypingRuntime {
         loadedModelPath = modelPath
         cachedTokens = []
         lastPrefillTokenCount = 0
+        // Cache the architecture capability once, at load: probing inside generate
+        // would emit a dylib stderr warning on every call for recurrent models.
+        supportsPartialReuse = !llama_model_is_recurrent(m) && !llama_model_is_hybrid(m)
         warmup()
     }
 
@@ -89,6 +98,7 @@ actor LlamaCotypingRuntime {
         vocab = nil
         loadedModelPath = nil
         cachedTokens = []
+        supportsPartialReuse = false
     }
 
     /// Runs one priming decode so Metal pipelines are hot before the first real
@@ -165,19 +175,30 @@ actor LlamaCotypingRuntime {
         defer { llama_sampler_free(sampler) }
 
         let mem = llama_get_memory(ctx)
-        // KV-reuse probe: how many leading tokens this prompt shares with the one
-        // resident in the cache. The bundled Qwen3.5 is a hybrid SSM/attention
-        // model whose recurrent state cannot be partially rewound, so we cannot
-        // physically keep only the shared prefix; we rebuild the full prompt each
-        // call. `lastPrefillTokenCount` still reports the *new* (diverged-suffix)
-        // tokens, which is the meaningful KV-reuse signal for callers.
-        let reuse = IncrementalPrefill.commonPrefixLength(cachedTokens, promptTokens)
-        lastPrefillTokenCount = promptTokens.count - reuse
 
-        // Recurrent state has no per-position cells to evict, so reset and
-        // prefill the whole prompt from position 0 for a clean, contiguous state.
-        llama_memory_seq_rm(mem, 0, 0, -1)
-        guard decode(promptTokens, startPos: 0, logitsLastOnly: true) else { return "" }
+        // KV-reuse probe: how many leading tokens this prompt shares with the cache.
+        // Clamp to count-1 so we ALWAYS decode >=1 token and get fresh logits for the
+        // next-token sample — required when the new prompt equals/prefixes the cached
+        // one (e.g. an identical re-generation), else we'd sample from stale logits.
+        let shared = IncrementalPrefill.commonPrefixLength(cachedTokens, promptTokens)
+        let reuse = min(shared, promptTokens.count - 1)
+
+        if supportsPartialReuse, reuse > 0 {
+            // Attention model: keep the shared prefix KV, re-decode only the suffix.
+            // seq_rm drops [reuse, end) — the diverged tail plus any stale tokens the
+            // previous generation appended past the prompt.
+            llama_memory_seq_rm(mem, 0, Int32(reuse), -1)
+            guard decode(Array(promptTokens[reuse...]), startPos: Int32(reuse),
+                         logitsLastOnly: true) else { return "" }
+        } else {
+            // Recurrent/hybrid model (SSM/Mamba) cannot partially rewind its rolling
+            // state, so a non-zero-p0 seq_rm is unsupported — reset and prefill the
+            // whole prompt from position 0. `reuse` above is still the meaningful
+            // KV-reuse *signal* callers read via lastPrefillTokenCount.
+            llama_memory_seq_rm(mem, 0, 0, -1)
+            guard decode(promptTokens, startPos: 0, logitsLastOnly: true) else { return "" }
+        }
+        lastPrefillTokenCount = promptTokens.count - reuse
         cachedTokens = promptTokens
 
         var output = ""

--- a/LokalBot/Cotyping/Llama/LlamaSamplerSpec.swift
+++ b/LokalBot/Cotyping/Llama/LlamaSamplerSpec.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Value-typed description of the llama.cpp sampler chain, in apply order.
+/// Pure so the config→chain mapping is unit-testable without libllama; the
+/// runtime turns each case into the matching `llama_sampler_init_*` call.
+///
+/// Order mirrors llama.cpp's `common` default for this subset:
+/// penalties → top_k → top_p → min_p → temp → dist (final distribution sampler).
+enum LlamaSamplerSpec: Equatable {
+    case penalties(lastN: Int32, repeat: Float, freq: Float, present: Float)
+    case topK(Int32)
+    case topP(Float, minKeep: Int)
+    case minP(Float, minKeep: Int)
+    case temp(Float)
+    case dist(seed: UInt32)
+
+    static func specs(
+        temperature: Float,
+        topK: Int32,
+        topP: Float,
+        minP: Float,
+        repeatPenalty: Float,
+        repeatLastN: Int32,
+        seed: UInt32
+    ) -> [LlamaSamplerSpec] {
+        [
+            .penalties(lastN: repeatLastN, repeat: repeatPenalty, freq: 0, present: 0),
+            .topK(topK),
+            .topP(topP, minKeep: 1),
+            .minP(minP, minKeep: 1),
+            .temp(temperature),
+            .dist(seed: seed),
+        ]
+    }
+
+    static func specs(from config: CotypingConfiguration) -> [LlamaSamplerSpec] {
+        specs(
+            temperature: Float(config.temperature),
+            topK: Int32(config.topK),
+            topP: Float(config.topP),
+            minP: Float(config.minP),
+            repeatPenalty: Float(config.repeatPenalty),
+            repeatLastN: 64,
+            seed: UInt32(truncatingIfNeeded: config.seed))
+    }
+}

--- a/LokalBot/Cotyping/Llama/LocalLlamaCotypingEngine.swift
+++ b/LokalBot/Cotyping/Llama/LocalLlamaCotypingEngine.swift
@@ -31,6 +31,11 @@ final class LocalLlamaCotypingEngine: CotypingCompleting {
         try await runtime.prewarm(modelPath: modelPath)
     }
 
+    /// Frees the in-process model + context. Called when the selector routes
+    /// away from local (flag toggled off, or the model stops resolving) so the
+    /// ~6.66 GB of weights don't stay resident while completions go to HTTP.
+    func unload() async { await runtime.unload() }
+
     func generate(_ request: CotypingRequest) async throws -> CotypingNormalizationResult {
         try await run(request) { _ in }
     }
@@ -62,7 +67,11 @@ final class LocalLlamaCotypingEngine: CotypingCompleting {
             seed: UInt32(truncatingIfNeeded: request.seed))
 
         let accumulator = TokenAccumulator()
-        let raw = await runtime.generate(
+        // `try` (not silent `await`): a thrown LlamaRuntimeError.decodeFailed
+        // propagates out of run() → the selector's `catch let error as
+        // LlamaRuntimeError`, so a decode failure reaches the HTTP fallback
+        // instead of surfacing a silent empty/truncated ghost.
+        let raw = try await runtime.generate(
             promptTokens: promptTokens,
             maxTokens: request.maxTokens,
             samplerSpecs: specs

--- a/LokalBot/Cotyping/Llama/LocalLlamaCotypingEngine.swift
+++ b/LokalBot/Cotyping/Llama/LocalLlamaCotypingEngine.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// In-process `CotypingCompleting` conformer. Tokenizes the already-built
+/// prompt, drives `LlamaCotypingRuntime`, and reuses the EXACT same
+/// normalization + decode-stop policy as the HTTP engine so suggestions are
+/// shaped identically. Stops on the stop policy, the token budget, or task
+/// cancellation (superseded keystroke).
+@MainActor
+final class LocalLlamaCotypingEngine: CotypingCompleting {
+    private let runtime: LlamaCotypingRuntime
+    private let modelPath: String
+
+    init(runtime: LlamaCotypingRuntime, modelPath: String) {
+        self.runtime = runtime
+        self.modelPath = modelPath
+    }
+
+    /// Loads + primes the model so the first keystroke isn't cold.
+    func prewarm() async throws {
+        try await runtime.prewarm(modelPath: modelPath)
+    }
+
+    func generate(_ request: CotypingRequest) async throws -> CotypingNormalizationResult {
+        try await run(request) { _ in }
+    }
+
+    func generateStreaming(
+        _ request: CotypingRequest,
+        onPartial: @escaping @Sendable (CotypingNormalizationResult) -> Void
+    ) async throws -> CotypingNormalizationResult {
+        try await run(request, onPartial: onPartial)
+    }
+
+    private func run(
+        _ request: CotypingRequest,
+        onPartial: @escaping @Sendable (CotypingNormalizationResult) -> Void
+    ) async throws -> CotypingNormalizationResult {
+        try await runtime.loadIfNeeded(modelPath: modelPath)
+        let promptTokens = await runtime.tokenize(request.prompt, addBOS: true)
+        guard !promptTokens.isEmpty else {
+            return CotypingNormalizationResult(text: "", suppression: .emptyGeneration)
+        }
+
+        let specs = LlamaSamplerSpec.specs(
+            temperature: Float(request.temperature),
+            topK: Int32(request.topK),
+            topP: Float(request.topP),
+            minP: Float(request.minP),
+            repeatPenalty: Float(request.repeatPenalty),
+            repeatLastN: 64,
+            seed: UInt32(truncatingIfNeeded: request.seed))
+
+        let accumulator = TokenAccumulator()
+        let raw = await runtime.generate(
+            promptTokens: promptTokens,
+            maxTokens: request.maxTokens,
+            samplerSpecs: specs
+        ) { piece in
+            if Task.isCancelled { return false }
+            accumulator.append(piece)
+            let result = CotypingTextNormalizer.normalizeDetailed(accumulator.raw, for: request)
+            onPartial(result)
+            // Native decode-stop at the SAME boundary the HTTP path stops at.
+            if CotypingDecodeStopPolicy.verdict(
+                accumulated: accumulator.raw,
+                tokensGenerated: accumulator.count) != nil {
+                return false
+            }
+            return true
+        }
+
+        if Task.isCancelled { throw CancellationError() }
+        return CotypingTextNormalizer.normalizeDetailed(raw, for: request)
+    }
+}
+
+/// Reference-typed accumulator the decode closure mutates across token calls.
+/// The runtime invokes `onToken` serially on one thread, so no synchronization
+/// is required; marked `@unchecked Sendable` only to cross the actor boundary.
+private final class TokenAccumulator: @unchecked Sendable {
+    private(set) var raw = ""
+    private(set) var count = 0
+    func append(_ piece: String) { raw += piece; count += 1 }
+}

--- a/LokalBot/Cotyping/Llama/LocalLlamaCotypingEngine.swift
+++ b/LokalBot/Cotyping/Llama/LocalLlamaCotypingEngine.swift
@@ -9,11 +9,22 @@ import Foundation
 final class LocalLlamaCotypingEngine: CotypingCompleting {
     private let runtime: LlamaCotypingRuntime
     private let modelPath: String
+    private var memoryPressureSource: DispatchSourceMemoryPressure?
 
     init(runtime: LlamaCotypingRuntime, modelPath: String) {
         self.runtime = runtime
         self.modelPath = modelPath
+
+        let source = DispatchSource.makeMemoryPressureSource(
+            eventMask: [.warning, .critical], queue: .global(qos: .utility))
+        source.setEventHandler { [runtime] in
+            Task { await runtime.handleMemoryPressure() }
+        }
+        source.resume()
+        self.memoryPressureSource = source
     }
+
+    deinit { memoryPressureSource?.cancel() }
 
     /// Loads + primes the model so the first keystroke isn't cold.
     func prewarm() async throws {

--- a/LokalBot/Engines/ModelCatalog.swift
+++ b/LokalBot/Engines/ModelCatalog.swift
@@ -103,40 +103,8 @@ struct ModelCatalog {
         }
         let downloaded = storage.rootURL.appendingPathComponent("models/\(entry.fileName)")
         if ModelFileValidator.looksLikeGGUF(downloaded) { return downloaded }
-        if entry.id == recommendedCotypingID, let cotypist = cotypistModelURL() {
-            return cotypist
-        }
         return nil
     }
-
-    /// Cotypist stores the same Q5 XL GGUF under Application Support. When it is
-    /// already present, use it read-only instead of forcing another 6+ GB fetch.
-    /// This is best-effort cross-app reuse: if Cotypist changes its bundle id or
-    /// model layout, validation fails closed and LokalBot falls back to its own
-    /// download path.
-    static func cotypistModelURL(fileManager: FileManager = .default) -> URL? {
-        guard let appSupport = fileManager.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first else { return nil }
-        return cotypistModelURL(appSupport: appSupport)
-    }
-
-    static func cotypistModelURL(appSupport: URL) -> URL? {
-        let models = appSupport
-            .appendingPathComponent("app.cotypist.Cotypist", isDirectory: true)
-            .appendingPathComponent("Models", isDirectory: true)
-        for fileName in cotypistParityFileNames {
-            let url = models.appendingPathComponent(fileName)
-            if ModelFileValidator.looksLikeGGUF(url) { return url }
-        }
-        return nil
-    }
-
-    private static let cotypistParityFileNames = [
-        "gemma-4-E4B-it-UD-Q5_K_XL.gguf",
-        "gemma-4-E4B-UD-Q5_K_XL.gguf",
-    ]
 }
 
 enum ModelFileValidator {

--- a/LokalBot/LokalBotApp.swift
+++ b/LokalBot/LokalBotApp.swift
@@ -385,7 +385,10 @@ final class AppState: ObservableObject {
             detector.stopDebounce = settings.stopDebounceSeconds
             detector.calendarEnabled = settings.calendarDetectionEnabled
             detector.requireCalendarForBrowser = settings.requireCalendarForBrowser
-            if interactive { cotyping.applySettings() }
+            if interactive {
+                cotyping.applySettings()
+                if settings.cotypingEnabled { Task { await cotypingEngine.prewarm() } }
+            }
         }
     }
 
@@ -427,12 +430,18 @@ final class AppState: ObservableObject {
     /// Cotyping (inline AI autocomplete). Always runs its own model on the
     /// dedicated `LlamaServer.cotyping` instance so it never thrashes the
     /// shared summarizer server. Resolved per-completion, so changes apply live.
-    private(set) lazy var cotypingEngine = CotypingEngine(makeEngine: { [weak self] in
-        guard let self else { throw TextEngineError.unavailable("LokalBot is shutting down.") }
-        return try await self.pipeline.makeTextEngine(
-            self.settings.cotypingTextEngineSettings,
-            server: .cotyping)
-    })
+    private(set) lazy var cotypingEngine = CotypingEngineSelector(
+        http: CotypingEngine(makeEngine: { [weak self] in
+            guard let self else { throw TextEngineError.unavailable("LokalBot is shutting down.") }
+            return try await self.pipeline.makeTextEngine(
+                self.settings.cotypingTextEngineSettings,
+                server: .cotyping)
+        }),
+        makeLocal: { modelPath in
+            LocalLlamaCotypingEngine(runtime: LlamaCotypingRuntime(), modelPath: modelPath)
+        },
+        settings: { [weak self] in self?.settings ?? AppSettings() },
+        storage: storage)
     private(set) lazy var cotyping = CotypingCoordinator(
         engine: cotypingEngine,
         settingsProvider: { [weak self] in self?.settings ?? AppSettings() },
@@ -618,6 +627,7 @@ final class AppState: ObservableObject {
         // Bring cotyping up if the user left it enabled and the grants are in
         // place; otherwise it parks itself (no taps installed).
         cotyping.applySettings()
+        if settings.cotypingEnabled { Task { await cotypingEngine.prewarm() } }
     }
 
     // MARK: - Recording control

--- a/LokalBot/LokalBotApp.swift
+++ b/LokalBot/LokalBotApp.swift
@@ -424,15 +424,14 @@ final class AppState: ObservableObject {
     private(set) lazy var pipeline = ProcessingPipeline(storage: storage) { [weak self] in
         self?.settings ?? AppSettings()
     }
-    /// Cotyping (inline AI autocomplete). By default it reuses the summarizer's
-    /// `TextEngine`; when a separate cotyping model is enabled it runs on the
+    /// Cotyping (inline AI autocomplete). Always runs its own model on the
     /// dedicated `LlamaServer.cotyping` instance so it never thrashes the
-    /// shared server. Resolved per-completion, so changes apply live.
+    /// shared summarizer server. Resolved per-completion, so changes apply live.
     private(set) lazy var cotypingEngine = CotypingEngine(makeEngine: { [weak self] in
         guard let self else { throw TextEngineError.unavailable("LokalBot is shutting down.") }
         return try await self.pipeline.makeTextEngine(
             self.settings.cotypingTextEngineSettings,
-            server: self.settings.cotypingUseSeparateModel ? .cotyping : .shared)
+            server: .cotyping)
     })
     private(set) lazy var cotyping = CotypingCoordinator(
         engine: cotypingEngine,

--- a/LokalBot/Models/AppSettings.swift
+++ b/LokalBot/Models/AppSettings.swift
@@ -156,13 +156,10 @@ struct AppSettings: Codable {
     var cotypingLanguages: String = ""
     /// Free-form notes / glossary / jargon folded into the prompt as context.
     var cotypingExtendedContext: String = ""
-    /// Use a model for cotyping that differs from the summarization model. Off
-    /// by default — cotyping reuses the summarization engine. When on, a
-    /// dedicated built-in (llama.cpp) model runs on its own server instance, so
-    /// a smaller/faster model can power inline suggestions without contending
-    /// with summarization for the shared server.
-    var cotypingUseSeparateModel: Bool = false
-    /// Built-in catalog model id used for cotyping when the toggle is on.
+    /// Built-in catalog model id for cotyping. Cotyping always runs its own
+    /// dedicated built-in (llama.cpp) model on a separate server instance, so
+    /// inline suggestions never contend with summarization for the shared
+    /// server. Defaults to the recommended Cotypist-parity model.
     var cotypingBuiltInModelID: String = ModelCatalog.recommendedCotypingID
     /// Learn from accepted continuation text, encrypted locally. Stores accepted
     /// text plus a short sanitized prefix/context hint for ranking — never full
@@ -206,12 +203,10 @@ struct AppSettings: Codable {
         return cotypingMultiLine ? min(base * 2, 120) : min(base, 120)
     }
 
-    /// Settings the cotyping engine builds its `TextEngine` from. With a
-    /// separate cotyping model enabled, this is a copy pinned to the built-in
-    /// backend with `cotypingBuiltInModelID`; otherwise it is `self` (cotyping
-    /// reuses whatever the summarizer uses).
+    /// Settings the cotyping engine builds its `TextEngine` from. Cotyping always
+    /// runs its own model, so this is a copy pinned to the built-in backend with
+    /// `cotypingBuiltInModelID` (independent of the summarizer's backend/model).
     var cotypingTextEngineSettings: AppSettings {
-        guard cotypingUseSeparateModel else { return self }
         var s = self
         s.summarizerBackend = .builtIn
         s.builtInModelID = cotypingBuiltInModelID
@@ -283,7 +278,6 @@ struct AppSettings: Codable {
         case cotypingMacros
         case cotypingLanguages
         case cotypingExtendedContext
-        case cotypingUseSeparateModel
         case cotypingBuiltInModelID
         case cotypingUseLocalLearning
         case cotypingLearningExamplesInPrompt
@@ -357,7 +351,6 @@ struct AppSettings: Codable {
         try c.encode(cotypingMacros, forKey: .cotypingMacros)
         try c.encode(cotypingLanguages, forKey: .cotypingLanguages)
         try c.encode(cotypingExtendedContext, forKey: .cotypingExtendedContext)
-        try c.encode(cotypingUseSeparateModel, forKey: .cotypingUseSeparateModel)
         try c.encode(cotypingBuiltInModelID, forKey: .cotypingBuiltInModelID)
         try c.encode(cotypingUseLocalLearning, forKey: .cotypingUseLocalLearning)
         try c.encode(cotypingLearningExamplesInPrompt, forKey: .cotypingLearningExamplesInPrompt)
@@ -420,7 +413,6 @@ struct AppSettings: Codable {
         cotypingMacros = (try? c.decode(Bool.self, forKey: .cotypingMacros)) ?? defaults.cotypingMacros
         cotypingLanguages = (try? c.decode(String.self, forKey: .cotypingLanguages)) ?? defaults.cotypingLanguages
         cotypingExtendedContext = (try? c.decode(String.self, forKey: .cotypingExtendedContext)) ?? defaults.cotypingExtendedContext
-        cotypingUseSeparateModel = (try? c.decode(Bool.self, forKey: .cotypingUseSeparateModel)) ?? defaults.cotypingUseSeparateModel
         cotypingBuiltInModelID = (try? c.decode(String.self, forKey: .cotypingBuiltInModelID)) ?? defaults.cotypingBuiltInModelID
         cotypingUseLocalLearning = (try? c.decode(Bool.self, forKey: .cotypingUseLocalLearning)) ?? defaults.cotypingUseLocalLearning
         let learnedCount = (try? c.decode(Int.self, forKey: .cotypingLearningExamplesInPrompt)) ?? defaults.cotypingLearningExamplesInPrompt

--- a/LokalBot/Models/AppSettings.swift
+++ b/LokalBot/Models/AppSettings.swift
@@ -161,6 +161,11 @@ struct AppSettings: Codable {
     /// inline suggestions never contend with summarization for the shared
     /// server. Defaults to the recommended Cotypist-parity model.
     var cotypingBuiltInModelID: String = ModelCatalog.recommendedCotypingID
+    /// When true (default), cotyping uses the in-process `libllama` runtime for
+    /// the built-in GGUF backend on Apple Silicon; false forces the HTTP
+    /// `llama-server` path. The HTTP fallback also covers non-GGUF backends and
+    /// any in-process load failure regardless of this flag.
+    var cotypingInProcessRuntime: Bool = true
     /// Learn from accepted continuation text, encrypted locally. Stores accepted
     /// text plus a short sanitized prefix/context hint for ranking — never full
     /// raw typing streams — and skips secure fields, terminals, and code editors.
@@ -279,6 +284,7 @@ struct AppSettings: Codable {
         case cotypingLanguages
         case cotypingExtendedContext
         case cotypingBuiltInModelID
+        case cotypingInProcessRuntime
         case cotypingUseLocalLearning
         case cotypingLearningExamplesInPrompt
     }
@@ -352,6 +358,7 @@ struct AppSettings: Codable {
         try c.encode(cotypingLanguages, forKey: .cotypingLanguages)
         try c.encode(cotypingExtendedContext, forKey: .cotypingExtendedContext)
         try c.encode(cotypingBuiltInModelID, forKey: .cotypingBuiltInModelID)
+        try c.encode(cotypingInProcessRuntime, forKey: .cotypingInProcessRuntime)
         try c.encode(cotypingUseLocalLearning, forKey: .cotypingUseLocalLearning)
         try c.encode(cotypingLearningExamplesInPrompt, forKey: .cotypingLearningExamplesInPrompt)
     }
@@ -414,6 +421,7 @@ struct AppSettings: Codable {
         cotypingLanguages = (try? c.decode(String.self, forKey: .cotypingLanguages)) ?? defaults.cotypingLanguages
         cotypingExtendedContext = (try? c.decode(String.self, forKey: .cotypingExtendedContext)) ?? defaults.cotypingExtendedContext
         cotypingBuiltInModelID = (try? c.decode(String.self, forKey: .cotypingBuiltInModelID)) ?? defaults.cotypingBuiltInModelID
+        cotypingInProcessRuntime = (try? c.decode(Bool.self, forKey: .cotypingInProcessRuntime)) ?? defaults.cotypingInProcessRuntime
         cotypingUseLocalLearning = (try? c.decode(Bool.self, forKey: .cotypingUseLocalLearning)) ?? defaults.cotypingUseLocalLearning
         let learnedCount = (try? c.decode(Int.self, forKey: .cotypingLearningExamplesInPrompt)) ?? defaults.cotypingLearningExamplesInPrompt
         cotypingLearningExamplesInPrompt = min(5, max(1, learnedCount))

--- a/LokalBot/Views/CotypingView.swift
+++ b/LokalBot/Views/CotypingView.swift
@@ -137,30 +137,14 @@ private struct CotypingContent: View {
     }
 
     private var engineDescription: String {
-        if app.settings.cotypingUseSeparateModel {
-            let entry = ModelCatalog.entry(
-                id: app.settings.cotypingBuiltInModelID,
-                custom: app.settings.customBuiltInModels)
-            return "Dedicated — \(entry?.displayName ?? "built-in model")"
-        }
-        switch app.settings.summarizerBackend {
-        case .builtIn:
-            return ModelCatalog.entry(id: app.settings.builtInModelID,
-                                      custom: app.settings.customBuiltInModels)?.displayName
-                ?? "Built-in model"
-        case .appleIntelligence: return "Apple Intelligence"
-        case .ollama:
-            return "Ollama — " + (app.settings.ollamaModel.isEmpty ? "no model selected" : app.settings.ollamaModel)
-        case .openAICompatible:
-            return "OpenAI-compatible — " + (app.settings.openAIModel.isEmpty ? "no model selected" : app.settings.openAIModel)
-        }
+        let entry = ModelCatalog.entry(
+            id: app.settings.cotypingBuiltInModelID,
+            custom: app.settings.customBuiltInModels)
+        return "Dedicated — \(entry?.displayName ?? "built-in model")"
     }
 
     private var modelDetail: String {
-        if app.settings.cotypingUseSeparateModel {
-            return "Cotyping runs on its own llama.cpp server, separate from summarization. Gemma 4 E4B Q5 XL is the recommended quality target."
-        }
-        return "Cotyping reuses your Summarization backend and model. Turn on the dedicated model in Settings → Cotyping or Models for higher-quality inline suggestions."
+        "Cotyping runs on its own llama.cpp server, separate from summarization. Gemma 4 E4B Q5 XL is the recommended quality target."
     }
 
     // MARK: Preview

--- a/LokalBot/Views/ModelsView.swift
+++ b/LokalBot/Views/ModelsView.swift
@@ -153,21 +153,15 @@ struct ModelsView: View {
     private var cotypingCard: some View {
         ModelCard(icon: "text.cursor", title: "Cotyping",
                   subtitle: "Inline AI autocomplete as you type") {
-            Toggle("Use a separate model for cotyping", isOn: $app.settings.cotypingUseSeparateModel)
             CotypingModelPreparationView(compact: true)
-            if app.settings.cotypingUseSeparateModel {
-                Picker("Cotyping model", selection: $app.settings.cotypingBuiltInModelID) {
-                    ForEach(ModelCatalog.selectableEntries(custom: app.settings.customBuiltInModels)) { entry in
-                        Text(entry.displayName).tag(entry.id)
-                    }
+            Picker("Cotyping model", selection: $app.settings.cotypingBuiltInModelID) {
+                ForEach(ModelCatalog.selectableEntries(custom: app.settings.customBuiltInModels)) { entry in
+                    Text(entry.displayName).tag(entry.id)
                 }
-                .frame(maxWidth: 360)
-                Text("Runs on a dedicated built-in llama.cpp server, separate from summarization. Gemma 4 E4B Q5 XL is the recommended quality target; Qwen3.5 2B and LFM2.5 1.2B are smaller latency options.")
-                    .font(.caption).foregroundStyle(.secondary)
-            } else {
-                Text("Cotyping uses your summarization model. Turn this on to run a separate model tuned for inline suggestion quality.")
-                    .font(.caption).foregroundStyle(.secondary)
             }
+            .frame(maxWidth: 360)
+            Text("Cotyping runs on a dedicated built-in llama.cpp server, separate from summarization. Gemma 4 E4B Q5 XL is the recommended quality target; Qwen3.5 2B and LFM2.5 1.2B are smaller latency options.")
+                .font(.caption).foregroundStyle(.secondary)
         }
         .accessibilityIdentifier("models.cotyping")
     }

--- a/LokalBot/Views/SettingsView.swift
+++ b/LokalBot/Views/SettingsView.swift
@@ -176,7 +176,8 @@ struct SettingsView: View {
                         Text("When off, suggestions appear once fully formed, matching Cotypist's default. Turn on to show token-by-token partials sooner.")
                             .font(.caption).foregroundStyle(.secondary)
                         Toggle("Use the fast in-process runtime (recommended)", isOn: $app.settings.cotypingInProcessRuntime)
-                        Text("Decodes the built-in model in-process for lower latency. Turn off to use the background llama-server. Non-built-in backends always use the server.")
+                            .disabled(!CotypingEngineSelector.isAppleSilicon)
+                        Text("Decodes the built-in model in-process for lower latency. Turn off to use the background llama-server. Non-built-in backends always use the server. Requires Apple Silicon.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         LabeledContent("Pause before suggesting") {

--- a/LokalBot/Views/SettingsView.swift
+++ b/LokalBot/Views/SettingsView.swift
@@ -127,17 +127,14 @@ struct SettingsView: View {
                 // answers a user wants first, before any behavior tuning.
                 if app.settings.cotypingEnabled, shows("Cotyping", ["model", "stats", "generated", "accepted", "latency"]) {
                     Section("Model & activity") {
-                        Toggle("Use a dedicated high-quality cotyping model", isOn: $app.settings.cotypingUseSeparateModel)
                         CotypingModelPreparationView(compact: true)
-                        if app.settings.cotypingUseSeparateModel {
-                            Picker("Cotyping model", selection: $app.settings.cotypingBuiltInModelID) {
-                                ForEach(ModelCatalog.selectableEntries(custom: app.settings.customBuiltInModels)) { entry in
-                                    Text(entry.displayName).tag(entry.id)
-                                }
+                        Picker("Cotyping model", selection: $app.settings.cotypingBuiltInModelID) {
+                            ForEach(ModelCatalog.selectableEntries(custom: app.settings.customBuiltInModels)) { entry in
+                                Text(entry.displayName).tag(entry.id)
                             }
-                            Text("Gemma 4 E4B Q5 XL is the recommended quality target; Qwen3.5 2B and LFM2.5 1.2B are smaller latency options.")
-                                .font(.caption).foregroundStyle(.secondary)
                         }
+                        Text("Cotyping runs its own dedicated model. Gemma 4 E4B Q5 XL is the recommended quality target; Qwen3.5 2B and LFM2.5 1.2B are smaller latency options.")
+                            .font(.caption).foregroundStyle(.secondary)
                         LabeledContent("Suggestions generated") {
                             Text("\(cotypingStats.stats.generations)").foregroundStyle(.secondary)
                         }

--- a/LokalBot/Views/SettingsView.swift
+++ b/LokalBot/Views/SettingsView.swift
@@ -175,6 +175,10 @@ struct SettingsView: View {
                         Toggle("Stream suggestions while generating", isOn: $app.settings.cotypingStreamSuggestionsWhileGenerating)
                         Text("When off, suggestions appear once fully formed, matching Cotypist's default. Turn on to show token-by-token partials sooner.")
                             .font(.caption).foregroundStyle(.secondary)
+                        Toggle("Use the fast in-process runtime (recommended)", isOn: $app.settings.cotypingInProcessRuntime)
+                        Text("Decodes the built-in model in-process for lower latency. Turn off to use the background llama-server. Non-built-in backends always use the server.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                         LabeledContent("Pause before suggesting") {
                             Text("\(app.settings.cotypingDebounceMs) ms").foregroundStyle(.secondary)
                         }

--- a/LokalBotTests/CotypingABBenchmarkTests.swift
+++ b/LokalBotTests/CotypingABBenchmarkTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import LokalBot
+
+final class CotypingABBenchmarkTests: XCTestCase {
+    private func summary(latency: Int, ttft: Int) -> CotypingBenchmarkSummary {
+        CotypingBenchmarkSummary(results: [
+            CotypingBenchmarkCaseResult(
+                scenarioID: "s", name: "s", text: "hello", latencyMs: latency,
+                firstVisibleLatencyMs: ttft, expectedTermHits: 0, expectedTermCount: 0,
+                suppression: nil, error: nil, expectedVisibleSuggestion: true,
+                allowedSuppression: false, latencyTargetMs: 2000),
+        ])
+    }
+
+    func testComparisonComputesDeltas() {
+        let comparison = CotypingABComparison(
+            local: summary(latency: 300, ttft: 120),
+            http: summary(latency: 1100, ttft: 600))
+        XCTAssertEqual(comparison.p95DeltaMs, 800)    // http p95 - local p95
+        XCTAssertEqual(comparison.ttftDeltaMs, 480)   // http ttft - local ttft (local is faster)
+    }
+
+    func testComparisonHandlesMissingTTFT() {
+        let comparison = CotypingABComparison(
+            local: summary(latency: 300, ttft: 120),
+            http: CotypingBenchmarkSummary(results: []))
+        XCTAssertNil(comparison.p95DeltaMs)
+        XCTAssertNil(comparison.ttftDeltaMs)
+    }
+}

--- a/LokalBotTests/CotypingEngineSelectorTests.swift
+++ b/LokalBotTests/CotypingEngineSelectorTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import LokalBot
 
+@MainActor
 final class CotypingEngineSelectorTests: XCTestCase {
     private let modelURL = URL(fileURLWithPath: "/models/gemma.gguf")
 
@@ -26,5 +27,182 @@ final class CotypingEngineSelectorTests: XCTestCase {
         var s = AppSettings(); s.cotypingInProcessRuntime = true
         XCTAssertFalse(CotypingEngineSelector.shouldUseLocal(
             settings: s, modelURL: nil, isAppleSilicon: true))
+    }
+
+    // MARK: - Route-away unload (Fix 1) + decode-failure fallback (Fix 2)
+
+    /// FIX 1: when the runtime flag flips OFF the selector must drop its cached
+    /// in-process engine (and unload its model); flipping it back ON rebuilds a
+    /// fresh engine. We prove the cache is dropped by counting `makeLocal` calls
+    /// through the injectable seam: build → drop → rebuild ⇒ exactly two builds.
+    ///
+    /// These selector paths only run on Apple Silicon (`isAppleSilicon`), so the
+    /// test is skipped on Intel where `localIfEligible()` always returns nil.
+    func testRouteAwayDropsCacheAndRebuildOnReenable() throws {
+        try XCTSkipUnless(CotypingEngineSelector.isAppleSilicon,
+                          "Selector routes to local only on Apple Silicon.")
+        let env = try GGUFFixture()
+        defer { env.tearDown() }
+
+        var flagOn = true
+        let http = RecordingHTTPEngine()
+        let counter = BuildCounter()
+        let selector = CotypingEngineSelector(
+            http: http,
+            makeLocal: { _ in counter.bump(); return RecordingHTTPEngine() },
+            settings: {
+                var s = env.settings
+                s.cotypingInProcessRuntime = flagOn
+                return s
+            },
+            storage: env.storage)
+
+        // Flag ON + model resolves → first build, routes local (HTTP untouched).
+        let r1 = makeMinimalRequestExpectingNoServer()
+        _ = try? awaitGenerate(selector, r1)
+        XCTAssertEqual(counter.value, 1, "flag ON should build the local engine once")
+
+        // Flag OFF → ineligible branch calls dropLocalEngine(), routes to HTTP.
+        flagOn = false
+        let httpBefore = http.generateCalls
+        _ = try? awaitGenerate(selector, r1)
+        XCTAssertEqual(http.generateCalls, httpBefore + 1, "flag OFF should route to HTTP")
+        XCTAssertEqual(counter.value, 1, "flag OFF must not build a new local engine")
+
+        // Flag ON again → cache was dropped, so a FRESH engine is rebuilt.
+        flagOn = true
+        _ = try? awaitGenerate(selector, r1)
+        XCTAssertEqual(counter.value, 2,
+                       "re-enabling after route-away must rebuild a fresh local engine")
+    }
+
+    /// FIX 2: a thrown `LlamaRuntimeError.decodeFailed` from the local engine must
+    /// reach the selector's `catch let error as LlamaRuntimeError` and fall back to
+    /// HTTP. Enabled by the `CotypingCompleting` seam on `makeLocal` (a throwing
+    /// fake can now be injected as the local engine).
+    func testDecodeFailureFallsBackToHTTP() throws {
+        try XCTSkipUnless(CotypingEngineSelector.isAppleSilicon,
+                          "Selector routes to local only on Apple Silicon.")
+        let env = try GGUFFixture()
+        defer { env.tearDown() }
+
+        let http = RecordingHTTPEngine()
+        let selector = CotypingEngineSelector(
+            http: http,
+            makeLocal: { _ in ThrowingLocalEngine(error: .decodeFailed) },
+            settings: { env.settings },
+            storage: env.storage)
+
+        let result = try awaitGenerate(selector, makeMinimalRequestExpectingNoServer())
+        XCTAssertEqual(http.generateCalls, 1,
+                       "a thrown LlamaRuntimeError must route the completion to HTTP")
+        XCTAssertEqual(result.text, RecordingHTTPEngine.sentinel,
+                       "the returned result must be the HTTP engine's output")
+    }
+
+    // MARK: - Helpers
+
+    /// Builds a temp StorageManager rooted at a throwaway dir with a GGUF-magic
+    /// file and a matching custom catalog entry, so `resolvedModelURL` resolves
+    /// without a real 6.66 GB model. `looksLikeGGUF` only checks the first 4
+    /// bytes are the ASCII magic "GGUF".
+    private struct GGUFFixture {
+        let storage: StorageManager
+        let settings: AppSettings
+        private let tempRoot: URL
+        private let previousDefault: String?
+
+        init() throws {
+            tempRoot = FileManager.default.temporaryDirectory
+                .appendingPathComponent("lokalbot-selector-\(UUID().uuidString)", isDirectory: true)
+            let modelsDir = tempRoot.appendingPathComponent("models", isDirectory: true)
+            try FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
+
+            let fileName = "selector-fixture.gguf"
+            let modelFile = modelsDir.appendingPathComponent(fileName)
+            try Data("GGUF".utf8).write(to: modelFile)   // magic-only stub; not loaded
+
+            // Point StorageManager at the temp root via the UI-test override hook.
+            previousDefault = UserDefaults.standard.string(forKey: UITestRuntime.storageRootKey)
+            UserDefaults.standard.set(tempRoot.path, forKey: UITestRuntime.storageRootKey)
+            storage = StorageManager()
+
+            let custom = ModelCatalog.Entry(
+                id: "selector-fixture", displayName: "Selector Fixture",
+                fileName: fileName, url: "", sizeGB: 0, blurb: "", disablesThinking: false)
+            var s = AppSettings()
+            s.cotypingInProcessRuntime = true
+            s.customBuiltInModels = [custom]
+            s.cotypingBuiltInModelID = custom.id
+            settings = s
+        }
+
+        func tearDown() {
+            if let previousDefault {
+                UserDefaults.standard.set(previousDefault, forKey: UITestRuntime.storageRootKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UITestRuntime.storageRootKey)
+            }
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+    }
+
+    /// A request whose generation never reaches a real server: the fakes above
+    /// short-circuit before any network/model call, so the prompt content is
+    /// irrelevant — we only need a valid `CotypingRequest`.
+    private func makeMinimalRequestExpectingNoServer() -> CotypingRequest {
+        let field = CotypingField(
+            appName: "Mail", bundleID: "com.apple.mail", processID: 0, role: "AXTextArea",
+            precedingText: "Hi Sarah,\nThanks for sending this over. I wanted to follow",
+            trailingText: "", selectionLength: 0, caretRect: .zero, isSecure: false,
+            caretIsExact: true, windowTitle: "Re: Q3", fieldPlaceholder: nil)
+        return CotypingRequestBuilder.build(
+            field: field, config: .standard,
+            personalization: .none, generation: 1, learnedExamples: [])!
+    }
+
+    private func awaitGenerate(
+        _ selector: CotypingEngineSelector, _ request: CotypingRequest
+    ) throws -> CotypingNormalizationResult {
+        let exp = expectation(description: "generate")
+        var captured: Result<CotypingNormalizationResult, Error>!
+        Task { @MainActor in
+            do { captured = .success(try await selector.generate(request)) }
+            catch { captured = .failure(error) }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5)
+        return try captured.get()
+    }
+}
+
+/// Thread-safe build counter for the `makeLocal` seam.
+private final class BuildCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    func bump() { lock.lock(); count += 1; lock.unlock() }
+    var value: Int { lock.lock(); defer { lock.unlock() }; return count }
+}
+
+/// Stands in for the HTTP `CotypingCompleting` and records that it was invoked,
+/// returning a sentinel result so the caller can assert the fallback path ran.
+@MainActor
+private final class RecordingHTTPEngine: CotypingCompleting {
+    static let sentinel = "HTTP-FALLBACK"
+    private(set) var generateCalls = 0
+    func generate(_ request: CotypingRequest) async throws -> CotypingNormalizationResult {
+        generateCalls += 1
+        return CotypingNormalizationResult(text: Self.sentinel, suppression: nil)
+    }
+}
+
+/// A local-engine fake that always throws a `LlamaRuntimeError`, used to prove
+/// the selector's HTTP fallback fires on a decode failure (Fix 2).
+@MainActor
+private final class ThrowingLocalEngine: CotypingCompleting {
+    let error: LlamaRuntimeError
+    init(error: LlamaRuntimeError) { self.error = error }
+    func generate(_ request: CotypingRequest) async throws -> CotypingNormalizationResult {
+        throw error
     }
 }

--- a/LokalBotTests/CotypingEngineSelectorTests.swift
+++ b/LokalBotTests/CotypingEngineSelectorTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import LokalBot
+
+final class CotypingEngineSelectorTests: XCTestCase {
+    private let modelURL = URL(fileURLWithPath: "/models/gemma.gguf")
+
+    func testUsesLocalWhenFlagOnAppleSiliconAndModelResolves() {
+        var s = AppSettings(); s.cotypingInProcessRuntime = true
+        XCTAssertTrue(CotypingEngineSelector.shouldUseLocal(
+            settings: s, modelURL: modelURL, isAppleSilicon: true))
+    }
+
+    func testFallsBackWhenFlagOff() {
+        var s = AppSettings(); s.cotypingInProcessRuntime = false
+        XCTAssertFalse(CotypingEngineSelector.shouldUseLocal(
+            settings: s, modelURL: modelURL, isAppleSilicon: true))
+    }
+
+    func testFallsBackOnIntel() {
+        var s = AppSettings(); s.cotypingInProcessRuntime = true
+        XCTAssertFalse(CotypingEngineSelector.shouldUseLocal(
+            settings: s, modelURL: modelURL, isAppleSilicon: false))
+    }
+
+    func testFallsBackWhenModelMissing() {
+        var s = AppSettings(); s.cotypingInProcessRuntime = true
+        XCTAssertFalse(CotypingEngineSelector.shouldUseLocal(
+            settings: s, modelURL: nil, isAppleSilicon: true))
+    }
+}

--- a/LokalBotTests/CotypingEngineSelectorTests.swift
+++ b/LokalBotTests/CotypingEngineSelectorTests.swift
@@ -76,11 +76,16 @@ final class CotypingEngineSelectorTests: XCTestCase {
                        "re-enabling after route-away must rebuild a fresh local engine")
     }
 
-    /// FIX 2: a thrown `LlamaRuntimeError.decodeFailed` from the local engine must
-    /// reach the selector's `catch let error as LlamaRuntimeError` and fall back to
-    /// HTTP. Enabled by the `CotypingCompleting` seam on `makeLocal` (a throwing
-    /// fake can now be injected as the local engine).
-    func testDecodeFailureFallsBackToHTTP() throws {
+    /// FIX 2 (selector half): a `LlamaRuntimeError` thrown by the local engine must
+    /// reach the selector's `catch let error as LlamaRuntimeError` and route the
+    /// completion to HTTP. This injects a `ThrowingLocalEngine` fake (enabled by the
+    /// `CotypingCompleting` seam on `makeLocal`), so it proves the selector's
+    /// fallback wiring — NOT that `LlamaCotypingRuntime.generate` actually throws on
+    /// a failed `llama_decode`. That runtime half is locked by compilation (the
+    /// `try await` propagation in `LlamaCotypingRuntimeTests`); a genuine
+    /// `llama_decode == 0` fault (KV exhaustion / OOM) can't be provoked
+    /// deterministically in a unit test.
+    func testLocalRuntimeErrorRoutesToHTTPFallback() throws {
         try XCTSkipUnless(CotypingEngineSelector.isAppleSilicon,
                           "Selector routes to local only on Apple Silicon.")
         let env = try GGUFFixture()

--- a/LokalBotTests/CotypingTests.swift
+++ b/LokalBotTests/CotypingTests.swift
@@ -184,12 +184,12 @@ final class CotypingModelPreparationTests: XCTestCase {
         XCTAssertEqual(status, .ready(entry))
     }
 
-    func testRecommendedActiveRequiresToggleAndModelID() {
+    func testRecommendedActiveTracksModelID() {
         var settings = AppSettings()
-        XCTAssertFalse(CotypingModelPreparer.recommendedIsActive(settings: settings))
-        settings.cotypingUseSeparateModel = true
-        settings.cotypingBuiltInModelID = ModelCatalog.recommendedCotypingID
+        // Cotyping always runs its own model; the recommended Gemma id is the default.
         XCTAssertTrue(CotypingModelPreparer.recommendedIsActive(settings: settings))
+        settings.cotypingBuiltInModelID = ModelCatalog.bundledID
+        XCTAssertFalse(CotypingModelPreparer.recommendedIsActive(settings: settings))
     }
 
     func testPrepareActionDownloadsBeforeActivatingMissingModel() {
@@ -592,8 +592,7 @@ final class CotypingSettingsTests: XCTestCase {
         settings.cotypingAcceptGranularity = .phrase
         settings.cotypingFullAcceptKey = .rightArrow
         settings.cotypingExcludedApps = "Terminal, 1Password"
-        settings.cotypingUseSeparateModel = true
-        settings.cotypingBuiltInModelID = ModelCatalog.recommendedCotypingID
+        settings.cotypingBuiltInModelID = ModelCatalog.bundledID
         settings.cotypingUseLocalLearning = false
         settings.cotypingLearningExamplesInPrompt = 5
 
@@ -609,8 +608,7 @@ final class CotypingSettingsTests: XCTestCase {
         XCTAssertEqual(decoded.cotypingAcceptGranularity, .phrase)
         XCTAssertEqual(decoded.cotypingFullAcceptKey, .rightArrow)
         XCTAssertEqual(decoded.cotypingExcludedAppList, ["Terminal", "1Password"])
-        XCTAssertTrue(decoded.cotypingUseSeparateModel)
-        XCTAssertEqual(decoded.cotypingBuiltInModelID, ModelCatalog.recommendedCotypingID)
+        XCTAssertEqual(decoded.cotypingBuiltInModelID, ModelCatalog.bundledID)
         XCTAssertFalse(decoded.cotypingUseLocalLearning)
         XCTAssertEqual(decoded.cotypingLearningExamplesInPrompt, 5)
     }

--- a/LokalBotTests/CotypingTests.swift
+++ b/LokalBotTests/CotypingTests.swift
@@ -627,6 +627,25 @@ final class CotypingSettingsTests: XCTestCase {
         XCTAssertTrue(settings.menuBarOnly)
     }
 
+    func testInProcessRuntimeDefaultsOn() {
+        XCTAssertTrue(AppSettings().cotypingInProcessRuntime)
+    }
+
+    func testInProcessRuntimeRoundTrips() throws {
+        var settings = AppSettings()
+        settings.cotypingInProcessRuntime = false
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+        XCTAssertFalse(decoded.cotypingInProcessRuntime)
+    }
+
+    func testTolerantDecodeDefaultsInProcessRuntimeOn() throws {
+        // A saved blob predating the flag must decode with the default (true).
+        let json = "{}".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: json)
+        XCTAssertTrue(decoded.cotypingInProcessRuntime)
+    }
+
     func testDefaultsMirrorCotypistLengthAndDebounce() {
         let settings = AppSettings()
         XCTAssertEqual(settings.cotypingMaxWords, 20)

--- a/LokalBotTests/IncrementalPrefillTests.swift
+++ b/LokalBotTests/IncrementalPrefillTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import LokalBot
+
+final class IncrementalPrefillTests: XCTestCase {
+    func testEmptyInputs() {
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([], []), 0)
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([1, 2], []), 0)
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([], [1, 2]), 0)
+    }
+
+    func testIdenticalSequences() {
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([1, 2, 3], [1, 2, 3]), 3)
+    }
+
+    func testDivergeAtZero() {
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([9, 2, 3], [1, 2, 3]), 0)
+    }
+
+    func testOneIsPrefixOfOther() {
+        // Typing forward: old cache [1,2,3], new prompt [1,2,3,4,5] → reuse 3.
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([1, 2, 3], [1, 2, 3, 4, 5]), 3)
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([1, 2, 3, 4, 5], [1, 2, 3]), 3)
+    }
+
+    func testDivergeInMiddle() {
+        XCTAssertEqual(IncrementalPrefill.commonPrefixLength([1, 2, 3, 4], [1, 2, 9, 4]), 2)
+    }
+}

--- a/LokalBotTests/LlamaCoreSmokeTests.swift
+++ b/LokalBotTests/LlamaCoreSmokeTests.swift
@@ -13,6 +13,10 @@ final class LlamaCoreSmokeTests: XCTestCase {
         XCTAssertEqual(model.n_gpu_layers, -1)
         let ctx = llama_context_default_params()
         XCTAssertGreaterThan(ctx.n_ctx, 0)
-        llama_backend_free()
+        // Intentionally NOT calling llama_backend_free(): this runs in the shared
+        // test process, and freeing the global backend here would be a footgun for
+        // any test class that loads a model (LlamaCotypingRuntime's once-let init).
+        // The smoke test's purpose — LlamaCore imports, dylib links, default-params
+        // structs resolve — needs no teardown.
     }
 }

--- a/LokalBotTests/LlamaCoreSmokeTests.swift
+++ b/LokalBotTests/LlamaCoreSmokeTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+import LlamaCore
+
+/// Proves the LlamaCore module imports, the vendored libllama.dylib links, and
+/// the @rpath resolves at runtime by executing real b9789 C calls.
+final class LlamaCoreSmokeTests: XCTestCase {
+    func testBackendInitAndDefaultParamsLink() {
+        llama_backend_init()
+        let model = llama_model_default_params()
+        // The n_gpu_layers field must be reachable through the imported struct.
+        // b9789 defaults it to -1 ("a negative value means all layers" per
+        // llama.h) — i.e. full Metal offload, exactly what the runtime wants.
+        XCTAssertEqual(model.n_gpu_layers, -1)
+        let ctx = llama_context_default_params()
+        XCTAssertGreaterThan(ctx.n_ctx, 0)
+        llama_backend_free()
+    }
+}

--- a/LokalBotTests/LlamaCotypingRuntimeTests.swift
+++ b/LokalBotTests/LlamaCotypingRuntimeTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import LokalBot
+
+final class LlamaCotypingRuntimeTests: XCTestCase {
+
+    /// Resolves the bundled tiny model from the app bundle's Resources, or skips.
+    private func bundledModelPath() throws -> String {
+        let entry = ModelCatalog.entry(id: ModelCatalog.bundledID)!
+        let storage = StorageManager()
+        guard let url = ModelCatalog.localURL(for: entry, storage: storage) else {
+            throw XCTSkip("Bundled model \(entry.fileName) not present; skipping libllama integration test.")
+        }
+        return url.path
+    }
+
+    private let standardSpecs = LlamaSamplerSpec.specs(from: .standard)
+
+    func testLoadsAndGeneratesDeterministically() async throws {
+        let path = try bundledModelPath()
+        let runtime = LlamaCotypingRuntime()
+        try await runtime.loadIfNeeded(modelPath: path)
+        let loaded = await runtime.isLoaded
+        XCTAssertTrue(loaded)
+
+        let prompt = await runtime.tokenize("The capital of France is", addBOS: true)
+        XCTAssertFalse(prompt.isEmpty)
+
+        let first = await runtime.generate(
+            promptTokens: prompt, maxTokens: 8, samplerSpecs: standardSpecs) { _ in true }
+        XCTAssertFalse(first.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+        // Same prompt + fixed seed (0x00C0FFEE in standardSpecs) → identical output.
+        try await runtime.loadIfNeeded(modelPath: path) // no-op reload
+        let second = await runtime.generate(
+            promptTokens: prompt, maxTokens: 8, samplerSpecs: standardSpecs) { _ in true }
+        XCTAssertEqual(first, second, "fixed seed must produce deterministic output")
+    }
+
+    func testKVReuseDecodesOnlySuffix() async throws {
+        let path = try bundledModelPath()
+        let runtime = LlamaCotypingRuntime()
+        try await runtime.loadIfNeeded(modelPath: path)
+
+        let base = await runtime.tokenize("Hi Sarah, thanks for sending this over. I wanted to follow", addBOS: true)
+        _ = await runtime.generate(promptTokens: base, maxTokens: 2, samplerSpecs: standardSpecs) { _ in true }
+        let firstPrefill = await runtime.lastPrefillTokenCount
+        XCTAssertEqual(firstPrefill, base.count, "cold prompt prefills every token")
+
+        // Extend the prompt: the shared prefix must be reused, only the suffix decoded.
+        let extended = base + (await runtime.tokenize(" up tomorrow", addBOS: false))
+        _ = await runtime.generate(promptTokens: extended, maxTokens: 2, samplerSpecs: standardSpecs) { _ in true }
+        let secondPrefill = await runtime.lastPrefillTokenCount
+        XCTAssertLessThan(secondPrefill, extended.count, "KV reuse must skip the shared prefix")
+        XCTAssertEqual(secondPrefill, extended.count - base.count,
+                       "only the appended suffix should be prefilled")
+    }
+
+    func testOnTokenReturningFalseStopsDecode() async throws {
+        let path = try bundledModelPath()
+        let runtime = LlamaCotypingRuntime()
+        try await runtime.loadIfNeeded(modelPath: path)
+        let prompt = await runtime.tokenize("Once upon a time", addBOS: true)
+        let counter = TokenCounter()
+        let out = await runtime.generate(
+            promptTokens: prompt, maxTokens: 20, samplerSpecs: standardSpecs
+        ) { _ in counter.increment() < 3 }   // stop after 3 tokens
+        XCTAssertLessThanOrEqual(counter.value, 3)
+        XCTAssertFalse(out.isEmpty)
+    }
+}
+
+/// Thread-safe counter so the `@Sendable` onToken closure can tally tokens
+/// without tripping Swift's concurrent-capture diagnostics.
+private final class TokenCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    /// Increments and returns the new count (so the first call returns 1).
+    @discardableResult
+    func increment() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        count += 1
+        return count
+    }
+    var value: Int {
+        lock.lock(); defer { lock.unlock() }
+        return count
+    }
+}

--- a/LokalBotTests/LlamaCotypingRuntimeTests.swift
+++ b/LokalBotTests/LlamaCotypingRuntimeTests.swift
@@ -25,13 +25,13 @@ final class LlamaCotypingRuntimeTests: XCTestCase {
         let prompt = await runtime.tokenize("The capital of France is", addBOS: true)
         XCTAssertFalse(prompt.isEmpty)
 
-        let first = await runtime.generate(
+        let first = try await runtime.generate(
             promptTokens: prompt, maxTokens: 8, samplerSpecs: standardSpecs) { _ in true }
         XCTAssertFalse(first.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
 
         // Same prompt + fixed seed (0x00C0FFEE in standardSpecs) → identical output.
         try await runtime.loadIfNeeded(modelPath: path) // no-op reload
-        let second = await runtime.generate(
+        let second = try await runtime.generate(
             promptTokens: prompt, maxTokens: 8, samplerSpecs: standardSpecs) { _ in true }
         XCTAssertEqual(first, second, "fixed seed must produce deterministic output")
     }
@@ -59,13 +59,13 @@ final class LlamaCotypingRuntimeTests: XCTestCase {
         try await runtime.loadIfNeeded(modelPath: path)
 
         let base = await runtime.tokenize("Hi Sarah, thanks for sending this over. I wanted to follow", addBOS: true)
-        _ = await runtime.generate(promptTokens: base, maxTokens: 2, samplerSpecs: standardSpecs) { _ in true }
+        _ = try await runtime.generate(promptTokens: base, maxTokens: 2, samplerSpecs: standardSpecs) { _ in true }
         let firstPrefill = await runtime.lastPrefillTokenCount
         XCTAssertEqual(firstPrefill, base.count, "cold prompt prefills every token")
 
         // Extend the prompt: the reuse signal must subtract the shared prefix.
         let extended = base + (await runtime.tokenize(" up tomorrow", addBOS: false))
-        _ = await runtime.generate(promptTokens: extended, maxTokens: 2, samplerSpecs: standardSpecs) { _ in true }
+        _ = try await runtime.generate(promptTokens: extended, maxTokens: 2, samplerSpecs: standardSpecs) { _ in true }
         let secondPrefill = await runtime.lastPrefillTokenCount
         XCTAssertLessThan(secondPrefill, extended.count, "reuse signal must discount the shared prefix")
         XCTAssertEqual(secondPrefill, extended.count - base.count,
@@ -78,7 +78,7 @@ final class LlamaCotypingRuntimeTests: XCTestCase {
         try await runtime.loadIfNeeded(modelPath: path)
         let prompt = await runtime.tokenize("Once upon a time", addBOS: true)
         let counter = TokenCounter()
-        let out = await runtime.generate(
+        let out = try await runtime.generate(
             promptTokens: prompt, maxTokens: 20, samplerSpecs: standardSpecs
         ) { _ in counter.increment() < 3 }   // stop after 3 tokens
         XCTAssertLessThanOrEqual(counter.value, 3)

--- a/LokalBotTests/LlamaCotypingRuntimeTests.swift
+++ b/LokalBotTests/LlamaCotypingRuntimeTests.swift
@@ -36,6 +36,15 @@ final class LlamaCotypingRuntimeTests: XCTestCase {
         XCTAssertEqual(first, second, "fixed seed must produce deterministic output")
     }
 
+    func testMemoryPressureUnloadsWhenNotLoaded() async {
+        let runtime = LlamaCotypingRuntime()
+        let before = await runtime.isLoaded
+        XCTAssertFalse(before)
+        await runtime.handleMemoryPressure()   // safe no-op when nothing is loaded
+        let after = await runtime.isLoaded
+        XCTAssertFalse(after)
+    }
+
     func testKVReuseDecodesOnlySuffix() async throws {
         let path = try bundledModelPath()
         let runtime = LlamaCotypingRuntime()

--- a/LokalBotTests/LlamaCotypingRuntimeTests.swift
+++ b/LokalBotTests/LlamaCotypingRuntimeTests.swift
@@ -45,7 +45,15 @@ final class LlamaCotypingRuntimeTests: XCTestCase {
         XCTAssertFalse(after)
     }
 
-    func testKVReuseDecodesOnlySuffix() async throws {
+    func testReusedPrefixIsReflectedInPrefillTokenCount() async throws {
+        // Validates the IncrementalPrefill reuse SIGNAL — the logical
+        // `lastPrefillTokenCount` (prompt.count - sharedPrefix) — not the physical
+        // reuse branch. The bundled CI model is hybrid SSM, so it always takes the
+        // full-reprefill fallback; the arithmetic below holds on BOTH that fallback
+        // and the production attention model's partial-reuse branch, so it cannot
+        // observe physical suffix-only prefill on this fixture. The pure-attention
+        // partial-reuse branch is exercised only on the production Gemma-4 model /
+        // a manual run.
         let path = try bundledModelPath()
         let runtime = LlamaCotypingRuntime()
         try await runtime.loadIfNeeded(modelPath: path)
@@ -55,13 +63,13 @@ final class LlamaCotypingRuntimeTests: XCTestCase {
         let firstPrefill = await runtime.lastPrefillTokenCount
         XCTAssertEqual(firstPrefill, base.count, "cold prompt prefills every token")
 
-        // Extend the prompt: the shared prefix must be reused, only the suffix decoded.
+        // Extend the prompt: the reuse signal must subtract the shared prefix.
         let extended = base + (await runtime.tokenize(" up tomorrow", addBOS: false))
         _ = await runtime.generate(promptTokens: extended, maxTokens: 2, samplerSpecs: standardSpecs) { _ in true }
         let secondPrefill = await runtime.lastPrefillTokenCount
-        XCTAssertLessThan(secondPrefill, extended.count, "KV reuse must skip the shared prefix")
+        XCTAssertLessThan(secondPrefill, extended.count, "reuse signal must discount the shared prefix")
         XCTAssertEqual(secondPrefill, extended.count - base.count,
-                       "only the appended suffix should be prefilled")
+                       "logical prefill count should equal only the appended suffix")
     }
 
     func testOnTokenReturningFalseStopsDecode() async throws {

--- a/LokalBotTests/LlamaSamplerSpecTests.swift
+++ b/LokalBotTests/LlamaSamplerSpecTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import LokalBot
+
+final class LlamaSamplerSpecTests: XCTestCase {
+    func testStandardConfigMapsToOrderedChain() {
+        let specs = LlamaSamplerSpec.specs(from: .standard)
+        XCTAssertEqual(specs, [
+            .penalties(lastN: 64, repeat: 1.05, freq: 0, present: 0),
+            .topK(20),
+            .topP(0.7, minKeep: 1),
+            .minP(0.08, minKeep: 1),
+            .temp(0.1),
+            .dist(seed: 0x00C0_FFEE),
+        ])
+    }
+
+    func testExplicitParamsPreserveSamplerOrder() {
+        let specs = LlamaSamplerSpec.specs(
+            temperature: 0.2, topK: 40, topP: 0.9, minP: 0.05,
+            repeatPenalty: 1.1, repeatLastN: 64, seed: 42)
+        XCTAssertEqual(specs.map(\.order), [0, 1, 2, 3, 4, 5])
+        XCTAssertEqual(specs.last, .dist(seed: 42))
+    }
+}
+
+private extension LlamaSamplerSpec {
+    var order: Int {
+        switch self {
+        case .penalties: 0
+        case .topK: 1
+        case .topP: 2
+        case .minP: 3
+        case .temp: 4
+        case .dist: 5
+        }
+    }
+}

--- a/LokalBotTests/LocalLlamaCotypingEngineTests.swift
+++ b/LokalBotTests/LocalLlamaCotypingEngineTests.swift
@@ -36,4 +36,18 @@ final class LocalLlamaCotypingEngineTests: XCTestCase {
         _ = try await engine.generateStreaming(makeRequest()) { _ in partials += 1 }
         XCTAssertGreaterThan(partials, 0)
     }
+
+    /// `unload()` is callable on the engine seam and is a safe no-op when nothing
+    /// is loaded (mirrors LlamaCotypingRuntimeTests.testMemoryPressureUnloadsWhenNotLoaded).
+    /// No GGUF needed: the runtime is never loaded, so unload just confirms the
+    /// route-away teardown path the selector uses can't crash on an idle engine.
+    func testUnloadIsCallableAndLeavesUnloadedRuntimeUnloaded() async {
+        let runtime = LlamaCotypingRuntime()
+        let engine = LocalLlamaCotypingEngine(runtime: runtime, modelPath: "/nonexistent.gguf")
+        let before = await runtime.isLoaded
+        XCTAssertFalse(before)
+        await engine.unload()
+        let after = await runtime.isLoaded
+        XCTAssertFalse(after)
+    }
 }

--- a/LokalBotTests/LocalLlamaCotypingEngineTests.swift
+++ b/LokalBotTests/LocalLlamaCotypingEngineTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import LokalBot
+
+@MainActor
+final class LocalLlamaCotypingEngineTests: XCTestCase {
+    private func bundledModelPath() throws -> String {
+        let entry = ModelCatalog.entry(id: ModelCatalog.bundledID)!
+        guard let url = ModelCatalog.localURL(for: entry, storage: StorageManager()) else {
+            throw XCTSkip("Bundled model not present; skipping engine integration test.")
+        }
+        return url.path
+    }
+
+    private func makeRequest() -> CotypingRequest {
+        let field = CotypingField(
+            appName: "Mail", bundleID: "com.apple.mail", processID: 0, role: "AXTextArea",
+            precedingText: "Hi Sarah,\nThanks for sending this over. I wanted to follow",
+            trailingText: "", selectionLength: 0, caretRect: .zero, isSecure: false,
+            caretIsExact: true, windowTitle: "Re: Q3", fieldPlaceholder: nil)
+        return CotypingRequestBuilder.build(
+            field: field, config: .standard,
+            personalization: .none, generation: 1, learnedExamples: [])!
+    }
+
+    func testGenerateReturnsNormalizedResult() async throws {
+        let path = try bundledModelPath()
+        let engine = LocalLlamaCotypingEngine(runtime: LlamaCotypingRuntime(), modelPath: path)
+        let result = try await engine.generate(makeRequest())
+        XCTAssertFalse(result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    func testStreamingFiresPartials() async throws {
+        let path = try bundledModelPath()
+        let engine = LocalLlamaCotypingEngine(runtime: LlamaCotypingRuntime(), modelPath: path)
+        var partials = 0
+        _ = try await engine.generateStreaming(makeRequest()) { _ in partials += 1 }
+        XCTAssertGreaterThan(partials, 0)
+    }
+}

--- a/LokalBotTests/ModelCatalogTests.swift
+++ b/LokalBotTests/ModelCatalogTests.swift
@@ -72,34 +72,6 @@ final class ModelCatalogTests: XCTestCase {
         XCTAssertEqual(LlamaServer.cotyping.contextTokens, 2_048)
     }
 
-    func testCotypistModelReuseRequiresGGUFAtExpectedPath() throws {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cotypist-model-\(UUID().uuidString)", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: root) }
-        let models = root
-            .appendingPathComponent("app.cotypist.Cotypist", isDirectory: true)
-            .appendingPathComponent("Models", isDirectory: true)
-        try FileManager.default.createDirectory(at: models, withIntermediateDirectories: true)
-        let model = models.appendingPathComponent("gemma-4-E4B-UD-Q5_K_XL.gguf")
-        try Data("GGUF".utf8).write(to: model)
-
-        XCTAssertEqual(ModelCatalog.cotypistModelURL(appSupport: root), model)
-    }
-
-    func testCotypistModelReuseIgnoresInvalidFiles() throws {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cotypist-invalid-\(UUID().uuidString)", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: root) }
-        let models = root
-            .appendingPathComponent("app.cotypist.Cotypist", isDirectory: true)
-            .appendingPathComponent("Models", isDirectory: true)
-        try FileManager.default.createDirectory(at: models, withIntermediateDirectories: true)
-        try Data("nope".utf8)
-            .write(to: models.appendingPathComponent("gemma-4-E4B-UD-Q5_K_XL.gguf"))
-
-        XCTAssertNil(ModelCatalog.cotypistModelURL(appSupport: root))
-    }
-
     func testDownloadURLsAreValid() {
         for entry in ModelCatalog.entries {
             XCTAssertNotNil(URL(string: entry.url), "\(entry.id) has an invalid URL")

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ LokalBot is a strictly-local meeting recorder for macOS. It records both sides o
 - **Writes the recap automatically.** A TL;DR with decisions and action items the moment the call ends. Pick a notes template, summary language, and re-run anytime.
 - **Search every word you've heard.** Full-text *and* meaning-based search across transcripts, summaries, and on-screen text. Click a hit to play from that exact second.
 - **Chat with your meetings.** Ask "what did we decide?" or "find the action items" in plain language — answers are grounded in your library.
-- **Cotyping — inline AI autocomplete.** Ghost text as you type in almost any app; press **Tab** to accept. Runs on the same local model. Opt-in.
+- **Cotyping — inline AI autocomplete.** Ghost text as you type in almost any app; press **Tab** to accept. Runs its own dedicated on-device model (in-process Gemma-4 by default). Opt-in.
 - **See where your day went.** A private timeline of apps and meetings, a generated daily digest, and an "ask your day" box.
 - **Private by construction.** Optional screenshots are AES-GCM encrypted and auto-delete after 14 days. Password fields and excluded apps are never read.
 - **Bring your own model.** Built-in llama.cpp model (zero setup), or point at Ollama, any OpenAI-compatible server, or Apple Intelligence.
@@ -179,7 +179,7 @@ Models auto-download from Hugging Face on first use and are cached under Applica
 <summary><strong>Cotyping</strong> — inline AI autocomplete</summary>
 
 - **Ghost text everywhere:** as you type in almost any macOS text field, a gray suggestion appears next to the cursor; press **Tab** to accept (a word at a time, or the whole thing — Settings → Cotyping), or keep typing / press **Esc** to dismiss. Built on the same loop as [Cotabby](https://cotabby.app): an Accessibility poll resolves the focused field + caret, a `CGEventTap` watches keystrokes (and swallows the accept key only while a suggestion shows), a borderless click-through `NSPanel` renders the ghost at the caret, and accepted text is inserted as synthetic Unicode keystrokes.
-- **Reuses the local LLM:** suggestions come from the **same** backend as summaries through a low-latency raw `/v1/completions` call. The prompt treats the model as a pure text-continuer; raw output is cleaned by a shared normalizer (strips chat/`<think>` scaffolding, prompt echoes, and trailing-text duplication; collapses to one line). Nothing leaves the Mac.
+- **Its own dedicated on-device model:** cotyping decodes a dedicated model (default **Gemma 4 E4B Q5 XL**) **in-process via libllama** for low latency, with the localhost `llama-server` as the fallback (non-GGUF backends, the in-process runtime toggled off, or on model load failure). The prompt treats the model as a pure text-continuer; raw output is cleaned by a shared normalizer (strips chat/`<think>` scaffolding, prompt echoes, and trailing-text duplication; collapses to one line). Nothing leaves the Mac.
 - **Opt-in & private:** off by default; needs **Accessibility** + **Input Monitoring**. Never reads password/secure fields; honors a per-user app exclusion list (preseeded with password managers and terminals).
 - **In-app preview:** the **Cotyping** tab has a live playground that runs the real pipeline on text typed *inside LokalBot* — try it with zero system permissions. Quick-toggle from the menu bar.
 

--- a/Scripts/fetch-llama.sh
+++ b/Scripts/fetch-llama.sh
@@ -35,6 +35,46 @@ if [ "$installed_tag" != "$TAG" ]; then
   rm -rf "$tmp"
 fi
 
+# --- Public C headers for in-process libllama (LlamaCore module) ---
+# Fetched from the pinned source tag so the Swift module compiles against the
+# exact b9789 API the vendored dylib exports. Idempotent: skip if present.
+INCLUDE_DIR="$SERVER_DIR/include"
+RAW_BASE="https://raw.githubusercontent.com/ggml-org/llama.cpp/$TAG"
+HEADERS=(
+  "include/llama.h"
+  "ggml/include/ggml.h"
+  "ggml/include/ggml-backend.h"
+  "ggml/include/ggml-alloc.h"
+  "ggml/include/ggml-cpu.h"
+  "ggml/include/ggml-metal.h"
+  "ggml/include/ggml-opt.h"
+  "ggml/include/gguf.h"
+)
+mkdir -p "$INCLUDE_DIR"
+for h in "${HEADERS[@]}"; do
+  dest="$INCLUDE_DIR/$(basename "$h")"
+  if [ ! -f "$dest" ]; then
+    echo "fetch-llama: downloading header $(basename "$h")"
+    curl -fsSL "$RAW_BASE/$h" -o "$dest"
+  fi
+done
+
+# Declare the LlamaCore Clang module over the fetched headers. Generated here
+# (not committed) so the whole Vendor/ tree stays reproducible and gitignored,
+# matching the dylibs/model. Rewritten every run so it tracks any HEADERS edit.
+cat > "$INCLUDE_DIR/module.modulemap" <<'EOF'
+module LlamaCore {
+    header "llama.h"
+    header "ggml.h"
+    header "ggml-backend.h"
+    header "ggml-alloc.h"
+    header "ggml-cpu.h"
+    header "ggml-opt.h"
+    header "gguf.h"
+    export *
+}
+EOF
+
 if [ ! -f "$MODEL_DIR/$DEFAULT_MODEL" ]; then
   echo "fetch-llama: downloading default model $DEFAULT_MODEL (~0.64 GB)..."
   mkdir -p "$MODEL_DIR"

--- a/project.yml
+++ b/project.yml
@@ -8,6 +8,19 @@ options:
   generateEmptyDirectories: true
   groupSortPosition: top
 
+# Shared across EVERY target (incl. LokalBotTests, which `import LlamaCore`
+# directly): point the compiler at the vendored b9789 headers + the generated
+# LlamaCore module map so `import LlamaCore` resolves. Link flags / rpath live
+# on the LokalBotApp template only — see its settings.base below.
+settings:
+  base:
+    HEADER_SEARCH_PATHS:
+      - $(inherited)
+      - $(SRCROOT)/Vendor/llama-cpp/include
+    SWIFT_INCLUDE_PATHS:
+      - $(inherited)
+      - $(SRCROOT)/Vendor/llama-cpp/include
+
 packages:
   FluidAudio:
     url: https://github.com/FluidInference/FluidAudio
@@ -131,6 +144,19 @@ targetTemplates:
         # survive rebuilds — ad-hoc signing invalidates them every build.
         DEVELOPMENT_TEAM: K96P3M3997
         GENERATE_INFOPLIST_FILE: NO
+        # In-process libllama: link the vendored dylib (-lllama resolves the
+        # libllama.dylib symlink in Vendor/llama-cpp) and make its @rpath install
+        # name (@rpath/libllama.0.dylib) resolve at runtime against the copies the
+        # Vendor/llama-cpp folder-resource phase places in Contents/Resources/llama-cpp.
+        LIBRARY_SEARCH_PATHS:
+          - $(inherited)
+          - $(SRCROOT)/Vendor/llama-cpp
+        OTHER_LDFLAGS:
+          - $(inherited)
+          - -lllama
+        LD_RUNPATH_SEARCH_PATHS:
+          - $(inherited)
+          - "@executable_path/../Resources/llama-cpp"
 
 targets:
   LokalBot:
@@ -185,6 +211,24 @@ targets:
         GENERATE_INFOPLIST_FILE: YES
         PRODUCT_MODULE_NAME: LokalBotTests
         PRODUCT_BUNDLE_IDENTIFIER: me.dotenv.LokalBotTests
+        # Tests that `import LlamaCore` and call libllama C functions directly
+        # must link the dylib themselves: -bundle_loader only resolves symbols
+        # DEFINED IN the host executable, and the llama_* symbols live in
+        # libllama.dylib (which the host only *loads*, not defines). Link it here
+        # and add an rpath that reaches the host app's Contents/Resources/llama-cpp
+        # copies — both from the injected .xctest binary (@loader_path) and from
+        # the host app executable (@executable_path), since at runtime the test
+        # bundle is loaded inside the TEST_HOST process.
+        LIBRARY_SEARCH_PATHS:
+          - $(inherited)
+          - $(SRCROOT)/Vendor/llama-cpp
+        OTHER_LDFLAGS:
+          - $(inherited)
+          - -lllama
+        LD_RUNPATH_SEARCH_PATHS:
+          - $(inherited)
+          - "@executable_path/../Resources/llama-cpp"
+          - "@loader_path/../../../../Resources/llama-cpp"
 
   # Synthetic-data UI tests. Drives the UI-test host app via
   # XCUITest with `LOKALBOT_UI_TEST=1` so the app skips Core Audio polling,

--- a/web/index.html
+++ b/web/index.html
@@ -28,8 +28,22 @@
   <div class="bg-field" aria-hidden="true">
     <div class="bg-glow bg-glow--a"></div>
     <div class="bg-glow bg-glow--b"></div>
+    <div class="bg-glow bg-glow--c"></div>
+    <div class="bg-refract"></div>
     <div class="bg-grain"></div>
   </div>
+
+  <!-- Liquid-glass displacement filter: feTurbulence + feDisplacementMap, the
+       primitive behind aave.com/design/building-glass-for-the-web. It refracts
+       the real rendered pixels of the layer it is applied to (here, ambient
+       light), and runs in every modern browser including Safari. -->
+  <svg class="glass-defs" aria-hidden="true" focusable="false" width="0" height="0">
+    <filter id="liquidGlass" x="-25%" y="-25%" width="150%" height="150%" color-interpolation-filters="sRGB">
+      <feTurbulence type="fractalNoise" baseFrequency="0.011 0.015" numOctaves="2" seed="7" result="noise" />
+      <feGaussianBlur in="noise" stdDeviation="2.4" result="soft" />
+      <feDisplacementMap in="SourceGraphic" in2="soft" scale="26" xChannelSelector="R" yChannelSelector="G" />
+    </filter>
+  </svg>
 
   <!-- ───────────────────────── NAV ───────────────────────── -->
   <header class="nav" id="top">

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,14 +1,18 @@
 /* =========================================================================
-   LokalBot landing page
-   Theme: locked dark (matches the dark app icon). One accent: teal.
-   Amber (#fbbf24) is used once, only for the live "recording" indicator.
-   Radius system: pill for interactive (buttons/chips), 18px containers,
-   12px code/inputs. Type: native SF system stack (Apple-native on macOS).
+   LokalBot landing page — "Glass for the web"
+   Aesthetic: frosted, translucent glass panels over a dark, glowing field,
+   in the spirit of aave.com/design/building-glass-for-the-web. Every surface
+   is real glass: backdrop blur + saturate, a masked specular rim that catches
+   light on the top-left and breaks into a teal fringe, layered float shadows,
+   and a feTurbulence/feDisplacementMap refraction running in the background.
+   Identity stays teal; a faint violet appears only in glass refraction/glow.
+   Radius system: pill for interactive, 18px containers, 12px code/inputs.
+   Type: native SF system stack (Apple-native on macOS).
    ========================================================================= */
 
 :root {
-  --bg: #0b1119;
-  --bg-2: #0e141c;
+  --bg: #080d14;
+  --bg-2: #0b1119;
   --surface: #121a25;
   --surface-2: #16212e;
   --line: rgba(150, 180, 200, 0.13);
@@ -23,6 +27,29 @@
   --teal-soft: rgba(35, 196, 174, 0.14);
   --teal-ink: #04141a;
   --amber: #fbbf24;
+  --violet: #8b7bf0;          /* prismatic accent — glows & glass fringe only */
+
+  /* ── glass system ─────────────────────────────────────────────────── */
+  --glass-tint: rgba(18, 28, 40, 0.52);        /* default panel fill        */
+  --glass-tint-strong: rgba(20, 31, 44, 0.64); /* hero / download / cotype  */
+  --glass-tint-chip: rgba(22, 33, 46, 0.45);   /* small controls            */
+  --glass-blur: 22px;
+  --glass-blur-chip: 14px;
+  --glass-sat: 165%;
+  --glass-border: rgba(255, 255, 255, 0.1);
+  /* top gloss baked into the fill so it paints above the blurred backdrop */
+  --glass-gloss: linear-gradient(
+    180deg, rgba(255, 255, 255, 0.085), rgba(255, 255, 255, 0.012) 42%, rgba(255, 255, 255, 0) 70%);
+  /* specular rim: bright top-left light catch → teal chromatic fringe */
+  --glass-rim: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.62) 0%,
+    rgba(255, 255, 255, 0.1) 24%,
+    rgba(255, 255, 255, 0) 50%,
+    rgba(110, 242, 220, 0.16) 82%,
+    rgba(139, 123, 240, 0.18) 100%);
+  --glass-shadow: 0 26px 60px -18px rgba(0, 0, 0, 0.62), 0 10px 26px -12px rgba(0, 0, 0, 0.5);
+  --glass-inset: inset 0 1px 0 rgba(255, 255, 255, 0.14), inset 0 -1px 0 rgba(0, 0, 0, 0.22);
 
   --radius: 18px;
   --radius-lg: 26px;
@@ -62,6 +89,8 @@ p { margin: 0; }
 a { color: inherit; text-decoration: none; }
 ul, ol { margin: 0; padding: 0; list-style: none; }
 
+.glass-defs { position: absolute; width: 0; height: 0; pointer-events: none; }
+
 ::selection { background: var(--teal); color: var(--teal-ink); }
 
 :focus-visible {
@@ -84,32 +113,120 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
 }
 .skip-link:focus { top: 16px; }
 
-/* ───────────────────────── ambient background ───────────────────────── */
+/* =========================================================================
+   GLASS — shared surface + masked specular rim
+   ========================================================================= */
+.glass,
+.nav,
+.proof,
+.tile,
+.cotype,
+.appcard,
+.download__panel,
+.hero__diagram,
+.faq__list {
+  position: relative;
+  background: var(--glass-gloss), var(--glass-tint);
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-inset), var(--glass-shadow);
+}
+
+/* the rim: a 1px gradient ring masked to the border only, so the panel
+   interior shows the live (blurred) content straight through */
+.glass::after,
+.nav::after,
+.proof::after,
+.tile::after,
+.cotype::after,
+.appcard::after,
+.download__panel::after,
+.hero__diagram::after,
+.faq__list::after,
+.btn--ghost::after,
+.icon-link::after,
+.step__num::after,
+.recorder::after,
+.track::after,
+.tile__tags li::after,
+kbd::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: var(--glass-rim);
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+          mask-composite: exclude;
+  pointer-events: none;
+  z-index: 3;
+}
+
+/* small glass controls: lighter blur, lighter fill */
+.btn--ghost,
+.icon-link,
+.step__num,
+.recorder,
+.track,
+.tile__tags li,
+kbd {
+  position: relative;
+  -webkit-backdrop-filter: blur(var(--glass-blur-chip)) saturate(150%);
+  backdrop-filter: blur(var(--glass-blur-chip)) saturate(150%);
+}
+
+/* =========================================================================
+   ambient background — glowing field + liquid refraction + grain
+   ========================================================================= */
 .bg-field { position: fixed; inset: 0; z-index: -1; overflow: hidden; background: var(--bg); }
 .bg-glow {
   position: absolute;
   border-radius: 50%;
-  filter: blur(110px);
-  opacity: 0.5;
+  filter: blur(120px);
+  opacity: 0.55;
 }
 .bg-glow--a {
-  width: 60vw; height: 60vw;
-  top: -22vw; left: -16vw;
-  background: radial-gradient(circle, rgba(35, 196, 174, 0.30), transparent 62%);
+  width: 62vw; height: 62vw;
+  top: -24vw; left: -16vw;
+  background: radial-gradient(circle, rgba(35, 196, 174, 0.34), transparent 62%);
 }
 .bg-glow--b {
-  width: 55vw; height: 55vw;
-  bottom: -26vw; right: -14vw;
-  background: radial-gradient(circle, rgba(34, 46, 61, 0.85), transparent 60%);
+  width: 58vw; height: 58vw;
+  bottom: -28vw; right: -16vw;
+  background: radial-gradient(circle, rgba(70, 96, 168, 0.5), transparent 62%);
+}
+.bg-glow--c {
+  width: 38vw; height: 38vw;
+  top: 36%; left: 52%;
+  background: radial-gradient(circle, rgba(139, 123, 240, 0.22), transparent 64%);
+}
+/* feTurbulence + feDisplacementMap refracts these light streaks — the real
+   primitive from the Aave article, applied to a safe decorative layer */
+.bg-refract {
+  position: absolute;
+  inset: -12%;
+  pointer-events: none;
+  opacity: 0.7;
+  mix-blend-mode: screen;
+  background:
+    radial-gradient(42% 30% at 24% 28%, rgba(110, 242, 220, 0.12), transparent 70%),
+    radial-gradient(40% 28% at 78% 66%, rgba(139, 123, 240, 0.12), transparent 72%),
+    radial-gradient(30% 22% at 60% 12%, rgba(35, 196, 174, 0.1), transparent 70%);
+  filter: url(#liquidGlass);
 }
 .bg-grain {
   position: absolute; inset: 0;
   pointer-events: none;
-  opacity: 0.04;
+  opacity: 0.045;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
-/* ───────────────────────── buttons & chips ───────────────────────── */
+/* =========================================================================
+   buttons & chips
+   ========================================================================= */
 .btn {
   display: inline-flex;
   align-items: center;
@@ -127,20 +244,33 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
 }
 .btn i { font-size: 1.15em; }
 .btn--primary {
-  background: linear-gradient(135deg, var(--teal-bright), var(--teal));
+  position: relative;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0) 46%),
+    linear-gradient(135deg, var(--teal-bright), var(--teal));
   color: var(--teal-ink);
-  box-shadow: 0 8px 24px rgba(35, 196, 174, 0.22);
+  box-shadow: 0 8px 24px rgba(35, 196, 174, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.45), inset 0 -1px 0 rgba(4, 20, 26, 0.25);
 }
 .btn--primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 14px 34px rgba(35, 196, 174, 0.34);
+  box-shadow: 0 16px 38px rgba(35, 196, 174, 0.42),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5), inset 0 -1px 0 rgba(4, 20, 26, 0.25);
 }
 .btn--ghost {
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--glass-gloss), var(--glass-tint-chip);
   color: var(--text);
-  border-color: var(--line-strong);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-inset), 0 8px 22px -12px rgba(0, 0, 0, 0.5);
 }
-.btn--ghost:hover { border-color: var(--teal); background: var(--teal-soft); transform: translateY(-2px); }
+.btn--ghost:hover {
+  color: var(--teal-bright);
+  background:
+    linear-gradient(180deg, rgba(110, 242, 220, 0.12), rgba(255, 255, 255, 0) 60%),
+    var(--glass-tint-strong);
+  transform: translateY(-2px);
+  box-shadow: var(--glass-inset), 0 14px 30px -14px rgba(35, 196, 174, 0.4);
+}
 .btn:active { transform: translateY(0) scale(0.985); }
 .btn--sm { padding: 9px 16px; font-size: 0.9rem; }
 .btn--lg { padding: 16px 30px; font-size: 1.06rem; }
@@ -151,12 +281,14 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
   justify-content: center;
   width: 40px; height: 40px;
   border-radius: var(--pill);
-  border: 1px solid var(--line);
+  border: 1px solid var(--glass-border);
+  background: var(--glass-gloss), var(--glass-tint-chip);
+  box-shadow: var(--glass-inset);
   color: var(--text-dim);
   font-size: 1.3rem;
   transition: color 0.2s var(--ease), border-color 0.2s var(--ease), background 0.2s var(--ease);
 }
-.icon-link:hover { color: var(--teal-bright); border-color: var(--teal); background: var(--teal-soft); }
+.icon-link:hover { color: var(--teal-bright); border-color: rgba(110, 242, 220, 0.4); background: var(--teal-soft); }
 
 .eyebrow {
   display: inline-block;
@@ -168,22 +300,26 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
   margin-bottom: 16px;
 }
 
-/* ───────────────────────── nav ───────────────────────── */
+/* =========================================================================
+   nav — floating glass pill
+   ========================================================================= */
 .nav {
   position: sticky;
-  top: 0;
+  top: 12px;
   z-index: 50;
   display: flex;
   align-items: center;
   gap: 20px;
-  height: 66px;
-  padding: 0 24px;
+  height: 64px;
+  padding: 0 14px 0 22px;
   max-width: var(--maxw);
-  margin: 0 auto;
-  background: rgba(11, 17, 25, 0.66);
-  backdrop-filter: blur(16px) saturate(150%);
-  -webkit-backdrop-filter: blur(16px) saturate(150%);
-  border-bottom: 1px solid var(--line);
+  margin: 12px auto 0;
+  width: calc(100% - 32px);
+  border-radius: var(--pill);
+  /* override: lighter, brighter glass for the floating bar */
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0) 60%),
+    rgba(10, 16, 24, 0.55);
 }
 .brand { display: inline-flex; align-items: center; gap: 10px; font-weight: 640; letter-spacing: -0.01em; }
 .brand__mark { border-radius: 8px; display: block; }
@@ -193,7 +329,9 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
 .nav__links a:hover { color: var(--text); }
 .nav__actions { display: flex; align-items: center; gap: 12px; margin-left: 8px; }
 
-/* ───────────────────────── layout helpers ───────────────────────── */
+/* =========================================================================
+   layout helpers
+   ========================================================================= */
 .section {
   max-width: var(--maxw);
   margin: 0 auto;
@@ -203,21 +341,9 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
 .section__title { font-size: clamp(1.7rem, 3.4vw, 2.55rem); }
 .section__lead { color: var(--text-dim); font-size: 1.08rem; max-width: 56ch; margin-top: 18px; }
 
-/* ───────────────────────── hero diagram ───────────────────────── */
-.hero__diagram { position: relative; margin: 0; width: min(860px, 100%); }
-.hero__diagram::before {
-  content: "";
-  position: absolute;
-  inset: 8% 4% 12%;
-  z-index: -1;
-  border-radius: 50%;
-  background: radial-gradient(58% 58% at 50% 46%, rgba(35, 196, 174, 0.32), transparent 70%);
-  filter: blur(46px);
-  opacity: 0.85;
-}
-.hero__diagram-img { display: block; width: 100%; height: auto; animation: float 7s ease-in-out infinite; }
-
-/* ───────────────────────── hero ───────────────────────── */
+/* =========================================================================
+   hero
+   ========================================================================= */
 .hero {
   max-width: var(--maxw);
   margin: 0 auto;
@@ -250,7 +376,7 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
   text-align: center;
   align-items: start;
   min-height: 0;
-  gap: 30px;
+  gap: 36px;
   padding-top: 60px;
   padding-bottom: 68px;
 }
@@ -260,19 +386,41 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
 .hero--centered .hero__cta { justify-content: center; }
 .hero--centered .hero__stage { width: 100%; }
 
-/* hero stage: the real app icon presented as an "app glamour" tile */
+/* hero diagram — the super-app SVG floats inside a frosted glass slab */
 .hero__stage { display: flex; justify-content: center; }
+.hero__diagram {
+  position: relative;
+  margin: 0;
+  width: min(760px, 100%);
+  padding: clamp(20px, 4vw, 40px);
+  border-radius: var(--radius-lg);
+  background: var(--glass-gloss), var(--glass-tint-strong);
+  animation: float 7s ease-in-out infinite;
+}
+/* soft teal aura blooming behind the glass slab */
+.hero__diagram::before {
+  content: "";
+  position: absolute;
+  inset: 4% 6% 8%;
+  z-index: -1;
+  border-radius: 50%;
+  background: radial-gradient(58% 58% at 50% 44%, rgba(35, 196, 174, 0.38), transparent 70%);
+  filter: blur(52px);
+  opacity: 0.9;
+}
+.hero__diagram-img { display: block; width: 100%; height: auto; position: relative; }
+
+/* hero "app glamour" card (kept for the alternate hero layout) */
 .appcard {
   position: relative;
   width: min(380px, 100%);
   padding: 38px 32px 30px;
   text-align: center;
-  background: linear-gradient(180deg, var(--surface-2), var(--surface));
-  border: 1px solid var(--line-strong);
   border-radius: var(--radius-lg);
-  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  background: var(--glass-gloss), var(--glass-tint-strong);
   animation: float 7s ease-in-out infinite;
 }
+.appcard > * { position: relative; z-index: 2; }
 .appcard__glow {
   position: absolute;
   inset: -2px;
@@ -293,8 +441,8 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
   margin: 22px auto 0;
   padding: 10px 16px;
   width: fit-content;
-  background: rgba(0, 0, 0, 0.28);
-  border: 1px solid var(--line);
+  background: rgba(8, 13, 20, 0.4);
+  border: 1px solid var(--glass-border);
   border-radius: var(--pill);
 }
 .recorder__dot {
@@ -317,13 +465,12 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
 .track {
   font-size: 0.78rem; font-weight: 560;
   padding: 5px 12px; border-radius: var(--pill);
-  border: 1px solid var(--line);
+  border: 1px solid var(--glass-border);
+  background: var(--glass-tint-chip);
 }
 .track--me { color: var(--teal-bright); border-color: rgba(35, 196, 174, 0.4); background: var(--teal-soft); }
 .track--them { color: var(--text-dim); }
 
-/* Hero transcript snippet — shows the Me/Them transcript + a search match,
-   so the abstract app card also hints at the product's core artifact. */
 .appcard__lines {
   margin: 18px 0 0;
   padding: 12px 14px;
@@ -331,8 +478,8 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
   display: flex;
   flex-direction: column;
   gap: 8px;
-  background: rgba(0, 0, 0, 0.28);
-  border: 1px solid var(--line);
+  background: rgba(8, 13, 20, 0.4);
+  border: 1px solid var(--glass-border);
   border-radius: var(--radius-sm);
 }
 .appcard__lines li { display: flex; gap: 9px; align-items: baseline; }
@@ -360,74 +507,85 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
   100% { box-shadow: 0 0 0 0 rgba(251, 191, 36, 0); }
 }
 
-/* ───────────────────────── proof strip ───────────────────────── */
+/* =========================================================================
+   proof strip — one glass card, divided
+   ========================================================================= */
 .proof {
-  max-width: var(--maxw);
+  max-width: calc(var(--maxw) - 48px);
   margin: 0 auto;
-  padding: 8px 24px 8px;
+  padding: 4px;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 4px;
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
+  gap: 0;
+  border-radius: var(--radius-lg);
 }
-.proof__item { display: flex; gap: 14px; align-items: center; padding: 26px 24px; }
-.proof__item + .proof__item { border-left: 1px solid var(--line); }
+.proof__item { display: flex; gap: 14px; align-items: center; padding: 26px 28px; }
+.proof__item + .proof__item { box-shadow: inset 1px 0 0 var(--glass-border); }
 .proof__item i { font-size: 1.7rem; color: var(--teal-bright); flex-shrink: 0; }
 .proof__item strong { display: block; font-size: 0.98rem; font-weight: 620; }
 .proof__item span { color: var(--text-dim); font-size: 0.9rem; }
 
-/* ───────────────────────── features bento ───────────────────────── */
+/* =========================================================================
+   features bento — glass tiles
+   ========================================================================= */
 .bento { display: grid; grid-template-columns: 1fr; gap: 16px; }
 .tile {
-  position: relative;
   padding: 28px;
-  background: var(--surface);
-  border: 1px solid var(--line);
   border-radius: var(--radius);
-  transition: transform 0.3s var(--ease), border-color 0.3s var(--ease), box-shadow 0.3s var(--ease);
+  transition: transform 0.3s var(--ease), box-shadow 0.3s var(--ease), background 0.3s var(--ease);
 }
+.tile > * { position: relative; z-index: 2; }
 .tile:hover {
   transform: translateY(-4px);
-  border-color: rgba(35, 196, 174, 0.4);
-  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.35);
+  box-shadow: var(--glass-inset), 0 30px 60px -20px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(110, 242, 220, 0.18), 0 18px 50px -24px rgba(35, 196, 174, 0.45);
 }
 .tile__icon { font-size: 2rem; color: var(--teal-bright); display: block; margin-bottom: 16px; }
 .tile h3 { font-size: 1.22rem; margin-bottom: 10px; }
 .tile p { color: var(--text-dim); font-size: 0.98rem; }
 .tile code { font-family: var(--mono); font-size: 0.86em; color: var(--teal-bright); }
-.tile--flag { background: linear-gradient(160deg, rgba(35, 196, 174, 0.10), var(--surface) 55%); }
+.tile--flag {
+  background:
+    linear-gradient(160deg, rgba(35, 196, 174, 0.16), rgba(255, 255, 255, 0) 52%),
+    var(--glass-gloss), var(--glass-tint-strong);
+}
 .tile--flag h3 { font-size: 1.5rem; }
 .tile__tags { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 18px; }
 .tile__tags li {
   font-size: 0.8rem; color: var(--text-dim);
   padding: 5px 12px; border-radius: var(--pill);
-  border: 1px solid var(--line); background: rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--glass-border);
+  background: var(--glass-tint-chip);
 }
 .tile--cli { display: grid; gap: 22px; align-content: center; }
 .tile--cli .tile__icon { margin-bottom: 12px; }
 
-/* code blocks */
+/* code blocks — dark glass slabs */
 .code {
   font-family: var(--mono);
   font-size: 0.86rem;
   line-height: 1.7;
   color: var(--text-dim);
-  background: rgba(0, 0, 0, 0.34);
-  border: 1px solid var(--line);
+  background: rgba(4, 8, 13, 0.5);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  border: 1px solid var(--glass-border);
   border-radius: var(--radius-sm);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
   padding: 18px 20px;
   margin: 0;
   overflow-x: auto;
   white-space: pre;
 }
-.code--inline { background: rgba(0, 0, 0, 0.28); }
+.code--inline { background: rgba(4, 8, 13, 0.42); }
 .c-prompt { color: var(--teal); user-select: none; margin-right: 4px; }
 .c-str { color: #f6c177; }
 .c-flag { color: var(--teal-bright); }
 .c-op { color: var(--text-faint); }
 
-/* ───────────────────────── how it works ───────────────────────── */
+/* =========================================================================
+   how it works — glass step pills
+   ========================================================================= */
 .steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 32px; position: relative; }
 .steps::before {
   content: "";
@@ -438,11 +596,13 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
 }
 .step { position: relative; }
 .step__num {
+  position: relative;
   display: inline-flex; align-items: center; justify-content: center;
   width: 56px; height: 56px;
   border-radius: var(--pill);
-  background: var(--bg-2);
-  border: 1px solid var(--line-strong);
+  background: var(--glass-gloss), var(--glass-tint-strong);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-inset), 0 10px 24px -12px rgba(0, 0, 0, 0.6);
   color: var(--teal-bright);
   font-weight: 680; font-size: 1.15rem;
   font-variant-numeric: tabular-nums;
@@ -451,7 +611,9 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
 .step h3 { font-size: 1.22rem; margin-bottom: 10px; }
 .step p { color: var(--text-dim); }
 
-/* ───────────────────────── cotyping spotlight ───────────────────────── */
+/* =========================================================================
+   cotyping spotlight — glass mock window
+   ========================================================================= */
 .spotlight {
   display: grid;
   grid-template-columns: 1.05fr 0.95fr;
@@ -468,26 +630,29 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
 }
 
 .cotype {
-  position: relative;
-  background: linear-gradient(180deg, var(--surface-2), var(--surface));
-  border: 1px solid var(--line-strong);
   border-radius: var(--radius);
   padding: 0 0 22px;
-  box-shadow: 0 26px 60px rgba(0, 0, 0, 0.4);
   overflow: hidden;
+  background: var(--glass-gloss), var(--glass-tint-strong);
 }
-.cotype.is-focused { border-color: rgba(35, 196, 174, 0.5); box-shadow: 0 0 0 3px var(--teal-soft), 0 26px 60px rgba(0, 0, 0, 0.4); }
+.cotype > *:not(.cotype__bar) { position: relative; z-index: 2; }
+.cotype.is-focused {
+  box-shadow: var(--glass-inset), var(--glass-shadow), 0 0 0 3px var(--teal-soft);
+}
 .cotype__bar {
+  position: relative;
+  z-index: 2;
   display: flex; align-items: center; gap: 7px;
   padding: 14px 18px;
-  border-bottom: 1px solid var(--line);
-  background: rgba(0, 0, 0, 0.18);
+  border-bottom: 1px solid var(--glass-border);
+  background: rgba(8, 13, 20, 0.32);
 }
 .cotype__chrome { width: 11px; height: 11px; border-radius: 50%; background: var(--line-strong); }
 .cotype__app { margin-left: 10px; font-size: 0.82rem; color: var(--text-faint); }
 .cotype__label { display: block; padding: 20px 22px 6px; font-size: 0.8rem; color: var(--text-faint); }
 .cotype__field {
   position: relative;
+  z-index: 2;
   padding: 4px 22px 8px;
   font-size: 1.1rem;
   line-height: 1.7;
@@ -515,35 +680,37 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
   font: inherit;
   padding: 4px 22px;
   outline: none;
+  z-index: 3;
 }
 .cotype__hint { padding: 4px 22px 0; color: var(--text-faint); font-size: 0.85rem; }
 kbd {
+  position: relative;
   font-family: var(--mono);
   font-size: 0.78rem;
   padding: 2px 7px;
   border-radius: 6px;
-  background: rgba(0, 0, 0, 0.4);
-  border: 1px solid var(--line-strong);
+  background: rgba(8, 13, 20, 0.5);
+  border: 1px solid var(--glass-border);
   border-bottom-width: 2px;
   color: var(--text);
 }
 @keyframes blink { 50% { opacity: 0; } }
 
-/* ───────────────────────── download ───────────────────────── */
+/* =========================================================================
+   download — hero glass panel
+   ========================================================================= */
 .download { display: flex; justify-content: center; }
 .download__panel {
-  position: relative;
   max-width: 720px;
   width: 100%;
   text-align: center;
   padding: 56px 40px;
-  background: linear-gradient(180deg, var(--surface-2), var(--surface));
-  border: 1px solid var(--line-strong);
   border-radius: var(--radius-lg);
-  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.4);
+  background: var(--glass-gloss), var(--glass-tint-strong);
 }
+.download__panel > * { position: relative; z-index: 2; }
 .download__panel .eyebrow { margin-top: 6px; }
-.download__icon { width: 80px; height: 80px; border-radius: 20px; }
+.download__icon { width: 80px; height: 80px; border-radius: 20px; box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4); }
 .download__panel .btn--lg { margin-top: 30px; }
 .download__sub { margin-top: 16px; color: var(--text-faint); font-size: 0.9rem; }
 .download__sub a { color: var(--teal-bright); }
@@ -556,12 +723,20 @@ kbd {
 }
 .reqs li { display: inline-flex; align-items: center; gap: 8px; }
 .reqs i { color: var(--teal-bright); font-size: 1.1rem; }
-.build { margin-top: 34px; text-align: left; border-top: 1px solid var(--line); padding-top: 28px; }
+.build { margin-top: 34px; text-align: left; border-top: 1px solid var(--glass-border); padding-top: 28px; }
 .build__label { color: var(--text-dim); font-size: 0.92rem; margin-bottom: 12px; text-align: center; }
 
-/* ───────────────────────── faq ───────────────────────── */
-.faq__list { max-width: 820px; }
-.qa { border-bottom: 1px solid var(--line); }
+/* =========================================================================
+   faq — glass list container
+   ========================================================================= */
+.faq__list {
+  max-width: 820px;
+  padding: 6px 26px;
+  border-radius: var(--radius-lg);
+}
+.faq__list > * { position: relative; z-index: 2; }
+.qa { border-bottom: 1px solid var(--glass-border); }
+.qa:last-child { border-bottom: 0; }
 .qa summary {
   display: flex; align-items: center; justify-content: space-between;
   gap: 16px;
@@ -579,12 +754,14 @@ kbd {
 .qa[open] summary i { transform: rotate(45deg); }
 .qa p { color: var(--text-dim); padding: 0 4px 24px; max-width: 70ch; }
 
-/* ───────────────────────── footer ───────────────────────── */
+/* =========================================================================
+   footer
+   ========================================================================= */
 .footer {
   max-width: var(--maxw);
   margin: 0 auto;
   padding: 64px 24px 56px;
-  border-top: 1px solid var(--line);
+  border-top: 1px solid var(--glass-border);
   display: grid;
   grid-template-columns: 2fr 1fr 1fr;
   gap: 40px;
@@ -595,9 +772,11 @@ kbd {
 .footer__col h4 { font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-faint); margin-bottom: 16px; }
 .footer__col a { display: block; color: var(--text-dim); padding: 6px 0; font-size: 0.95rem; transition: color 0.2s var(--ease); }
 .footer__col a:hover { color: var(--teal-bright); }
-.footer__legal { grid-column: 1 / -1; border-top: 1px solid var(--line); padding-top: 26px; color: var(--text-faint); font-size: 0.88rem; }
+.footer__legal { grid-column: 1 / -1; border-top: 1px solid var(--glass-border); padding-top: 26px; color: var(--text-faint); font-size: 0.88rem; }
 
-/* ───────────────────────── reveal animation ───────────────────────── */
+/* =========================================================================
+   reveal animation
+   ========================================================================= */
 .reveal { opacity: 0; transform: translateY(20px); transition: opacity 0.7s var(--ease), transform 0.7s var(--ease); transition-delay: var(--rd, 0ms); }
 .reveal.in { opacity: 1; transform: none; }
 .bento .tile:nth-child(2) { --rd: 70ms; }
@@ -610,7 +789,9 @@ kbd {
 .proof__item:nth-child(2) { --rd: 90ms; }
 .proof__item:nth-child(3) { --rd: 180ms; }
 
-/* ───────────────────────── responsive ───────────────────────── */
+/* =========================================================================
+   responsive
+   ========================================================================= */
 @media (min-width: 600px) {
   .bento { grid-template-columns: repeat(2, 1fr); }
   .bento > :nth-child(1), .bento > :nth-child(6) { grid-column: span 2; }
@@ -638,7 +819,7 @@ kbd {
   .section { padding: 72px 20px; }
   .hero { padding: 36px 20px 64px; }
   .proof { grid-template-columns: 1fr; }
-  .proof__item + .proof__item { border-left: 0; border-top: 1px solid var(--line); }
+  .proof__item + .proof__item { box-shadow: inset 0 1px 0 var(--glass-border); }
   .steps { grid-template-columns: 1fr; gap: 28px; }
   .steps::before { display: none; }
   .footer { grid-template-columns: 1fr 1fr; }
@@ -652,14 +833,37 @@ kbd {
   .nav .btn { width: auto; }
 }
 
-/* ───────────────────────── reduced motion ───────────────────────── */
+/* =========================================================================
+   accessibility fallbacks
+   ========================================================================= */
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
   *, *::before, *::after { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; transition-duration: 0.001ms !important; }
   .reveal { opacity: 1; transform: none; }
-  .appcard { animation: none; }
-  .hero__diagram-img { animation: none; }
+  .appcard, .hero__diagram { animation: none; }
   .wave span { transform: scaleY(0.6); }
   .wave span:nth-child(odd) { transform: scaleY(0.85); }
   .ct-caret { animation: none; }
+}
+
+/* If the browser can't frost (or the user prefers less transparency),
+   fall back to solid surfaces so contrast and depth survive. */
+@media (prefers-reduced-transparency: reduce) {
+  .nav, .proof, .tile, .cotype, .appcard, .download__panel, .hero__diagram,
+  .faq__list, .btn--ghost, .icon-link, .step__num, .recorder, .track,
+  .tile__tags li, kbd {
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+    background: var(--surface);
+  }
+  .bg-refract { display: none; }
+}
+@supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+  .nav, .proof, .tile, .cotype, .appcard, .download__panel, .hero__diagram, .faq__list {
+    background: var(--surface);
+  }
+  .nav { background: rgba(11, 17, 25, 0.96); }
+  .btn--ghost, .icon-link, .step__num, .recorder, .track, .tile__tags li, kbd {
+    background: var(--surface-2);
+  }
 }


### PR DESCRIPTION
## Summary

Cotyping (inline ghost-text) now decodes a **dedicated** model **in-process** via `libllama`, instead of always going over HTTP to the background `llama-server`. The default cotyping model is **Gemma 4 E4B Q5 XL** (~6.66 GB GGUF), and the old "Use a separate model for cotyping" UI toggle is removed — cotyping is always its own model.

The localhost `llama-server` HTTP path is retained as the **fallback** (non-GGUF backends, runtime toggled off, or load/decode failure). Everything remains **100% on-device** — the "HTTP fallback" is localhost (`127.0.0.1`), not a cloud call.

## Architecture

```
CotypingCoordinator
  └─ CotypingEngineSelector            // routes per-completion
       ├─ LocalLlamaCotypingEngine     // in-process, default
       │    └─ LlamaCotypingRuntime    // actor: persistent KV cache, suffix re-prefill, libllama b9789
       └─ HTTP llama-server            // fallback
```

- **Persistent KV cache** with incremental prefill — re-prefills only the typed suffix (`IncrementalPrefill.commonPrefixLength`).
- **Memory-pressure unload** — frees the resident model under `DispatchSourceMemoryPressure`.
- **Route-away unload** — toggling the runtime off (or the model failing to resolve) tears down the cached engine and unloads the ~6.66 GB model rather than leaving it resident.
- **Apple Silicon only**; the Settings toggle is disabled on Intel.

## Settings

- New `AppSettings.cotypingInProcessRuntime` (default **on**), exposed as a Settings toggle ("Use the fast in-process runtime"). Backward-compatible `Codable` decode; the removed `cotypingUseSeparateModel` key is ignored without throwing.

## Tests

- **412 tests, 0 failures** (`xcodebuild test -only-testing:LokalBotTests`).
- New coverage: incremental-prefix length, sampler-spec mapping, runtime memory-pressure/KV-reuse, selector routing + route-away teardown + `LlamaRuntimeError → HTTP` fallback, A/B benchmark math.
- Model-dependent runtime tests are `XCTSkip`-gated when the bundled GGUF is absent (CI-safe).

## Review status

Built and reviewed via Subagent-Driven Development (10 TDD tasks, per-task spec+quality review, final whole-branch review, and an adversarial multi-lens re-review of the hardening commit). **0 Critical / 0 Important** outstanding. Three confirmed **Minor** items:

- **M3 — fixed** (`f62e220`): renamed an over-claiming selector fallback test to reflect that it proves the selector wiring, not the runtime throw.
- **M2 — no action**: the throw-on-decode-failure change is a behavioral *improvement* (it no longer surfaces a partial the stop-policy hadn't accepted).
- **M1 — logged, deferred**: when `cotypingStreamSuggestionsWhileGenerating` is enabled (**default off**) and a rare mid-generation decode fault throws after partials were painted, a stale local ghost can linger for the HTTP-fallback window (transient, self-healing; a precisely-timed Tab could insert it). A correct fix is coordinator-level and disproportionate to land here.

## Manual verification (recommended before merge — needs a real model loaded)

- [ ] **TTFT / p95 A/B** — `CotypingBenchmarkRunner.runAB(...)` / `Scripts/compare-cotyping.sh`: first ghost token < ~200–300 ms post-warmup, p95 well under 2000 ms, beating HTTP.
- [ ] **No main-thread hitch** — Instruments (Time Profiler) while typing with a generation in flight.
- [ ] **Instant cancellation** — fast typing; superseding keystrokes drop stale ghosts.
- [ ] **Fallback paths** — toggle runtime off → suggestions still come from `llama-server`; rename the GGUF → graceful fallback, no crash.

## Notes

- `LokalBot.xcodeproj` is generated via XcodeGen (`project.yml`) and gitignored — not part of this diff.
- llama.cpp pinned at release `b9789`; only the vendored header + prebuilt `libllama` dylib are used (both gitignored under `Vendor/`).
