### PR TITLE
Redesign Phase 0: Slate & Signal design-system groundwork

### DIFF
--- a/LokalBot/Dictation/DictationOverlayView.swift
+++ b/LokalBot/Dictation/DictationOverlayView.swift
@@ -114,7 +114,7 @@ struct DictationOverlayView: View {
                 }
                 Spacer(minLength: 10)
                 if dictation.state.isRecording {
-                    DictationWaveform()
+                    LiveWaveform().padding(.trailing, 8)
                 }
                 cancelButton
             }
@@ -175,7 +175,7 @@ struct DictationOverlayView: View {
             PulsingDictationDot()
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.leading, 15)
-            DictationWaveform()
+            LiveWaveform().padding(.trailing, 8)
             cancelButton
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .padding(.trailing, 10)
@@ -243,29 +243,5 @@ struct DictationOverlayView: View {
 private struct PulsingDictationDot: View {
     var body: some View {
         StatusDot(color: Brand.recording, size: 7, pulses: true)
-    }
-}
-
-private struct DictationWaveform: View {
-    private let barCount = 9
-
-    var body: some View {
-        SwiftUI.TimelineView(.animation) { timeline in
-            HStack(alignment: .center, spacing: 3) {
-                ForEach(0..<barCount, id: \.self) { index in
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(Color.accentColor)
-                        .frame(width: 4, height: height(for: index, at: timeline.date))
-                }
-            }
-            .frame(height: 18)
-            .padding(.trailing, 8)
-        }
-    }
-
-    private func height(for index: Int, at date: Date) -> CGFloat {
-        let t = date.timeIntervalSinceReferenceDate * 5.2
-        let wave = (sin(t + Double(index) * 0.72) + 1) / 2
-        return max(3, min(18, 3 + CGFloat(pow(wave, 0.7)) * 15))
     }
 }

--- a/LokalBot/Dictation/DictationOverlayView.swift
+++ b/LokalBot/Dictation/DictationOverlayView.swift
@@ -74,10 +74,7 @@ struct DictationOverlayView: View {
             }
         }
         .frame(width: width, height: height)
-        .background(.background.opacity(0.98), in: RoundedRectangle(cornerRadius: radius))
-        .overlay(
-            RoundedRectangle(cornerRadius: radius)
-                .strokeBorder(Color.primary.opacity(0.12), lineWidth: 1))
+        .hudCapsule(radius: radius, shadowed: false)
         .animation(.snappy(duration: 0.28), value: dictation.state)
         .animation(.snappy(duration: 0.22), value: dictation.liveTranscript)
     }

--- a/LokalBot/Support/Brand.swift
+++ b/LokalBot/Support/Brand.swift
@@ -19,6 +19,19 @@ enum Brand {
     /// "Them" speaker (system track) — other participants.
     static let them = Color(red: 0.49, green: 0.62, blue: 0.76)
 
+    /// The icon's dark plate, brought into the app for hero surfaces and
+    /// HUDs. Deliberately stays dark in both appearances — hero surfaces
+    /// read as "plated" like the icon, so content on slate must use fixed
+    /// light foregrounds (white / tealBright), never semantic label colors.
+    static let slate = Color(red: 0.059, green: 0.090, blue: 0.165)          // #0f172a
+    static let slateElevated = Color(red: 0.118, green: 0.161, blue: 0.231)  // #1e293b
+
+    /// Plate gradient for hero panels — elevated slate falling to slate,
+    /// echoing the icon's plate lighting.
+    static let plateGradient = LinearGradient(
+        colors: [slateElevated, slate],
+        startPoint: .topLeading, endPoint: .bottomTrailing)
+
     /// Vertical gradient used on hero surfaces (onboarding, empty states) to
     /// echo the icon body without leaning on the system accent.
     static let gradient = LinearGradient(

--- a/LokalBot/Support/DesignSystem.swift
+++ b/LokalBot/Support/DesignSystem.swift
@@ -18,6 +18,8 @@ extension Brand {
         static let panel: CGFloat = 12
         /// Hero surfaces (getting-started card, onboarding cards).
         static let card: CGFloat = 14
+        /// Floating capsules (dictation HUD, banners, the recording pill).
+        static let hud: CGFloat = 20
     }
 }
 
@@ -141,5 +143,38 @@ struct IconTile: View {
                 .foregroundStyle(.white)
         }
         .frame(width: size, height: size)
+    }
+}
+
+// MARK: - Section header
+
+/// Uppercase caption header for list groupings (meeting-list day labels,
+/// menu-bar Recent, inspector headings) — one treatment everywhere.
+struct SectionHeader: View {
+    let text: String
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.secondary)
+    }
+}
+
+// MARK: - Stat tile
+
+/// Icon + value + label stat chip (timeline header stats, Type stats,
+/// Settings metrics). The value keeps monospaced digits so rows align.
+struct StatTile: View {
+    let icon: String
+    let value: String
+    let label: String
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: icon).font(.caption).foregroundStyle(.secondary)
+            Text(value).font(.callout.weight(.semibold).monospacedDigit())
+            Text(label).font(.caption).foregroundStyle(.secondary)
+        }
+        .chipChrome()
     }
 }

