### PR TITLE
Allow cold native builds to finish in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,10 @@ jobs:
   build:
     name: xcodebuild (macOS)
     runs-on: macos-15
-    timeout-minutes: 40
+    # A cold checksum-pinned llama.cpp source build can take more than 40
+    # minutes on GitHub's macOS runners. Keep enough headroom for that first
+    # build to finish and populate the shared Vendor cache.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
   release:
     name: Archive, notarize, publish
     runs-on: macos-15
-    timeout-minutes: 90
+    # A cache miss includes a full llama.cpp source build before archive,
+    # export, two notarization submissions, stapling, and publication.
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,9 @@ jobs:
   tests:
     name: xcodebuild test (macOS)
     runs-on: macos-15
-    timeout-minutes: 45
+    # Match the cold-build budget used by the compile gate, then leave room
+    # for the full app-hosted test suite before the Vendor cache is warm.
+    timeout-minutes: 100
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 


### PR DESCRIPTION
## Summary

- raise the Build job budget from 40 to 90 minutes
- raise the Tests job budget from 45 to 100 minutes
- raise the signed release job budget from 90 to 150 minutes

## Root cause

The first clean build after the checksum-pinned llama.cpp source-build change spent more than 40 minutes compiling the native runtime. GitHub cancelled the vendor step before the app build and skipped cache publication. The application code did not fail.

## Validation

- parsed all three edited workflow files as YAML
- `git diff --check`
- reproduced on master in Build run 29282232459, where `Fetch llama.cpp vendor` was cancelled at the job timeout