### PR TITLE
Redesign Phase 4: polish + Settings absorbs Models

### DIFF
--- a/Docs/screenshot-kit.md
+++ b/Docs/screenshot-kit.md
@@ -1,0 +1,61 @@
+# Screenshot kit — Show HN + website
+
+The shot list and repeatable setup for marketing screenshots. Shots are taken
+against the **LokalBot UI Test Host** target with a synthetic library, so no
+real meetings, TCC grants, or network are involved and the content is
+reproducible.
+
+## Setup
+
+1. Build the host once: the `LokalBot UI Test Host` scheme (or let
+   `Scripts/ui-tests.sh` build it).
+2. Plant a synthetic library. The UI-test fixture
+   (`LokalBotUITests/SyntheticFixture.swift`) is the reference for what a
+   good-looking library contains: a few meetings across two days with
+   transcripts + summaries, and activity blocks so Capture opens in Day scope.
+3. Launch the host with the capture environment (see
+   `applyCaptureEnvironment` in `LokalBot/AppLifecycle.swift`):
+
+```bash
+LOKALBOT_UI_TEST=1 \
+LOKALBOT_STORAGE_ROOT=/tmp/lokalbot-shots \
+LOKALBOT_DISMISS_ONBOARDING=1 \
+LOKALBOT_INITIAL_SECTION=capture \
+LOKALBOT_SELECT_FIRST=1 \
+"…/LokalBot UI Test Host.app/Contents/MacOS/LokalBot"
+```
+
+`LOKALBOT_INITIAL_SECTION` accepts `capture`, `ask`, `type`, `settings`, and
+the legacy names — `models` lands on Settings with the Models tab
+preselected (spec §2.5).
+
+## Conventions
+
+- **Appearance:** dark mode is the primary set (matches the site's slate
+  aesthetic and the app icon); repeat the hero shot in light mode for the
+  README.
+- **Window:** ~1280×800, Retina (2×) display, `⇧⌘4 + space` window capture
+  with shadow.
+- **Content:** synthetic names only — no real meeting titles, contacts, or
+  screen content.
+
+## Shot list
+
+| # | Shot | Setup | Used in |
+|---|------|-------|---------|
+| 1 | Menu-bar dropdown while recording (HeroPanel, live timer + waveform) | Start a manual recording in the host, click the status item | Website hero strip, Show HN comment |
+| 2 | Capture — Day view (track + day overview) | `LOKALBOT_INITIAL_SECTION=capture`, fixture with activity | Website "Capture" section, README |
+| 3 | Capture — Library + meeting inspector | `capture` + `LOKALBOT_SELECT_FIRST=1`, switch scope to Library | Website, README |
+| 4 | Ask — results with facets + escalated assistant answer | `LOKALBOT_INITIAL_SECTION=ask`, type a query, press ↵ | Website "Ask" section, Show HN |
+| 5 | Type — Cotyping ghost text in a real app | Real (Dev) build, TextEdit + ghost suggestion visible | Website "Type" section |
+| 6 | Settings — Models tab (role cards) | `LOKALBOT_INITIAL_SECTION=models` | README, docs |
+
+Shot 5 is the one shot that needs the real Dev build (ghost text requires the
+AX/event-tap path the host build skips); grant the Dev bundle its own
+Accessibility/Input Monitoring permissions.
+
+## Destinations
+
+- `web/` — hero + per-pillar sections (`index.html`), comparison pages.
+- `Docs/show-hn-kit.md` — the Show HN post references shots 1, 2, and 4.
+- `README.md` — hero (light + dark) and shots 2/3/6.