--- a/LokalBot/Support/DesignSystemPanels.swift
+++ b/LokalBot/Support/DesignSystemPanels.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+// MARK: - Hero panel
+
+/// Slate "plate" card echoing the app icon: dark in both appearances, with
+/// a faint bright-teal hairline. Content on it must use fixed light
+/// foregrounds (white / Brand.tealBright), never semantic label colors —
+/// the plate does not flip with the system appearance.
+struct HeroPanel<Content: View>: View {
+    var radius: CGFloat = Brand.Radius.card
+    @ViewBuilder var content: Content
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    var body: some View {
+        content
+            .padding(14)
+            .background(Brand.plateGradient,
+                        in: RoundedRectangle(cornerRadius: radius, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .strokeBorder(contrast == .increased
+                                  ? Color.white.opacity(0.5)
+                                  : Brand.tealBright.opacity(0.14)))
+    }
+}
+
+// MARK: - HUD capsule
+
+extension View {
+    /// The one floating-surface chrome: material fill, hairline border, HUD
+    /// radius, soft shadow. Shared by the dictation HUD, the audio-source
+    /// banner, and the recording pill so every floating capsule reads as one
+    /// family. Pass `shadowed: false` inside borderless NSPanels sized
+    /// exactly to their content — a SwiftUI shadow would clip at the panel
+    /// edge there.
+    func hudCapsule(radius: CGFloat = Brand.Radius.hud, shadowed: Bool = true) -> some View {
+        background(.regularMaterial,
+                   in: RoundedRectangle(cornerRadius: radius, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: radius, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.12), lineWidth: 1))
+            .shadow(color: .black.opacity(shadowed ? 0.12 : 0), radius: shadowed ? 6 : 0, y: shadowed ? 3 : 0)
+    }
+}

--- a/LokalBot/Support/LiveWaveform.swift
+++ b/LokalBot/Support/LiveWaveform.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// Pure math behind the animated capture waveform, extracted so bar heights
+/// are unit-testable without driving SwiftUI's TimelineView. Same curve as
+/// the original dictation-HUD waveform.
+enum LiveWaveformMath {
+    /// Height of bar `index` at absolute time `time`, clamped to
+    /// `minHeight...maxHeight`.
+    static func height(index: Int, time: TimeInterval,
+                       minHeight: CGFloat = 3, maxHeight: CGFloat = 18) -> CGFloat {
+        let phase = time * 5.2
+        let wave = (sin(phase + Double(index) * 0.72) + 1) / 2
+        return max(minHeight,
+                   min(maxHeight, minHeight + CGFloat(pow(wave, 0.7)) * (maxHeight - minHeight)))
+    }
+}
+
+/// The one "audio is flowing" motion signature: tinted animated bars shared
+/// by the dictation HUD, the menu-bar status card, and the recording pill.
+/// Freezes at its time-zero shape under Reduce Motion.
+struct LiveWaveform: View {
+    var barCount: Int = 9
+    var barWidth: CGFloat = 4
+    var maxHeight: CGFloat = 18
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        SwiftUI.TimelineView(.animation(minimumInterval: nil, paused: reduceMotion)) { timeline in
+            HStack(alignment: .center, spacing: 3) {
+                ForEach(0..<barCount, id: \.self) { index in
+                    RoundedRectangle(cornerRadius: barWidth / 2)
+                        .fill(.tint)
+                        .frame(width: barWidth,
+                               height: LiveWaveformMath.height(
+                                   index: index,
+                                   time: reduceMotion ? 0 : timeline.date.timeIntervalSinceReferenceDate,
+                                   maxHeight: maxHeight))
+                }
+            }
+            .frame(height: maxHeight)
+        }
+    }
+}

--- a/LokalBot/Views/AudioSourceBanner.swift
+++ b/LokalBot/Views/AudioSourceBanner.swift
@@ -40,10 +40,8 @@ struct AudioSourceBanner: View {
             .buttonStyle(.plain)
             .help("Don't ask for this app this session.")
         }
-        .padding(.horizontal, 12).padding(.vertical, 9)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
-        .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(.tint.opacity(0.35)))
-        .shadow(color: .black.opacity(0.12), radius: 6, y: 3)
+        .padding(.horizontal, 14).padding(.vertical, 9)
+        .hudCapsule()
         .frame(maxWidth: 480)
     }
 }

--- a/LokalBot/Views/MainWindowView.swift
+++ b/LokalBot/Views/MainWindowView.swift
@@ -242,8 +242,7 @@ struct MainWindowView: View {
                         meetingRow(meeting).tag(meeting.id)
                     }
                 } header: {
-                    Text(group.label).font(.caption2.weight(.semibold))
-                        .foregroundStyle(.secondary)
+                    SectionHeader(text: group.label)
                 }
             }
         }

--- a/LokalBot/Views/MainWindowView.swift
+++ b/LokalBot/Views/MainWindowView.swift
@@ -249,13 +249,13 @@ struct MainWindowView: View {
         .accessibilityIdentifier("meeting.list")
         .overlay(alignment: .topTrailing) {
             if app.isRecording {
-                HStack(spacing: 5) {
+                HStack(spacing: 6) {
                     StatusDot(color: Brand.recording, size: 7)
                     Text("recording…").font(.caption)
+                    LiveWaveform(barCount: 5, barWidth: 2.5, maxHeight: 10)
                 }
-                .padding(.horizontal, 9).padding(.vertical, 4)
-                .background(.background.opacity(0.9), in: Capsule())
-                .overlay(Capsule().strokeBorder(.quaternary))
+                .padding(.horizontal, 10).padding(.vertical, 5)
+                .hudCapsule()
                 .padding(10)
             }
         }

--- a/LokalBot/Views/MainWindowView.swift
+++ b/LokalBot/Views/MainWindowView.swift
@@ -822,22 +822,25 @@ struct GettingStartedCard: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
-                HStack(spacing: 14) {
-                    IconTile(systemImage: "waveform.badge.magnifyingglass",
-                             tint: Brand.teal, size: 48)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Welcome to LokalBot").font(.title2.bold())
-                        Text("Record meetings, get the recap, and search everything — all on-device.")
-                            .font(.callout).foregroundStyle(.secondary)
+                HeroPanel(radius: Brand.Radius.card) {
+                    HStack(spacing: 14) {
+                        IconTile(systemImage: "waveform.badge.magnifyingglass",
+                                 tint: Brand.teal, size: 48)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Welcome to LokalBot").font(.title2.bold())
+                                .foregroundStyle(.white)
+                            Text("Record meetings, get the recap, and search everything — all on-device.")
+                                .font(.callout).foregroundStyle(.white.opacity(0.65))
+                        }
+                        Spacer()
+                        Button { dismissed = true } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.title3).foregroundStyle(.white.opacity(0.4))
+                        }
+                        .buttonStyle(.plain)
+                        .help("Dismiss")
+                        .accessibilityIdentifier("welcome.dismiss")
                     }
-                    Spacer()
-                    Button { dismissed = true } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.title3).foregroundStyle(.tertiary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Dismiss")
-                    .accessibilityIdentifier("welcome.dismiss")
                 }
 
                 HStack(spacing: 12) {

--- a/LokalBot/Views/MenuBarView.swift
+++ b/LokalBot/Views/MenuBarView.swift
@@ -201,7 +201,7 @@ struct MenuBarView: View {
 
     private var recentSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("RECENT").font(.caption2.weight(.semibold)).foregroundStyle(.secondary)
+            SectionHeader(text: "Recent")
             if app.meetings.isEmpty {
                 Text("No meetings yet").font(.caption).foregroundStyle(.secondary)
             } else {

--- a/LokalBot/Views/MenuBarView.swift
+++ b/LokalBot/Views/MenuBarView.swift
@@ -80,47 +80,52 @@ struct MenuBarView: View {
     // MARK: Recording status
 
     private var statusCard: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 10) {
-                statusDot
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(statusTitle)
-                        .font(.headline)
-                    Text(statusSubtitle)
-                        .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+        HeroPanel(radius: Brand.Radius.panel) {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 10) {
+                    statusDot
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(statusTitle)
+                            .font(.headline)
+                            .foregroundStyle(.white)
+                        Text(statusSubtitle)
+                            .font(.caption).foregroundStyle(.white.opacity(0.65)).lineLimit(1)
+                    }
+                    Spacer()
+                    if app.isRecording || app.dictation.state.isRecording {
+                        LiveWaveform(barCount: 7, barWidth: 3, maxHeight: 14)
+                    }
                 }
-                Spacer()
-            }
 
-            if app.isRecording || app.dictation.state.isWorking {
-                Text(primaryTimerLabel)
-                    .font(.system(size: 30, weight: .semibold, design: .rounded))
-                    .monospacedDigit()
-                Label(audioSourceLabel, systemImage: "waveform")
-                    .font(.caption).foregroundStyle(.secondary)
-            }
-
-            Button {
-                if app.isRecording {
-                    app.stopRecording()
-                } else if app.dictation.state.isWorking {
-                    app.dictation.toggle(source: "menubar")
-                } else {
-                    app.startRecording(context: app.recordingContext(for: app.detector.activeApp), source: "menubar")
+                if app.isRecording || app.dictation.state.isWorking {
+                    Text(primaryTimerLabel)
+                        .font(.system(size: 30, weight: .semibold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundStyle(.white)
+                    Label(audioSourceLabel, systemImage: "waveform")
+                        .font(.caption).foregroundStyle(.white.opacity(0.65))
                 }
-            } label: {
-                Label(primaryActionTitle, systemImage: primaryActionIcon)
-                    .frame(maxWidth: .infinity)
+
+                Button {
+                    if app.isRecording {
+                        app.stopRecording()
+                    } else if app.dictation.state.isWorking {
+                        app.dictation.toggle(source: "menubar")
+                    } else {
+                        app.startRecording(context: app.recordingContext(for: app.detector.activeApp), source: "menubar")
+                    }
+                } label: {
+                    Label(primaryActionTitle, systemImage: primaryActionIcon)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .tint((app.isRecording || app.dictation.state.isRecording) ? .red : .accentColor)
             }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .tint((app.isRecording || app.dictation.state.isRecording) ? .red : .accentColor)
         }
-        .padding(12)
-        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: Brand.Radius.panel))
         .overlay(
             RoundedRectangle(cornerRadius: Brand.Radius.panel)
-                .strokeBorder(app.isRecording ? Brand.recording.opacity(0.35) : Color.clear))
+                .strokeBorder(app.isRecording ? Brand.recording.opacity(0.5) : Color.clear))
     }
 
     /// Solid dot, with an expanding ring that pulses while recording.

--- a/LokalBot/Views/TimelineView.swift
+++ b/LokalBot/Views/TimelineView.swift
@@ -205,21 +205,15 @@ struct TimelineDayView: View {
             Calendar.current.isDate($0.startedAt, inSameDayAs: model.day)
         }.count
         return HStack(spacing: 8) {
-            stat("clock", TimelineStyle.hm(total), "tracked")
-            stat("square.grid.2x2", "\(apps)", apps == 1 ? "app" : "apps")
-            stat("camera.viewfinder", "\(model.shots.count)", "screens")
-            if meetings > 0 { stat("waveform", "\(meetings)", meetings == 1 ? "meeting" : "meetings") }
+            StatTile(icon: "clock", value: TimelineStyle.hm(total), label: "tracked")
+            StatTile(icon: "square.grid.2x2", value: "\(apps)", label: apps == 1 ? "app" : "apps")
+            StatTile(icon: "camera.viewfinder", value: "\(model.shots.count)", label: "screens")
+            if meetings > 0 {
+                StatTile(icon: "waveform", value: "\(meetings)",
+                         label: meetings == 1 ? "meeting" : "meetings")
+            }
             Spacer()
         }
-    }
-
-    private func stat(_ icon: String, _ value: String, _ label: String) -> some View {
-        HStack(spacing: 5) {
-            Image(systemName: icon).font(.caption).foregroundStyle(.secondary)
-            Text(value).font(.callout.weight(.semibold).monospacedDigit())
-            Text(label).font(.caption).foregroundStyle(.secondary)
-        }
-        .chipChrome()
     }
 }
 