--- a/Docs/superpowers/plans/2026-07-03-redesign-phase4-polish.md
+++ b/Docs/superpowers/plans/2026-07-03-redesign-phase4-polish.md
@@ -1,0 +1,399 @@
+# Redesign Phase 4 — Settings absorbs Models + Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the redesign per spec §2.5 + §5 item 5: fold Models into Settings as a tab strip (General · Recording · Models · Privacy · Advanced), restyle onboarding to the three-pillar Capture/Ask/Type story, close the empty-state gaps, and produce the Show HN screenshot kit.
+
+**Architecture:** `NavSection` loses `.models` (legacy `"models"` capture name maps to `.settings` and preselects the Models tab via a new `AppState.SettingsTab`). `SettingsView` becomes header (search + segmented tab strip) over content (the Form's sections distributed across tabs; `ModelsView` unchanged as the Models tab). Search with a non-empty query filters across ALL tabs (the existing `shows()` gating, tab-agnostic) plus a Models jump row.
+
+**Tech Stack:** Swift 5.10, SwiftUI, macOS 15+, XcodeGen, XCTest.
+
+## Global Constraints
+
+- **No subagents** — all work inline in this session (user directive).
+- **No UI test runs** — user waiver; UI test *source* is still updated where selectors break, but gating is unit suite + build only.
+- Unit tests: `xcodebuild -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' test` (scheme "LokalBot"). Suite must stay green (641+ tests).
+- `git checkout -- default.profraw` before EVERY commit; never commit it.
+- No new source files except where listed; if any are added/removed, run `xcodegen generate`.
+- Nothing leaves the Mac — pure UI change, no new network surface.
+- Spec §2.5 verbatim: "One surface with a tab strip: **General · Recording · Models · Privacy · Advanced**. `ModelsView` becomes the Models tab unchanged; `SettingsView`'s existing sections distribute across the other tabs; the settings-search field filters across all tabs. No behavioral changes."
+- Spec §3.3: onboarding "same flow, restyled with `HeroPanel`/`IconTile`; the three-pillar framing (Capture / Ask / Type) replaces the current pillar copy". Cotyping ghost rendering/insertion/event tap untouched (§4) — verified: the ghost `NSPanel` is cotyping's only floating chrome, so no cotyping change in this phase. Dictation HUD (`.hudCapsule`) and menu-bar `HeroPanel` were completed in Phase 0 — no change.
+- Spec §3.4: `accessibilityReduceMotion` respected on all new animations; slate reserved for hero/HUD surfaces only (§7).
+- Preserved accessibility ids: `settings.form`, `settings.search`, `models.transcription`, `models.summarization`, `models.cotyping`, `models.embeddings`, `sidebar.settings`. Removed: `sidebar.models`. New: `settings.tab`.
+- Commit trailer: `Claude-Session: https://claude.ai/code/session_014XXdyc5pTVGh24L2MhTaSv`
+- Finish: push `redesign-phase4`, PR targeting `redesign-phase3` (stacked).
+
+---
+
+### Task 1: SettingsTab model + NavSection remap
+
+**Files:**
+- Modify: `LokalBot/LokalBotApp.swift` (NavSection enum ~line 114, TypeTab ~line 135, published nav state ~line 184)
+- Modify: `LokalBot/AppLifecycle.swift:158-183` (capture environment)
+- Modify: `LokalBot/Views/MainWindowView.swift:106-146` (navigation branch + sidebar)
+- Modify: `LokalBot/Views/CommandPaletteView.swift:89-90` (nav.models row)
+- Test: `LokalBotTests/NavSectionMappingTests.swift`
+
+**Interfaces:**
+- Consumes: existing `AppState.NavSection`, `AppState.TypeTab(captureName:)` pattern.
+- Produces: `AppState.SettingsTab` (`enum SettingsTab: String, CaseIterable { case general, recording, models, privacy, advanced }`) with `init?(captureName:)` and `var displayName: String`; `@Published var settingsTab: SettingsTab = .general`; `func openSettings(tab: SettingsTab)`. Task 2 binds `app.settingsTab` in SettingsView.
+
+- [ ] **Step 1: Update the mapping tests (failing first)**
+
+In `LokalBotTests/NavSectionMappingTests.swift`, change the `"models"` expectation and add SettingsTab coverage:
+
+```swift
+    func testCaptureNamesMapToTheirSections() {
+        XCTAssertEqual(AppState.NavSection(captureName: "capture"), .capture)
+        XCTAssertEqual(AppState.NavSection(captureName: "type"), .type)
+        XCTAssertEqual(AppState.NavSection(captureName: "ask"), .ask)
+        XCTAssertEqual(AppState.NavSection(captureName: "settings"), .settings)
+    }
+
+    /// Spec §2.5: Settings absorbs Models — the legacy "models" capture name
+    /// lands on Settings, and the SettingsTab mapping preselects its tab.
+    func testLegacyModelsNameMapsToSettings() {
+        XCTAssertEqual(AppState.NavSection(captureName: "models"), .settings)
+        XCTAssertEqual(AppState.NavSection(captureName: "Models"), .settings)
+    }
+
+    func testSettingsTabCaptureNamesSelectTheTab() {
+        XCTAssertEqual(AppState.SettingsTab(captureName: "models"), .models)
+        XCTAssertEqual(AppState.SettingsTab(captureName: "general"), .general)
+        XCTAssertEqual(AppState.SettingsTab(captureName: "recording"), .recording)
+        XCTAssertEqual(AppState.SettingsTab(captureName: "privacy"), .privacy)
+        XCTAssertEqual(AppState.SettingsTab(captureName: "advanced"), .advanced)
+        XCTAssertNil(AppState.SettingsTab(captureName: "settings"))
+        XCTAssertNil(AppState.SettingsTab(captureName: "capture"))
+    }
+```
+
+- [ ] **Step 2: Build tests to verify they fail** (`SettingsTab` undefined, `"models"` still maps to `.models`)
+
+- [ ] **Step 3: Implement in `LokalBotApp.swift`**
+
+NavSection becomes `case capture, type, ask, settings`; in `init?(captureName:)` replace the two lines `case "models": self = .models` / `case "settings": self = .settings` with `case "settings", "models": self = .settings`. After the `TypeTab` enum add:
+
+```swift
+    /// Which tab the Settings surface shows (spec §2.5 — Settings absorbs
+    /// Models as a tab strip). Session-sticky like TypeTab.
+    enum SettingsTab: String, CaseIterable {
+        case general, recording, models, privacy, advanced
+
+        var displayName: String { rawValue.capitalized }
+
+        /// Legacy capture names select their tab; the pre-merge "models"
+        /// section name lands on the Models tab.
+        init?(captureName: String) {
+            switch captureName.lowercased() {
+            case "general": self = .general
+            case "recording": self = .recording
+            case "models": self = .models
+            case "privacy": self = .privacy
+            case "advanced": self = .advanced
+            default: return nil
+            }
+        }
+    }
+```
+
+Next to `@Published var typeTab` add `@Published var settingsTab: SettingsTab = .general`, and next to `openType(_:)` add:
+
+```swift
+    /// Navigate to Settings with a specific tab preselected.
+    func openSettings(tab: SettingsTab) {
+        settingsTab = tab
+        navSection = .settings
+    }
+```
+
+- [ ] **Step 4: Compile fixes at the three consumers**
+
+`AppLifecycle.swift` inside `applyCaptureEnvironment`, after the TypeTab line:
+
+```swift
+            if let tab = AppState.SettingsTab(captureName: raw) { app.settingsTab = tab }
+```
+
+`CommandPaletteView.swift` nav.models row action becomes `{ app.openSettings(tab: .models) }` (title/icon/subtitle unchanged).
+
+`MainWindowView.swift`: delete the `else if app.navSection == .models { … }` navigation branch and the sidebar `Label("Models"…)` entry (its `.tag` and `sidebar.models` id) — the Configure section keeps only Settings.
+
+- [ ] **Step 5: Run the unit suite** — expected: all green including the updated mapping tests.
+
+- [ ] **Step 6: Commit** — `git checkout -- default.profraw; git add -A LokalBot LokalBotTests; git commit` message: `Fold the Models destination into Settings navigation`
+
+---
+
+### Task 2: SettingsView tab strip, section distribution, cross-tab search
+
+**Files:**
+- Modify: `LokalBot/Views/SettingsView.swift` (whole body restructure)
+- Modify: `LokalBot/Views/ModelsView.swift` (stale copy only)
+- Modify: `LokalBotUITests/MainWindowUITests.swift:77-93` (testModelsSectionRendersRoleCards selectors — source update only, not run)
+
+**Interfaces:**
+- Consumes: `app.settingsTab` + `AppState.SettingsTab` from Task 1; existing `shows(_:_:)` / `SettingsSearchRanker`.
+- Produces: layout = `VStack { header (search field `settings.search` + segmented Picker `settings.tab`); content }`, whole surface keeps `settings.form` id. Query empty → selected tab's sections (Models tab = `ModelsView()` unchanged); query non-empty → Form with ALL matching sections regardless of tab + a "Models" jump section when models keywords match.
+
+- [ ] **Step 1: Restructure `SettingsView.body`**
+
+Replace the body with a header + tabbed content. The existing `Section("…") { … }` blocks move verbatim into small `@ViewBuilder` vars (`generalSection`, `permissionsSection`, `meetingsSection`, `processingSection`, `summarizationSection`, `dayTrackingSection`, `privacySection`, `storageSection`, `updatesSection`, `systemSection`, `agentCLISection`) — each keeps its `if shows(…)` wrapper exactly as today. Distribution:
+
+- **General**: General, Permissions, Storage, Updates
+- **Recording**: Meetings, Processing, Summarization, Day tracking
+- **Models**: `ModelsView()`
+- **Privacy**: Privacy
+- **Advanced**: System, Agent CLI
+
+```swift
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if app.settingsTab == .models && queryIsEmpty {
+                ModelsView()
+            } else {
+                Form {
+                    if queryIsEmpty {
+                        sections(for: app.settingsTab)
+                    } else {
+                        searchResults
+                    }
+                }
+                .formStyle(.grouped)
+            }
+        }
+        .frame(minWidth: 460)
+        .accessibilityIdentifier("settings.form")
+        .navigationTitle("Settings")
+        .onAppear { … unchanged … }
+        .onDisappear { … unchanged … }
+    }
+
+    private var queryIsEmpty: Bool {
+        settingsQuery.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    private var header: some View {
+        VStack(spacing: 10) {
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+                TextField("Search settings…", text: $settingsQuery)
+                    .textFieldStyle(.plain)
+                    .accessibilityIdentifier("settings.search")
+                if !settingsQuery.isEmpty {
+                    Button { settingsQuery = "" } label: {
+                        Image(systemName: "xmark.circle.fill")
+                    }
+                    .buttonStyle(.plain).foregroundStyle(.secondary)
+                }
+            }
+            Picker("", selection: $app.settingsTab) {
+                ForEach(AppState.SettingsTab.allCases, id: \.self) { tab in
+                    Text(tab.displayName).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .accessibilityIdentifier("settings.tab")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder private func sections(for tab: AppState.SettingsTab) -> some View {
+        switch tab {
+        case .general:
+            generalSection; permissionsSection; storageSection; updatesSection
+        case .recording:
+            meetingsSection; processingSection; summarizationSection; dayTrackingSection
+        case .models:
+            EmptyView() // handled by the ModelsView branch in body
+        case .privacy:
+            privacySection
+        case .advanced:
+            systemSection; agentCLISection
+        }
+    }
+
+    /// Spec §2.5: the search field filters across ALL tabs — a non-empty
+    /// query shows every matching section regardless of the selected tab,
+    /// plus a jump row into the Models tab when its keywords match.
+    @ViewBuilder private var searchResults: some View {
+        generalSection; permissionsSection; meetingsSection; processingSection
+        summarizationSection; dayTrackingSection; privacySection; storageSection
+        updatesSection; systemSection; agentCLISection
+        if shows("Models", ["model", "models", "transcription", "summarization",
+                            "cotyping", "embeddings", "llm", "whisper", "download",
+                            "gguf", "hugging face", "ollama", "engine", "backend"]) {
+            Section("Models") {
+                Button("Open the Models tab…") {
+                    settingsQuery = ""
+                    app.settingsTab = .models
+                }
+                Text("Transcription, summarization, cotyping, and embedding models live in the Models tab.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+    }
+```
+
+The old first Form `Section` holding the search field is removed (search lives in the header now). All existing section bodies are byte-identical moves.
+
+- [ ] **Step 2: Copy fixes**
+
+- Processing section caption: `"Choose transcription and summarization models in the Models section (sidebar → Engine → Models)."` → `"Choose transcription and summarization models in the Models tab."`
+- `ModelsView` doc comment: `/// The "Models" section (sidebar → Engine → Models).` → `/// The Models tab of Settings (spec §2.5).`
+- `ModelsView` embeddings card: `"Off — enable it in the Search section"` → `"Off — enable it in Ask"`, and caption `"…(sidebar → Search)."` → `"…(enabled from Ask)."`
+- `ModelsView` drops `.navigationTitle("Models")` (it now lives inside Settings).
+
+- [ ] **Step 3: Update the UI test source (not run)**
+
+`MainWindowUITests.testModelsSectionRendersRoleCards`: `clickSidebar("sidebar.models")` → navigate via Settings:
+
+```swift
+        clickSidebar("sidebar.settings")
+        let tabs = app.descendants(matching: .any)["settings.tab"]
+        XCTAssertTrue(tabs.waitForExistence(timeout: 8), "settings tab strip missing")
+        let segment = tabs.buttons["Models"].exists
+            ? tabs.buttons["Models"] : tabs.radioButtons["Models"]
+        segment.click()
+```
+
+(assertions on `models.*` card ids unchanged).
+
+- [ ] **Step 4: Build + run the unit suite** — expected: green.
+
+- [ ] **Step 5: Commit** — message: `Restructure Settings into a five-tab surface absorbing Models`
+
+---
+
+### Task 3: Onboarding three-pillar restyle
+
+**Files:**
+- Modify: `LokalBot/Views/OnboardingView.swift` (welcomePage, flowPage, LokalBotHeroDemo)
+
+**Interfaces:**
+- Consumes: `HeroPanel`, `IconTile`, `Brand` tokens from Phase 0. No produced interfaces.
+
+- [ ] **Step 1: Welcome page — pillar copy + chips**
+
+Subtitle: `"Your local meeting memory, with recording, recap, search, and cotyping on this Mac."` → `"Capture your meetings and day, ask your local library anything, and type with on-device AI — nothing leaves this Mac."`
+
+Chips row becomes the three pillars plus the invariant:
+
+```swift
+            HStack(spacing: 8) {
+                OnboardingFeatureChip(systemImage: "lock.fill", label: "On-device")
+                OnboardingFeatureChip(systemImage: "waveform.circle", label: "Capture")
+                OnboardingFeatureChip(systemImage: "sparkle.magnifyingglass", label: "Ask")
+                OnboardingFeatureChip(systemImage: "keyboard", label: "Type")
+            }
+```
+
+- [ ] **Step 2: Flow page — three pillar cards**
+
+Header: title `"Three pillars: Capture, Ask, Type"`, subtitle `"Everything LokalBot does hangs off three verbs — all local."`, systemImage stays `"waveform.badge.magnifyingglass"`. The three `TimelineCard`s become:
+
+```swift
+                TimelineCard(
+                    number: "1",
+                    systemImage: "waveform.circle",
+                    tint: Brand.teal,
+                    title: "Capture",
+                    subtitle: "Meetings and your day, recorded, transcribed, and summarized locally."
+                )
+                TimelineCard(
+                    number: "2",
+                    systemImage: "sparkle.magnifyingglass",
+                    tint: .indigo,
+                    title: "Ask",
+                    subtitle: "One search over everything you captured — press ↵ to ask the local assistant."
+                )
+                TimelineCard(
+                    number: "3",
+                    systemImage: "keyboard",
+                    tint: .orange,
+                    title: "Type",
+                    subtitle: "Dictation and Cotyping inline autocomplete, anywhere you type."
+                )
+```
+
+(`.onboardingReveal` indices unchanged.)
+
+- [ ] **Step 3: Hero demo — pillar phases on a HeroPanel**
+
+`LokalBotHeroDemo` phases become the pillars and the card chrome becomes the slate `HeroPanel` (spec §3.2 "onboarding cards"); inner text goes white-on-slate:
+
+```swift
+    private let phases = [
+        ("Capture", "Google Meet · recording", "Mic + system audio, transcribed locally"),
+        ("Ask", "What did we promise Alex?", "Searches your local meeting library"),
+        ("Type", "Cotyping suggests as you type", "Inline autocomplete, on-device")
+    ]
+```
+
+Icon mapping in the body: phase 0 `"waveform.circle"`/`Brand.teal`, phase 1 `"sparkle.magnifyingglass"`/`.indigo`, phase 2 `"keyboard"`/`.orange`. Replace the outer `.padding(16).onboardingCard(cornerRadius: 14)` with wrapping the VStack in `HeroPanel(radius: 14) { … }`; the inner phase box swaps `Color(nsColor: .textBackgroundColor).opacity(0.72)` for `Color.white.opacity(0.08)` and the two secondary texts use `.foregroundStyle(.white.opacity(0.65))` with the title `.foregroundStyle(.white)` so the demo reads on slate in both appearances. Traffic-light dots and the reduce-motion `task` behavior stay as-is.
+
+- [ ] **Step 4: Build + spot-check** — build the LokalBot Dev scheme (`xcodebuild -project LokalBot.xcodeproj -scheme 'LokalBot Dev' -destination 'platform=macOS' build`); expected: succeeds.
+
+- [ ] **Step 5: Run the unit suite** (onboarding has no unit coverage; suite guards regressions) — expected: green.
+
+- [ ] **Step 6: Commit** — message: `Restyle onboarding around the Capture, Ask, Type pillars`
+
+---
+
+### Task 4: Empty-state polish
+
+**Files:**
+- Modify: `LokalBot/Views/MeetingListView.swift` (empty overlay)
+
+**Interfaces:** none produced.
+
+- [ ] **Step 1: Meeting-list empty state**
+
+The Library list renders blank when no meetings exist. Add after the recording overlay in `MeetingListView.body`:
+
+```swift
+        .overlay {
+            if groupedMeetings.isEmpty {
+                ContentUnavailableView(
+                    "No meetings yet",
+                    systemImage: "waveform.circle",
+                    description: Text("LokalBot detects meeting apps and records automatically — or press Record in the menu bar."))
+            }
+        }
+```
+
+- [ ] **Step 2: Audit the remaining empty states (verification, no code expected)**
+
+Confirm these render a proper empty state: Capture Day (`No activity recorded` ContentUnavailableView — CaptureView.swift:171), Capture inspector (CaptureDetailView.swift:26), Ask idle (`chat.empty` — AskView.swift:285), menu-bar recents (`No meetings yet` caption). Confirm slate appears only on HeroPanel/HUDCapsule surfaces (grep `Brand.slate` — expected: DesignSystem/Brand + HeroPanel usage only) and every `withAnimation`/`.animation` added this branch is guarded by or indifferent to `accessibilityReduceMotion` (this branch adds none).
+
+- [ ] **Step 3: Run the unit suite** — expected: green.
+
+- [ ] **Step 4: Commit** — message: `Add an empty state to the meeting library list`
+
+---
+
+### Task 5: Screenshot kit for Show HN + website
+
+**Files:**
+- Create: `Docs/screenshot-kit.md` (docs only — no xcodegen needed)
+
+**Interfaces:** consumes the UI-test-host env hooks (`LOKALBOT_INITIAL_SECTION`, `LOKALBOT_SELECT_FIRST`, `LOKALBOT_DISMISS_ONBOARDING` — AppLifecycle.swift:158-183).
+
+- [ ] **Step 1: Write the shot list**
+
+Document (a) the six shots: menu-bar dropdown while recording, Capture Day view, Capture Library + inspector, Ask with results + escalated answer, Type with Cotyping ghost text (composited or real), Settings Models tab; (b) per-shot setup: build the `LokalBot UI Test Host` target against a synthetic library (`LOKALBOT_STORAGE_ROOT` pointing at a seeded fixture) and launch with `LOKALBOT_INITIAL_SECTION` = `capture`/`ask`/`type`/`models` (the last now lands on Settings → Models tab), `LOKALBOT_SELECT_FIRST=1`, `LOKALBOT_DISMISS_ONBOARDING=1`; (c) both appearances (dark primary for the site's slate aesthetic, light for README), Retina 2×, window ~1280×800; (d) where they go: `web/` hero + Show HN kit (`Docs/show-hn-kit.md`).
+
+- [ ] **Step 2: Commit** — message: `Document the Show HN and website screenshot kit`
+
+---
+
+### Task 6: Finish the branch
+
+- [ ] Full unit suite green; `git checkout -- default.profraw`.
+- [ ] Whole-branch self-review vs `redesign-phase3` (`git diff redesign-phase3...HEAD --stat`): no stale `.models` NavSection producers (`grep -rn "navSection = .models\|NavSection.models"` → empty), preserved ids present, no `sidebar.models` left in app or test sources except intentionally-removed spots.
+- [ ] Push `redesign-phase4`, open PR targeting `redesign-phase3` with the session URL trailer.
+- [ ] Update `.superpowers/sdd/progress.md`.

--- a/LokalBot/AppLifecycle.swift
+++ b/LokalBot/AppLifecycle.swift
@@ -168,6 +168,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
            let section = AppState.NavSection(captureName: raw) {
             app.navSection = section
             if let tab = AppState.TypeTab(captureName: raw) { app.typeTab = tab }
+            if let tab = AppState.SettingsTab(captureName: raw) { app.settingsTab = tab }
         }
         if env["LOKALBOT_SELECT_FIRST"] == "1", let first = app.meetings.first {
             app.selectedMeetingIDs = [first.id]

--- a/LokalBot/LokalBotApp.swift
+++ b/LokalBot/LokalBotApp.swift
@@ -112,19 +112,19 @@ struct LokalBotApp: App {
 final class AppState: ObservableObject {
 
     enum NavSection: Hashable {
-        case capture, type, ask, models, settings
+        case capture, type, ask, settings
 
         /// Section names accepted from the UI-test capture environment and
         /// deep links. Legacy pre-merge names keep working: "meetings" and
         /// "timeline" land on the merged Capture section, "dictation" and
-        /// "cotyping" on Type, "search"/"chat" on Ask (spec §2.1).
+        /// "cotyping" on Type, "search"/"chat" on Ask (spec §2.1), and
+        /// "models" on Settings, which absorbed it as a tab (spec §2.5).
         init?(captureName: String) {
             switch captureName.lowercased() {
             case "capture", "meetings", "timeline": self = .capture
             case "type", "dictation", "cotyping": self = .type
             case "ask", "search", "chat": self = .ask
-            case "models": self = .models
-            case "settings": self = .settings
+            case "settings", "models": self = .settings
             default: return nil
             }
         }
@@ -141,6 +141,27 @@ final class AppState: ObservableObject {
             switch captureName.lowercased() {
             case "dictation": self = .dictation
             case "cotyping": self = .cotyping
+            default: return nil
+            }
+        }
+    }
+
+    /// Which tab the Settings surface shows (spec §2.5 — Settings absorbs
+    /// Models as a tab strip). Session-sticky like TypeTab.
+    enum SettingsTab: String, CaseIterable {
+        case general, recording, models, privacy, advanced
+
+        var displayName: String { rawValue.capitalized }
+
+        /// Legacy capture names select their tab; the pre-merge "models"
+        /// section name lands on the Models tab.
+        init?(captureName: String) {
+            switch captureName.lowercased() {
+            case "general": self = .general
+            case "recording": self = .recording
+            case "models": self = .models
+            case "privacy": self = .privacy
+            case "advanced": self = .advanced
             default: return nil
             }
         }
@@ -183,6 +204,7 @@ final class AppState: ObservableObject {
     // pending "jump to timestamp" handed from search to the detail player.
     @Published var navSection: NavSection = .capture
     @Published var typeTab: TypeTab = .dictation
+    @Published var settingsTab: SettingsTab = .general
     @Published var selectedMeetingIDs: Set<Meeting.ID> = []
     @Published var pendingSeek: TimeInterval?
 
@@ -204,6 +226,12 @@ final class AppState: ObservableObject {
     func openType(_ tab: TypeTab) {
         typeTab = tab
         navSection = .type
+    }
+
+    /// Navigate to Settings with a specific tab preselected.
+    func openSettings(tab: SettingsTab) {
+        settingsTab = tab
+        navSection = .settings
     }
 
     /// Navigate to the Ask section, optionally pre-filling the query and/or

--- a/LokalBot/Views/CommandPaletteView.swift
+++ b/LokalBot/Views/CommandPaletteView.swift
@@ -87,7 +87,7 @@ struct CommandPaletteView: View {
                   title: app.settings.cotypingEnabled ? "Go to Cotyping (on)" : "Go to Cotyping (off)",
                   subtitle: "Type", action: { app.openType(.cotyping) }),
             .init(id: "nav.models", icon: "brain", title: "Go to Models",
-                  subtitle: "Configure", action: { app.navSection = .models }),
+                  subtitle: "Configure", action: { app.openSettings(tab: .models) }),
             .init(id: "nav.settings", icon: "gearshape", title: "Go to Settings",
                   subtitle: "Configure", action: { app.navSection = .settings })
         ]

--- a/LokalBot/Views/MainWindowView.swift
+++ b/LokalBot/Views/MainWindowView.swift
@@ -103,12 +103,6 @@ struct MainWindowView: View {
             } detail: {
                 AskView()
             }
-        } else if app.navSection == .models {
-            NavigationSplitView {
-                sidebar
-            } detail: {
-                ModelsView()
-            }
         } else {
             NavigationSplitView {
                 sidebar
@@ -134,9 +128,6 @@ struct MainWindowView: View {
                     .accessibilityIdentifier("sidebar.type")
             }
             Section("Configure") {
-                Label("Models", systemImage: "brain")
-                    .tag(AppState.NavSection.models)
-                    .accessibilityIdentifier("sidebar.models")
                 Label("Settings", systemImage: "gearshape")
                     .tag(AppState.NavSection.settings)
                     .accessibilityIdentifier("sidebar.settings")

--- a/LokalBot/Views/MeetingListView.swift
+++ b/LokalBot/Views/MeetingListView.swift
@@ -21,6 +21,15 @@ struct MeetingListView: View {
             }
         }
         .accessibilityIdentifier("meeting.list")
+        .overlay {
+            if groupedMeetings.isEmpty {
+                ContentUnavailableView(
+                    "No meetings yet",
+                    systemImage: "waveform.circle",
+                    description: Text("LokalBot detects meeting apps and records automatically — or press Record in the menu bar.")
+                )
+            }
+        }
         .overlay(alignment: .topTrailing) {
             if app.isRecording {
                 HStack(spacing: 6) {

--- a/LokalBot/Views/ModelsView.swift
+++ b/LokalBot/Views/ModelsView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 import AppKit
 
-/// The "Models" section (sidebar → Engine → Models). All model selection and
-/// management lives here, extracted from Settings into a dedicated card-per-role
-/// surface: Transcription, Summarization, Cotyping, and Embeddings each pick and
-/// manage their own model. Downloads come from the local catalog or Hugging Face.
+/// The Models tab of Settings (spec §2.5). All model selection and management
+/// lives here, a dedicated card-per-role surface: Transcription, Summarization,
+/// Cotyping, and Embeddings each pick and manage their own model. Downloads
+/// come from the local catalog or Hugging Face.
 struct ModelsView: View {
     @EnvironmentObject var app: AppState
 
@@ -35,7 +35,6 @@ struct ModelsView: View {
             .frame(maxWidth: 760, alignment: .leading)
             .frame(maxWidth: .infinity, alignment: .topLeading)
         }
-        .navigationTitle("Models")
         .task {
             refreshTranscriptionDownloads()
             await refreshOllama()
@@ -173,10 +172,10 @@ struct ModelsView: View {
         ModelCard(icon: "point.3.connected.trianglepath.dotted", title: "Embeddings",
                   subtitle: "Semantic search over transcripts & screenshots") {
             LabeledContent("Semantic search") {
-                Text(app.settings.semanticSearchEnabled ? "On" : "Off — enable it in the Search section")
+                Text(app.settings.semanticSearchEnabled ? "On" : "Off — enable it in Ask")
                     .foregroundStyle(.secondary)
             }
-            Text("Finds meetings by meaning, not just keywords. Uses Qwen3-Embedding 0.6B, downloaded when semantic search is first enabled (sidebar → Search).")
+            Text("Finds meetings by meaning, not just keywords. Uses Qwen3-Embedding 0.6B, downloaded when semantic search is first enabled (from Ask).")
                 .font(.caption).foregroundStyle(.secondary)
             Text("Text search now uses Qwen3-Embedding 0.6B. Screenshot/slide embeddings with Qwen3-VL-Embedding 2B are listed as a future pipeline because image vectors need separate indexing and ranking.")
                 .font(.caption).foregroundStyle(.secondary)

--- a/LokalBot/Views/OnboardingView.swift
+++ b/LokalBot/Views/OnboardingView.swift
@@ -124,7 +124,7 @@ private extension OnboardingView {
                 Text("Welcome to LokalBot")
                     .font(.system(size: 30, weight: .bold, design: .rounded))
 
-                Text("Your local meeting memory, with recording, recap, search, and cotyping on this Mac.")
+                Text("Capture your meetings and day, ask your local library anything, and type with on-device AI — nothing leaves this Mac.")
                     .font(.system(size: 15, design: .rounded))
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -138,8 +138,9 @@ private extension OnboardingView {
 
             HStack(spacing: 8) {
                 OnboardingFeatureChip(systemImage: "lock.fill", label: "On-device")
-                OnboardingFeatureChip(systemImage: "waveform", label: "Records both sides")
-                OnboardingFeatureChip(systemImage: "text.cursor", label: "Cotyping ready")
+                OnboardingFeatureChip(systemImage: "waveform.circle", label: "Capture")
+                OnboardingFeatureChip(systemImage: "sparkle.magnifyingglass", label: "Ask")
+                OnboardingFeatureChip(systemImage: "keyboard", label: "Type")
             }
             .onboardingReveal(3)
         }
@@ -152,36 +153,36 @@ private extension OnboardingView {
         VStack(spacing: 24) {
             OnboardingStepHeader(
                 systemImage: "waveform.badge.magnifyingglass",
-                title: "Calls become a searchable memory",
-                subtitle: "LokalBot quietly turns meetings into useful local artifacts."
+                title: "Three pillars: Capture, Ask, Type",
+                subtitle: "Everything LokalBot does hangs off three verbs — all local."
             )
             .onboardingReveal(0)
 
             VStack(spacing: 10) {
                 TimelineCard(
                     number: "1",
-                    systemImage: "dot.radiowaves.left.and.right",
+                    systemImage: "waveform.circle",
                     tint: Brand.teal,
-                    title: "Detect and record",
-                    subtitle: "Meeting audio is captured as separate mic and system tracks."
+                    title: "Capture",
+                    subtitle: "Meetings and your day, recorded, transcribed, and summarized locally."
                 )
                 .onboardingReveal(1)
 
                 TimelineCard(
                     number: "2",
-                    systemImage: "doc.text.viewfinder",
+                    systemImage: "sparkle.magnifyingglass",
                     tint: .indigo,
-                    title: "Transcribe and summarize",
-                    subtitle: "Local models produce the transcript, decisions, and action items."
+                    title: "Ask",
+                    subtitle: "One search over everything you captured — press ↵ to ask the local assistant."
                 )
                 .onboardingReveal(2)
 
                 TimelineCard(
                     number: "3",
-                    systemImage: "magnifyingglass.circle.fill",
+                    systemImage: "keyboard",
                     tint: .orange,
-                    title: "Search and ask",
-                    subtitle: "Replay, search screen text, and ask questions across your library."
+                    title: "Type",
+                    subtitle: "Dictation and Cotyping inline autocomplete, anywhere you type."
                 )
                 .onboardingReveal(3)
             }
@@ -390,56 +391,57 @@ private struct LokalBotHeroDemo: View {
     @State private var phase = 0
 
     private let phases = [
-        ("Recording", "Google Meet", "Mic + system audio"),
-        ("Transcript", "Decision: ship beta Friday", "Action items extracted"),
-        ("Ask", "What did we promise Alex?", "Searches local meetings")
+        ("Capture", "Google Meet · recording", "Mic + system audio, transcribed locally"),
+        ("Ask", "What did we promise Alex?", "Searches your local meeting library"),
+        ("Type", "Cotyping suggests as you type", "Inline autocomplete, on-device")
     ]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(spacing: 6) {
-                Circle().fill(Color(red: 1.0, green: 0.37, blue: 0.34))
-                Circle().fill(Color(red: 1.0, green: 0.74, blue: 0.18))
-                Circle().fill(Color(red: 0.16, green: 0.78, blue: 0.25))
-            }
-            .frame(height: 7)
-            .opacity(0.85)
-
-            HStack(alignment: .center, spacing: 14) {
-                IconTile(
-                    systemImage: phase == 0 ? "waveform" : phase == 1 ? "doc.text.viewfinder" : "bubble.left.and.text.bubble.right.fill",
-                    tint: phase == 0 ? Brand.teal : phase == 1 ? .indigo : .orange,
-                    size: 42
-                )
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(phases[phase].0)
-                        .font(.system(size: 13, weight: .semibold, design: .rounded))
-                        .foregroundStyle(.secondary)
-                    Text(phases[phase].1)
-                        .font(.system(size: 17, weight: .semibold, design: .rounded))
-                        .lineLimit(1)
-                    Text(phases[phase].2)
-                        .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
+        HeroPanel(radius: 14) {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 6) {
+                    Circle().fill(Color(red: 1.0, green: 0.37, blue: 0.34))
+                    Circle().fill(Color(red: 1.0, green: 0.74, blue: 0.18))
+                    Circle().fill(Color(red: 0.16, green: 0.78, blue: 0.25))
                 }
+                .frame(height: 7)
+                .opacity(0.85)
 
-                Spacer(minLength: 0)
+                HStack(alignment: .center, spacing: 14) {
+                    IconTile(
+                        systemImage: phase == 0 ? "waveform.circle" : phase == 1 ? "sparkle.magnifyingglass" : "keyboard",
+                        tint: phase == 0 ? Brand.teal : phase == 1 ? .indigo : .orange,
+                        size: 42
+                    )
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(phases[phase].0)
+                            .font(.system(size: 13, weight: .semibold, design: .rounded))
+                            .foregroundStyle(.white.opacity(0.65))
+                        Text(phases[phase].1)
+                            .font(.system(size: 17, weight: .semibold, design: .rounded))
+                            .foregroundStyle(.white)
+                            .lineLimit(1)
+                        Text(phases[phase].2)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.white.opacity(0.65))
+                            .lineLimit(1)
+                    }
+
+                    Spacer(minLength: 0)
+                }
+                .padding(12)
+                .background(
+                    RoundedRectangle(cornerRadius: 11, style: .continuous)
+                        .fill(Color.white.opacity(0.08))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 11, style: .continuous)
+                        .strokeBorder(Brand.teal.opacity(0.24), lineWidth: 1)
+                )
+                .animation(.spring(response: 0.4, dampingFraction: 0.82), value: phase)
             }
-            .padding(12)
-            .background(
-                RoundedRectangle(cornerRadius: 11, style: .continuous)
-                    .fill(Color(nsColor: .textBackgroundColor).opacity(0.72))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 11, style: .continuous)
-                    .strokeBorder(Brand.teal.opacity(0.24), lineWidth: 1)
-            )
-            .animation(.spring(response: 0.4, dampingFraction: 0.82), value: phase)
         }
-        .padding(16)
-        .onboardingCard(cornerRadius: 14)
         .task(id: reduceMotion) {
             guard !reduceMotion else {
                 phase = 1

--- a/LokalBot/Views/SettingsView.swift
+++ b/LokalBot/Views/SettingsView.swift
@@ -16,24 +16,108 @@ struct SettingsView: View {
     @ObservedObject private var metrics = GenerationMetricsStore.shared
 
     var body: some View {
-        Form {
-            Section {
-                HStack(spacing: 6) {
-                    Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
-                    TextField("Search settings…", text: $settingsQuery)
-                        .textFieldStyle(.plain)
-                        .frame(minWidth: 220, maxWidth: .infinity)
-                        .accessibilityIdentifier("settings.search")
-                    if !settingsQuery.isEmpty {
-                        Button { settingsQuery = "" } label: {
-                            Image(systemName: "xmark.circle.fill")
-                        }
-                        .buttonStyle(.plain).foregroundStyle(.secondary)
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if app.settingsTab == .models && queryIsEmpty {
+                ModelsView()
+            } else {
+                Form {
+                    if queryIsEmpty {
+                        sections(for: app.settingsTab)
+                    } else {
+                        searchResults
                     }
                 }
+                .formStyle(.grouped)
             }
+        }
+        .frame(minWidth: 460)
+        .accessibilityIdentifier("settings.form")
+        .navigationTitle("Settings")
+        .onAppear {
+            power.start()
+            permissions.startPolling()
+            app.calendar.refreshAuthorizationStatus()
+        }
+        .onDisappear { power.stop(); permissions.stopPolling() }
+    }
 
-            if shows("General", ["launch", "login", "startup", "open at login", "auto start",
+    private var queryIsEmpty: Bool {
+        settingsQuery.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    /// Search field + tab strip, above the tabbed content so search works
+    /// from any tab (including Models).
+    private var header: some View {
+        VStack(spacing: 10) {
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+                TextField("Search settings…", text: $settingsQuery)
+                    .textFieldStyle(.plain)
+                    .accessibilityIdentifier("settings.search")
+                if !settingsQuery.isEmpty {
+                    Button { settingsQuery = "" } label: {
+                        Image(systemName: "xmark.circle.fill")
+                    }
+                    .buttonStyle(.plain).foregroundStyle(.secondary)
+                }
+            }
+            Picker("", selection: $app.settingsTab) {
+                ForEach(AppState.SettingsTab.allCases, id: \.self) { tab in
+                    Text(tab.displayName).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .accessibilityIdentifier("settings.tab")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    /// Spec §2.5 tab distribution: SettingsView's existing sections spread
+    /// across General · Recording · Privacy · Advanced; Models is ModelsView.
+    @ViewBuilder private func sections(for tab: AppState.SettingsTab) -> some View {
+        switch tab {
+        case .general:
+            generalSection; permissionsSection; storageSection; updatesSection
+        case .recording:
+            meetingsSection; processingSection; summarizationSection; dayTrackingSection
+        case .models:
+            EmptyView() // handled by the ModelsView branch in body
+        case .privacy:
+            privacySection
+        case .advanced:
+            systemSection; agentCLISection
+        }
+    }
+
+    /// Spec §2.5: the search field filters across ALL tabs — a non-empty
+    /// query shows every matching section regardless of the selected tab,
+    /// plus a jump row into the Models tab when its keywords match.
+    @ViewBuilder private var searchResults: some View {
+        generalSection; permissionsSection; meetingsSection; processingSection
+        summarizationSection; dayTrackingSection; privacySection; storageSection
+        updatesSection; systemSection; agentCLISection
+        if shows("Models", ["model", "models", "transcription", "summarization",
+                            "cotyping", "embeddings", "llm", "whisper", "download",
+                            "gguf", "hugging face", "ollama", "engine", "backend"]) {
+            Section("Models") {
+                Button("Open the Models tab…") {
+                    settingsQuery = ""
+                    app.settingsTab = .models
+                }
+                Text("Transcription, summarization, cotyping, and embedding models live in the Models tab.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder private var generalSection: some View {
+        if shows("General", ["launch", "login", "startup", "open at login", "auto start",
                                  "menu bar", "menubar", "dock", "dock icon", "hide dock",
                                  "window", "background", "tray"]) {
                 Section("General") {
@@ -51,6 +135,9 @@ struct SettingsView: View {
                 }
             }
 
+    }
+
+    @ViewBuilder private var permissionsSection: some View {
             if shows("Permissions", ["permission", "grant", "access", "microphone", "mic",
                                      "screen recording", "system audio", "accessibility",
                                      "input monitoring", "keyboard", "relaunch", "tcc"]) {
@@ -69,6 +156,9 @@ struct SettingsView: View {
                 }
             }
 
+    }
+
+    @ViewBuilder private var meetingsSection: some View {
             if shows("Meetings", ["meeting", "auto record", "detect", "debounce", "stop debounce",
                                   "recording", "calendar", "calendar access", "browser", "google meet"]) {
                 Section("Meetings") {
@@ -109,16 +199,22 @@ struct SettingsView: View {
                 }
             }
 
+    }
+
+    @ViewBuilder private var processingSection: some View {
             if shows("Processing", ["transcribe", "transcription", "summarize", "summary",
                                     "automatic", "auto", "after meeting", "model", "models", "engine"]) {
                 Section("Processing") {
                     Toggle("Transcribe automatically after each meeting", isOn: $app.settings.autoTranscribe)
                     Toggle("Summarize automatically after transcription", isOn: $app.settings.autoSummarize)
-                    Text("Choose transcription and summarization models in the Models section (sidebar → Engine → Models).")
+                    Text("Choose transcription and summarization models in the Models tab.")
                         .font(.caption).foregroundStyle(.secondary)
                 }
             }
 
+    }
+
+    @ViewBuilder private var summarizationSection: some View {
             if shows("Summarization", ["summary", "summarize", "notes", "template", "language",
                                        "diarization", "speaker", "split speaker", "neural"]) {
                 Section("Summarization") {
@@ -143,6 +239,9 @@ struct SettingsView: View {
                 }
             }
 
+    }
+
+    @ViewBuilder private var dayTrackingSection: some View {
             if shows("Day tracking", ["tracking", "activity", "screenshots", "screen", "capture",
                                       "ocr", "window", "accessibility", "retention", "private",
                                       "excluded apps", "never capture"]) {
@@ -180,6 +279,9 @@ struct SettingsView: View {
                 }
             }
 
+    }
+
+    @ViewBuilder private var privacySection: some View {
             if shows("Privacy", ["privacy", "retention", "ocr", "text", "screen text", "history",
                                  "delete", "prune", "forever", "keep", "local", "network",
                                  "data", "security"]) {
@@ -196,6 +298,9 @@ struct SettingsView: View {
                 }
             }
 
+    }
+
+    @ViewBuilder private var storageSection: some View {
             if shows("Storage", ["storage", "location", "files", "folder", "finder", "disk"]) {
                 Section("Storage") {
                     LabeledContent("Location") {
@@ -207,6 +312,9 @@ struct SettingsView: View {
                 }
             }
 
+    }
+
+    @ViewBuilder private var updatesSection: some View {
             if shows("Updates", ["update", "version", "sparkle", "upgrade", "check", "release",
                                  "appcast", "download"]) {
                 Section("Updates") {
@@ -227,6 +335,9 @@ struct SettingsView: View {
                 }
             }
 
+    }
+
+    @ViewBuilder private var systemSection: some View {
             if shows("System", ["system", "hardware", "ram", "memory", "chip", "cpu", "battery",
                                 "power", "low power", "diagnostics", "performance", "generations"]) {
                 Section("System") {
@@ -257,6 +368,9 @@ struct SettingsView: View {
                 }
             }
 
+    }
+
+    @ViewBuilder private var agentCLISection: some View {
             if shows("Agent CLI", ["cli", "agent", "terminal", "claude", "codex", "cursor",
                                    "gemini", "symlink", "install", "uninstall", "path"]) {
                 Section("Agent CLI") {
@@ -321,17 +435,6 @@ struct SettingsView: View {
                 }
             }
 
-        }
-        .formStyle(.grouped)
-        .frame(minWidth: 460)
-        .accessibilityIdentifier("settings.form")
-        .navigationTitle("Settings")
-        .onAppear {
-            power.start()
-            permissions.startPolling()
-            app.calendar.refreshAuthorizationStatus()
-        }
-        .onDisappear { power.stop(); permissions.stopPolling() }
     }
 
     /// Calendar permission state + action for the Meetings section.

--- a/LokalBotTests/NavSectionMappingTests.swift
+++ b/LokalBotTests/NavSectionMappingTests.swift
@@ -10,8 +10,24 @@ final class NavSectionMappingTests: XCTestCase {
         XCTAssertEqual(AppState.NavSection(captureName: "capture"), .capture)
         XCTAssertEqual(AppState.NavSection(captureName: "type"), .type)
         XCTAssertEqual(AppState.NavSection(captureName: "ask"), .ask)
-        XCTAssertEqual(AppState.NavSection(captureName: "models"), .models)
         XCTAssertEqual(AppState.NavSection(captureName: "settings"), .settings)
+    }
+
+    /// Spec §2.5: Settings absorbs Models — the legacy "models" capture name
+    /// lands on Settings, and the SettingsTab mapping preselects its tab.
+    func testLegacyModelsNameMapsToSettings() {
+        XCTAssertEqual(AppState.NavSection(captureName: "models"), .settings)
+        XCTAssertEqual(AppState.NavSection(captureName: "Models"), .settings)
+    }
+
+    func testSettingsTabCaptureNamesSelectTheTab() {
+        XCTAssertEqual(AppState.SettingsTab(captureName: "models"), .models)
+        XCTAssertEqual(AppState.SettingsTab(captureName: "general"), .general)
+        XCTAssertEqual(AppState.SettingsTab(captureName: "recording"), .recording)
+        XCTAssertEqual(AppState.SettingsTab(captureName: "privacy"), .privacy)
+        XCTAssertEqual(AppState.SettingsTab(captureName: "advanced"), .advanced)
+        XCTAssertNil(AppState.SettingsTab(captureName: "settings"))
+        XCTAssertNil(AppState.SettingsTab(captureName: "capture"))
     }
 
     func testLegacyMeetingsAndTimelineNamesMapToCapture() {

--- a/LokalBotUITests/MainWindowUITests.swift
+++ b/LokalBotUITests/MainWindowUITests.swift
@@ -74,10 +74,16 @@ final class MainWindowUITests: XCTestCase {
                       "capture section did not come back")
     }
 
-    /// The new Models pane (sidebar → Engine → Models) renders its role cards,
-    /// proving model selection moved out of Settings into its own section.
+    /// The Models tab of Settings (spec §2.5) renders its role cards —
+    /// Models is reached via Settings' tab strip, not its own sidebar entry.
     func testModelsSectionRendersRoleCards() {
-        clickSidebar("sidebar.models")
+        clickSidebar("sidebar.settings")
+        let tabs = app.descendants(matching: .any)["settings.tab"]
+        XCTAssertTrue(tabs.waitForExistence(timeout: 8), "settings tab strip missing")
+        let segment = tabs.buttons["Models"].exists
+            ? tabs.buttons["Models"] : tabs.radioButtons["Models"]
+        XCTAssertTrue(segment.waitForExistence(timeout: 4), "Models segment missing")
+        segment.click()
         XCTAssertTrue(textWithContent("Transcription").firstMatch
             .waitForExistence(timeout: 6),
                       "Models pane did not render the Transcription card")


### PR DESCRIPTION
Final phase of the app redesign (spec `Docs/superpowers/specs/2026-07-02-app-redesign-design.md` §5 item 5 + deferred §2.5). Stacked on #10.

## What changed

- **Settings absorbs Models (spec §2.5):** Settings is now one surface with a segmented tab strip — **General · Recording · Models · Privacy · Advanced**. `ModelsView` becomes the Models tab unchanged; the existing settings sections distribute across the other tabs; the search field filters across **all** tabs (with a jump row into Models when model keywords match). The sidebar's separate Models destination is gone; `⌘K → Go to Models` and the legacy `LOKALBOT_INITIAL_SECTION=models` land on Settings with the Models tab preselected.
- **Onboarding restyled to the three pillars:** welcome copy, feature chips, the flow page's timeline cards, and the animated hero demo now tell the Capture → Ask → Type story, with the hero demo on a `HeroPanel` plate.
- **Empty state** for the meeting library list (`ContentUnavailableView`).
- **Screenshot kit** documented in `Docs/screenshot-kit.md` (Show HN + website shot list with a reproducible UI-test-host recipe).

## Testing

- Full unit suite green at every task gate: **643 tests, 0 failures** (2 new `SettingsTab` mapping tests).
- `LokalBot Dev` scheme builds clean.
- UI test runs waived per session instruction; `MainWindowUITests.testModelsSectionRendersRoleCards` selector updated at source level for the new tab strip. Preserved accessibility ids: `settings.form`, `settings.search`, `models.*`; new: `settings.tab`; removed: `sidebar.models`.

https://claude.ai/code/session_014XXdyc5pTVGh24L2MhTaSv