--- a/LokalBotTests/LiveWaveformMathTests.swift
+++ b/LokalBotTests/LiveWaveformMathTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import LokalBot
+
+final class LiveWaveformMathTests: XCTestCase {
+    func testHeightsStayWithinBounds() {
+        for index in 0..<9 {
+            for step in 0..<200 {
+                let h = LiveWaveformMath.height(index: index, time: Double(step) * 0.05)
+                XCTAssertGreaterThanOrEqual(h, 3)
+                XCTAssertLessThanOrEqual(h, 18)
+            }
+        }
+    }
+
+    func testBarsAreOutOfPhase() {
+        let heights = (0..<9).map { LiveWaveformMath.height(index: $0, time: 1.0) }
+        XCTAssertGreaterThan(Set(heights.map { Int($0.rounded()) }).count, 1,
+                             "neighboring bars should not all share one height")
+    }
+
+    func testCustomRangeIsRespected() {
+        for step in 0..<50 {
+            let h = LiveWaveformMath.height(index: 2, time: Double(step) * 0.1,
+                                            minHeight: 2, maxHeight: 10)
+            XCTAssertGreaterThanOrEqual(h, 2)
+            XCTAssertLessThanOrEqual(h, 10)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 0 of the app redesign (spec: `Docs/superpowers/specs/2026-07-02-app-redesign-design.md`): introduces the "Slate & Signal" design tokens and shared components, and applies them to existing surfaces with **zero IA or behavior change**.

- **Slate brand tokens** — `Brand.slate` (#0f172a), `Brand.slateElevated` (#1e293b), `plateGradient`; the icon's dark plate brought into the app, staying dark in both appearances
- **`SectionHeader` / `StatTile`** — one treatment for list-group headers and stat chips (adopted in Timeline stats, meeting-list day headers, menu-bar Recent)
- **`LiveWaveform`** — the shared "audio is flowing" motion signature, extracted from the dictation HUD with its bar math unit-tested (`LiveWaveformMath`, 3 tests); freezes under Reduce Motion
- **`HeroPanel` + `hudCapsule()`** — slate plate cards and the one floating-capsule chrome; unifies the dictation HUD, audio-source banner, and recording pill (pill gains a mini waveform)
- **Slate heroes** — menu-bar status card and welcome hero moved onto `HeroPanel` with fixed light foregrounds; amber recording border strengthened to hold against slate

All accessibility identifiers preserved verbatim. No new dependencies; nothing leaves the Mac.

## Test plan

- [x] Full unit suite: 608/608 passing (scheme `LokalBot`)
- [x] TDD for `LiveWaveformMath` (red → green)
- [x] UI tests: 16/18; the 2 failures are not regressions — `ChatHistoryUITests.testPersistedConversationLoadsIntoChat` passes in isolation (flaky under full-suite ordering) and `SettingsUITests.testPermissionRepairPaneRendersCorePermissions` fails identically on `master` (pre-existing, environment/TCC-dependent)
- [x] Prod and Dev schemes both build
- [ ] Visual smoke check on `LokalBot Dev` in dark + light appearance, Reduce Motion freeze

https://claude.ai/code/session_014XXdyc5pTVGh24L2MhTaSv