### PR TITLE
Harden privacy, recording, and inference lifecycle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,11 +72,11 @@ jobs:
       # The pre-build phase Scripts/fetch-llama.sh builds checksum-pinned
       # llama.cpp source for the app's deployment target into Vendor/. GGUF
       # models are user-selected downloads, not bundled in CI artifacts.
-      - name: Cache llama.cpp vendor
+      - name: Cache native vendors
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: Vendor
-          key: vendor-${{ runner.os }}-${{ hashFiles('Scripts/fetch-llama.sh') }}
+          key: vendor-${{ runner.os }}-${{ hashFiles('Scripts/fetch-llama.sh', 'Scripts/fetch-sherpa.sh') }}
 
       # Idempotent: a no-op on a cache hit, the real download on a miss. Running
       # it explicitly (rather than only via the xcodebuild pre-build phase) lets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,11 +131,11 @@ jobs:
       - name: Generate project
         run: xcodegen generate
 
-      - name: Cache llama.cpp vendor
+      - name: Cache native vendors
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: Vendor
-          key: vendor-${{ runner.os }}-${{ hashFiles('Scripts/fetch-llama.sh') }}
+          key: vendor-${{ runner.os }}-${{ hashFiles('Scripts/fetch-llama.sh', 'Scripts/fetch-sherpa.sh') }}
 
       - name: Fetch llama.cpp vendor
         run: bash Scripts/fetch-llama.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,12 +64,13 @@ jobs:
         run: xcodegen generate
 
       # The test host is the full app, so Vendor/ must be populated just like in
-      # the Build workflow. Same cache key (the fetch script) shares the cache.
-      - name: Cache llama.cpp vendor
+      # the Build workflow. The llama + Sherpa fetch scripts jointly key the
+      # cache, so either pinned native dependency invalidates stale contents.
+      - name: Cache native vendors
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: Vendor
-          key: vendor-${{ runner.os }}-${{ hashFiles('Scripts/fetch-llama.sh') }}
+          key: vendor-${{ runner.os }}-${{ hashFiles('Scripts/fetch-llama.sh', 'Scripts/fetch-sherpa.sh') }}
 
       - name: Fetch llama.cpp vendor
         run: bash Scripts/fetch-llama.sh

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -65,11 +65,11 @@ jobs:
       - name: Generate project
         run: xcodegen generate
 
-      - name: Cache llama.cpp vendor
+      - name: Cache native vendors
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: Vendor
-          key: vendor-${{ runner.os }}-${{ hashFiles('Scripts/fetch-llama.sh') }}
+          key: vendor-${{ runner.os }}-${{ hashFiles('Scripts/fetch-llama.sh', 'Scripts/fetch-sherpa.sh') }}
 
       - name: Fetch llama.cpp vendor
         run: bash Scripts/fetch-llama.sh

--- a/CLI/Commands/GetCommand.swift
+++ b/CLI/Commands/GetCommand.swift
@@ -28,23 +28,35 @@ struct GetCommand: AsyncParsableCommand {
     var format: String = "md"
 
     func run() async throws {
+        try AgentAccessGate().requireAuthorized()
+        let options = try parseOptions()
+        let normalizedFormat = format.lowercased()
+        guard normalizedFormat == "md" || normalizedFormat == "json" else {
+            throw ValidationError("Unknown format '\(format)'. Use 'md' or 'json'.")
+        }
         guard let meeting = try SessionLookup.find(id: id) else {
             throw ValidationError("No meeting with id '\(id)'. Run `list` to see available IDs.")
         }
-        let options = parseOptions()
-        switch format.lowercased() {
+        switch normalizedFormat {
         case "md":
             print(SessionFormatter.getMarkdown(meeting, options: options))
         case "json":
             print(SessionFormatter.getJSON(meeting, options: options))
-        default:
-            throw ValidationError("Unknown format '\(format)'. Use 'md' or 'json'.")
+        default: break
         }
     }
 
-    private func parseOptions() -> SessionFormatter.GetOptions {
+    private func parseOptions() throws -> SessionFormatter.GetOptions {
         let parts = include.split(separator: ",")
             .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+        let allowed = Set(["metadata", "summary", "transcript"])
+        let unknown = Set(parts).subtracting(allowed)
+        guard !parts.isEmpty, unknown.isEmpty else {
+            let detail = unknown.sorted().joined(separator: ", ")
+            throw ValidationError(detail.isEmpty
+                ? "--include must contain metadata, summary, or transcript."
+                : "Unknown --include value(s): \(detail).")
+        }
         return SessionFormatter.GetOptions(
             includeSummary: parts.contains("summary"),
             includeTranscript: parts.contains("transcript"),

--- a/CLI/Commands/ListCommand.swift
+++ b/CLI/Commands/ListCommand.swift
@@ -28,12 +28,19 @@ struct ListCommand: AsyncParsableCommand {
     var table: Bool = false
 
     func run() async throws {
+        try AgentAccessGate().requireAuthorized()
+        let sinceDate = try since.map { try Self.requireDate($0, option: "--since") }
+        let untilDate = try until.map { try Self.requireDate($0, option: "--until") }
+        if let limit, !(1...LibraryInputPolicy.maximumMeetingCount).contains(limit) {
+            throw ValidationError(
+                "--limit must be between 1 and \(LibraryInputPolicy.maximumMeetingCount).")
+        }
         var meetings = try SessionLookup.loadAllMeetings()
 
-        if let since, let date = Self.parseDate(since) {
+        if let date = sinceDate {
             meetings = meetings.filter { $0.startedAt >= date }
         }
-        if let until, let date = Self.parseDate(until) {
+        if let date = untilDate {
             let endOfDay = Calendar.current.date(byAdding: .day, value: 1, to: date) ?? date
             meetings = meetings.filter { $0.startedAt < endOfDay }
         }
@@ -53,5 +60,12 @@ struct ListCommand: AsyncParsableCommand {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withFullDate]
         return f.date(from: s)
+    }
+
+    private static func requireDate(_ value: String, option: String) throws -> Date {
+        guard let date = parseDate(value) else {
+            throw ValidationError("\(option) must use YYYY-MM-DD, got '\(value)'.")
+        }
+        return date
     }
 }

--- a/CLI/Commands/MCPCommand.swift
+++ b/CLI/Commands/MCPCommand.swift
@@ -34,10 +34,22 @@ struct MCPCommand: AsyncParsableCommand {
         FileHandle.standardError.write(Data(
             "lokalbot-cli mcp: serving on stdio (library: \(SessionLookup.storageRootURL.path))\n".utf8))
 
-        while let line = readLine(strippingNewline: true) {
-            guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { continue }
-            if let response = await dispatcher.handle(line: line) {
+        var reader = MCPStdioLineReader()
+        while true {
+            switch try reader.next() {
+            case .line(let line):
+                guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { continue }
+                if let response = await dispatcher.handle(line: line) {
+                    FileHandle.standardOutput.write(Data((response + "\n").utf8))
+                }
+            case .oversized:
+                let response = MCPResponse.failure(
+                    id: nil,
+                    code: -32600,
+                    message: "Request exceeds the 1 MiB limit")
                 FileHandle.standardOutput.write(Data((response + "\n").utf8))
+            case .end:
+                return
             }
         }
     }

--- a/CLI/Commands/PathCommand.swift
+++ b/CLI/Commands/PathCommand.swift
@@ -16,6 +16,7 @@ struct PathCommand: AsyncParsableCommand {
     var id: String?
 
     func run() async throws {
+        try AgentAccessGate().requireAuthorized()
         guard let id else {
             print(SessionLookup.storageRootURL.path(percentEncoded: false))
             return

--- a/CLI/Commands/SearchCommand.swift
+++ b/CLI/Commands/SearchCommand.swift
@@ -25,7 +25,20 @@ struct SearchCommand: AsyncParsableCommand {
     var table: Bool = false
 
     func run() async throws {
-        let hits = try LibrarySearch.hits(query: query, limit: limit)
+        try AgentAccessGate().requireAuthorized()
+        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedQuery.isEmpty else {
+            throw ValidationError("Query must not be empty.")
+        }
+        guard normalizedQuery.count <= LibraryInputPolicy.maximumQueryCharacters else {
+            throw ValidationError(
+                "Query must be at most \(LibraryInputPolicy.maximumQueryCharacters) characters.")
+        }
+        guard (1...LibraryInputPolicy.maximumSearchHits).contains(limit) else {
+            throw ValidationError(
+                "--limit must be between 1 and \(LibraryInputPolicy.maximumSearchHits).")
+        }
+        let hits = try LibrarySearch.hits(query: normalizedQuery, limit: limit)
         print(table
             ? SessionFormatter.searchTable(hits)
             : SessionFormatter.searchJSON(hits))

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -94,8 +94,8 @@ Models auto-download on first use (Hugging Face; the ONNX specialists fetch sher
 
 - **A coding agent in the sidebar:** the **Agent** section embeds the pi coding agent, preconnected to the same local Main LLM through an OpenAI-compatible shim — a coding agent running on your own GGUF (or whichever backend you configured). Sessions run in tabs, and an active session holds an inference lease so the model stays loaded while you work.
 - **Pi's own network behavior is disabled:** pi runs with `--offline`, version checks and crash reporting disabled. Enabling Agent Mode downloads its runtime once — a checksum-verified Bun release from GitHub plus the pi package from npm, pinned by a lockfile bundled with LokalBot. LLM requests stay local with the built-in backend; an approved remote Ollama or OpenAI-compatible endpoint receives agent context when selected.
-- **You approve the side effects:** `write` / `edit` / `bash` tool calls pause behind native approval cards before anything touches disk or shell; read-only tools run freely. Approved shell commands run with your macOS user permissions and may access files or the network.
-- **Headless:** `LokalBot --agent "<prompt>"` runs one agent turn from the terminal (see Headless flags).
+- **You approve sensitive access:** `write` / `edit` tool calls pause behind native approval cards unless you opt into file changes for the session. Every shell command and every read outside the selected workspace requires a fresh one-time approval. Approved shell commands run with your macOS user permissions and may access files or the network.
+- **Headless:** `LokalBot --agent "<prompt>"` runs one agent turn from the terminal (see Headless flags). It auto-approves file changes but safely declines shell and external-read requests because no person is present to review them.
 
 ## Screenshots, OCR & privacy
 

--- a/LokalBot/Agent/AgentApprovalPolicy.swift
+++ b/LokalBot/Agent/AgentApprovalPolicy.swift
@@ -6,23 +6,98 @@ enum ApprovalScope: Equatable {
 }
 
 /// Pure approval policy for gated agent tools. The bundled pi extension
-/// only raises approval requests for `write`, `edit`, and `bash` (reads run
-/// without asking — see Resources/pi/lokalbot-extension/index.ts). This type
+/// raises approval requests for `write`, `edit`, `bash`, and any `read` whose
+/// canonical path escapes the selected workspace. This type
 /// decides whether a raised request can be answered automatically
-/// (auto-approve toggle, session allowances) or must be shown to the user.
+/// (file-change toggle, session allowances) or must be shown to the user.
 struct AgentApprovalPolicy: Equatable {
-    var autoApproveAll = false
+    var autoApproveFileChanges = false
     private(set) var sessionAllowedTools: Set<String> = []
 
     enum Verdict: Equatable { case allow, ask }
 
-    func verdict(tool: String) -> Verdict {
-        if autoApproveAll || sessionAllowedTools.contains(tool) { return .allow }
+    func verdict(
+        tool: String,
+        path: String?,
+        requestWorkspace: String?,
+        selectedWorkspace: URL
+    ) -> Verdict {
+        // A read approval is only raised when pi's canonical path escapes the
+        // selected workspace. Bash can read or transmit arbitrary user files.
+        // Outside/malformed writes are privacy boundaries too. Only a canonical
+        // write/edit path inside the process's selected workspace may inherit a
+        // file-change toggle or a prior per-tool session allowance.
+        guard Self.canPersistApproval(
+            tool: tool,
+            path: path,
+            requestWorkspace: requestWorkspace,
+            selectedWorkspace: selectedWorkspace) else { return .ask }
+        if autoApproveFileChanges { return .allow }
+        if sessionAllowedTools.contains(tool.lowercased()) { return .allow }
         return .ask
     }
 
-    mutating func allowForSession(tool: String) {
-        sessionAllowedTools.insert(tool)
+    mutating func allowForSession(
+        tool: String,
+        path: String?,
+        requestWorkspace: String?,
+        selectedWorkspace: URL
+    ) {
+        guard Self.canPersistApproval(
+            tool: tool,
+            path: path,
+            requestWorkspace: requestWorkspace,
+            selectedWorkspace: selectedWorkspace) else { return }
+        sessionAllowedTools.insert(tool.lowercased())
+    }
+
+    static func requiresExplicitPerRequestApproval(tool: String) -> Bool {
+        tool.lowercased() == "read" || tool.lowercased() == "bash"
+    }
+
+    static func canPersistApproval(
+        tool: String,
+        path: String?,
+        requestWorkspace: String?,
+        selectedWorkspace: URL
+    ) -> Bool {
+        guard isFileChange(tool: tool),
+              let path,
+              let requestWorkspace,
+              let requestedRoot = canonicalFileURL(URL(fileURLWithPath: requestWorkspace)),
+              let selectedRoot = canonicalFileURL(selectedWorkspace),
+              requestedRoot.path == selectedRoot.path,
+              let requestedFile = canonicalFileURL(URL(fileURLWithPath: path)) else {
+            return false
+        }
+        let rootComponents = selectedRoot.pathComponents
+        let fileComponents = requestedFile.pathComponents
+        return fileComponents.count >= rootComponents.count
+            && Array(fileComponents.prefix(rootComponents.count)) == rootComponents
+    }
+
+    private static func isFileChange(tool: String) -> Bool {
+        tool.lowercased() == "write" || tool.lowercased() == "edit"
+    }
+
+    /// Resolve symlinks through the nearest existing ancestor, then append any
+    /// not-yet-created suffix. This matches the bundled extension's path rule
+    /// and prevents a symlinked parent from turning an apparently local write
+    /// into an external one.
+    private static func canonicalFileURL(_ url: URL) -> URL? {
+        var ancestor = url.standardizedFileURL
+        var suffix: [String] = []
+        while !FileManager.default.fileExists(atPath: ancestor.path) {
+            let parent = ancestor.deletingLastPathComponent()
+            guard parent.path != ancestor.path else { return nil }
+            suffix.insert(ancestor.lastPathComponent, at: 0)
+            ancestor = parent
+        }
+        var resolved = ancestor.resolvingSymlinksInPath()
+        for component in suffix {
+            resolved.appendPathComponent(component)
+        }
+        return resolved.standardizedFileURL
     }
 
     mutating func resetSession() {

--- a/LokalBot/Agent/AgentLLMEndpoint.swift
+++ b/LokalBot/Agent/AgentLLMEndpoint.swift
@@ -50,6 +50,11 @@ enum AgentLLMEndpointResolver {
                 return .unsupported(
                     reason: "Approve this remote Ollama server under Settings → Models before Agent Mode sends context to it.")
             }
+            guard InferenceEndpointPolicy.isLoopback(base)
+                    || base.scheme?.lowercased() == "https" else {
+                return .unsupported(
+                    reason: "Remote Ollama servers must use HTTPS so meeting context is encrypted in transit.")
+            }
             guard !settings.ollamaModel.isEmpty else {
                 return .unsupported(reason: "Pick an Ollama model under Settings → Models — Agent Mode needs an explicit model.")
             }
@@ -67,6 +72,11 @@ enum AgentLLMEndpointResolver {
                 base, approvedOrigins: settings.approvedRemoteInferenceOrigins) else {
                 return .unsupported(
                     reason: "Approve this remote inference server under Settings → Models before Agent Mode sends context to it.")
+            }
+            guard InferenceEndpointPolicy.isLoopback(base)
+                    || base.scheme?.lowercased() == "https" else {
+                return .unsupported(
+                    reason: "Remote inference servers must use HTTPS; LokalBot will not send meeting context or API keys over HTTP.")
             }
             guard !settings.openAIModel.isEmpty else {
                 return .unsupported(reason: "Set a model name for the OpenAI-compatible server under Settings → Models.")

--- a/LokalBot/Agent/AgentRuntime.swift
+++ b/LokalBot/Agent/AgentRuntime.swift
@@ -1,11 +1,11 @@
 import CryptoKit
 import Foundation
 
-enum AgentArchiveKind: Equatable {
+enum AgentArchiveKind: Equatable, Sendable {
     case zip, tarGz
 }
 
-struct AgentRuntimeArtifact: Equatable {
+struct AgentRuntimeArtifact: Equatable, Sendable {
     let name: String
     let url: URL
     let sha256: String        // lowercase hex
@@ -15,8 +15,27 @@ struct AgentRuntimeArtifact: Equatable {
 /// Pinned runtime components for Agent Mode. Bun is downloaded as a
 /// checksum-verified release archive. pi is installed from the public npm
 /// registry using the frozen lockfile bundled with LokalBot.
-struct AgentRuntimeManifest: Equatable {
+struct AgentRuntimeManifest: Equatable, Sendable {
     let bun: AgentRuntimeArtifact
+    let bunBinarySHA256: String?
+    let piCLISHA256: String?
+    let packageJSONSHA256: String?
+    let lockfileSHA256: String?
+    let piRuntimeTreeSHA256: String?
+
+    init(bun: AgentRuntimeArtifact,
+         bunBinarySHA256: String? = nil,
+         piCLISHA256: String? = nil,
+         packageJSONSHA256: String? = nil,
+         lockfileSHA256: String? = nil,
+         piRuntimeTreeSHA256: String? = nil) {
+        self.bun = bun
+        self.bunBinarySHA256 = bunBinarySHA256
+        self.piCLISHA256 = piCLISHA256
+        self.packageJSONSHA256 = packageJSONSHA256
+        self.lockfileSHA256 = lockfileSHA256
+        self.piRuntimeTreeSHA256 = piRuntimeTreeSHA256
+    }
 
     static let bunVersion = "1.3.14"
     static let piVersion = "0.80.3"
@@ -26,7 +45,23 @@ struct AgentRuntimeManifest: Equatable {
             name: "Bun \(bunVersion)",
             url: URL(string: "https://github.com/oven-sh/bun/releases/download/bun-v\(bunVersion)/bun-darwin-aarch64.zip")!,
             sha256: "d8b96221828ad6f97ac7ac0ab7e95872341af763001e8803e8267652c2652620",
-            archiveKind: .zip))
+            archiveKind: .zip),
+        bunBinarySHA256: "e0c90ec15d33363e6b70713d56bc3b2c7585c17f40a0fe0f8fd9305901d4e233",
+        piCLISHA256: "af302f231437eaf6f37691bce4b34234fcb626bcb5eb3910d4fc3f6519bf78ca",
+        packageJSONSHA256: "de26644ce5bd02d5ab06da79f2c52bb14a1a9ffb2741d6f5b1dbc7fe31c04d51",
+        lockfileSHA256: "2015685bbfa61c88d8351a5e9fb500edf51e605f1fa01102cd9a5a2925014147",
+        piRuntimeTreeSHA256: "44db8e5fdb7ed4aadd24e8df4bf4a6bba4720175656d5ca6879a7e786a59e0de")
+}
+
+struct AgentRuntimeVersionMarker: Codable, Equatable {
+    let bunVersion: String
+    let piVersion: String
+    let bunArchiveSHA256: String
+    let bunBinarySHA256: String
+    let piCLISHA256: String
+    let packageJSONSHA256: String
+    let lockfileSHA256: String
+    let piRuntimeTreeSHA256: String
 }
 
 /// On-disk layout of the installed runtime. Lives in Application Support
@@ -46,13 +81,43 @@ enum AgentRuntimeLayout {
         root.appendingPathComponent("pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js")
     }
 
-    static func isInstalled(under root: URL = defaultRoot) -> Bool {
-        FileManager.default.isExecutableFile(atPath: bunBinary(under: root).path)
-            && FileManager.default.fileExists(atPath: piCLI(under: root).path)
+    static func isInstalled(under root: URL = defaultRoot,
+                            manifest: AgentRuntimeManifest = .current) -> Bool {
+        let bun = bunBinary(under: root)
+        let cli = piCLI(under: root)
+        guard FileManager.default.isExecutableFile(atPath: bun.path),
+              FileManager.default.fileExists(atPath: cli.path),
+              let data = try? Data(contentsOf: versionMarker(under: root)),
+              let marker = try? JSONDecoder().decode(AgentRuntimeVersionMarker.self, from: data),
+              marker.bunVersion == AgentRuntimeManifest.bunVersion,
+              marker.piVersion == AgentRuntimeManifest.piVersion,
+              marker.bunArchiveSHA256 == manifest.bun.sha256.lowercased(),
+              let bunDigest = try? SHA256Verifier.hexDigest(of: bun),
+              let cliDigest = try? SHA256Verifier.hexDigest(of: cli),
+              bunDigest == marker.bunBinarySHA256,
+              cliDigest == marker.piCLISHA256,
+              manifest.bunBinarySHA256.map({ $0.lowercased() == bunDigest }) ?? true,
+              manifest.piCLISHA256.map({ $0.lowercased() == cliDigest }) ?? true else {
+            return false
+        }
+        let packageJSON = root.appendingPathComponent("pi/package.json")
+        let lockfile = root.appendingPathComponent("pi/bun.lock")
+        let piRuntime = root.appendingPathComponent("pi", isDirectory: true)
+        guard let packageDigest = try? SHA256Verifier.hexDigest(of: packageJSON),
+              let lockDigest = try? SHA256Verifier.hexDigest(of: lockfile),
+              let treeDigest = try? SHA256Verifier.treeHexDigest(of: piRuntime),
+              packageDigest == marker.packageJSONSHA256,
+              lockDigest == marker.lockfileSHA256,
+              treeDigest == marker.piRuntimeTreeSHA256,
+              manifest.packageJSONSHA256.map({ $0.lowercased() == packageDigest }) ?? true,
+              manifest.lockfileSHA256.map({ $0.lowercased() == lockDigest }) ?? true,
+              manifest.piRuntimeTreeSHA256.map({ $0.lowercased() == treeDigest }) ?? true else {
+            return false
+        }
+        return true
     }
 
-    /// Written at install time with the manifest's Bun and pi versions.
-    /// Data for a future update path; `isInstalled` stays an existence check.
+    /// Written at install time with versions and verified artifact digests.
     static func versionMarker(under root: URL) -> URL {
         root.appendingPathComponent("version.json")
     }
@@ -66,14 +131,103 @@ enum AgentRuntimeLayout {
 }
 
 enum SHA256Verifier {
+    enum DigestError: Error {
+        case notDirectory(String)
+        case unsupportedTreeEntry(String)
+    }
+
     /// Streaming digest so ~60 MB artifacts don't land in memory at once.
     static func hexDigest(of url: URL) throws -> String {
+        try digest(of: url).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Deterministic digest of a directory's complete shape and contents.
+    /// Records are ordered by raw UTF-8 path, length-delimited, and tagged by
+    /// file type. Symlinks hash their link text and are never followed; regular
+    /// files hash their bytes. Directory records make empty/additional
+    /// directories visible too. Metadata and absolute install paths are
+    /// deliberately excluded so identical installs hash identically.
+    static func treeHexDigest(of root: URL) throws -> String {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            throw DigestError.notDirectory(root.path)
+        }
+
+        var hasher = SHA256()
+        try hashDirectory(root, relativePath: "", into: &hasher)
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func digest(of url: URL) throws -> SHA256.Digest {
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
         var hasher = SHA256()
         while let chunk = try handle.read(upToCount: 1 << 20), !chunk.isEmpty {
             hasher.update(data: chunk)
         }
-        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+        return hasher.finalize()
+    }
+
+    private static func hashDirectory(
+        _ directory: URL,
+        relativePath: String,
+        into hasher: inout SHA256
+    ) throws {
+        let keys: Set<URLResourceKey> = [
+            .isDirectoryKey,
+            .isRegularFileKey,
+            .isSymbolicLinkKey,
+        ]
+        let entries = try FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: Array(keys),
+            options: [])
+            .sorted {
+                $0.lastPathComponent.utf8.lexicographicallyPrecedes(
+                    $1.lastPathComponent.utf8)
+            }
+
+        for entry in entries {
+            let path = relativePath.isEmpty
+                ? entry.lastPathComponent
+                : "\(relativePath)/\(entry.lastPathComponent)"
+            let values = try entry.resourceValues(forKeys: keys)
+            if values.isSymbolicLink == true {
+                let destination = try FileManager.default.destinationOfSymbolicLink(
+                    atPath: entry.path)
+                updateRecord(kind: 0x6C, path: path, payload: Data(destination.utf8), into: &hasher)
+            } else if values.isDirectory == true {
+                updateRecord(kind: 0x64, path: path, payload: Data(), into: &hasher)
+                try hashDirectory(entry, relativePath: path, into: &hasher)
+            } else if values.isRegularFile == true {
+                updateRecord(
+                    kind: 0x66,
+                    path: path,
+                    payload: Data(try digest(of: entry)),
+                    into: &hasher)
+            } else {
+                throw DigestError.unsupportedTreeEntry(entry.path)
+            }
+        }
+    }
+
+    private static func updateRecord(
+        kind: UInt8,
+        path: String,
+        payload: Data,
+        into hasher: inout SHA256
+    ) {
+        hasher.update(data: Data([kind]))
+        updateLengthPrefixed(Data(path.utf8), into: &hasher)
+        updateLengthPrefixed(payload, into: &hasher)
+    }
+
+    private static func updateLengthPrefixed(_ data: Data, into hasher: inout SHA256) {
+        var length = UInt64(data.count).bigEndian
+        withUnsafeBytes(of: &length) { bytes in
+            hasher.update(data: Data(bytes))
+        }
+        hasher.update(data: data)
     }
 }

--- a/LokalBot/Agent/AgentRuntimeInstaller.swift
+++ b/LokalBot/Agent/AgentRuntimeInstaller.swift
@@ -8,8 +8,10 @@ import Foundation
 final class AgentRuntimeInstaller: ObservableObject {
 
     typealias PackageInstaller = (_ bun: URL, _ template: URL, _ destination: URL) async throws -> Void
+    typealias RuntimeVerifier = @Sendable (URL, AgentRuntimeManifest) async -> Bool
 
     enum Phase: Equatable {
+        case checking
         case idle
         case downloading(name: String, progress: Double)   // 0…1; -1 when length unknown
         case installing(name: String)
@@ -23,22 +25,44 @@ final class AgentRuntimeInstaller: ObservableObject {
     private let session: URLSession
     private let runtimeTemplate: URL
     private let packageInstaller: PackageInstaller
+    private let runtimeVerifier: RuntimeVerifier
+    private var operationInProgress = false
 
     init(root: URL = AgentRuntimeLayout.defaultRoot,
          session: URLSession = .shared,
          runtimeTemplate: URL? = nil,
-         packageInstaller: @escaping PackageInstaller = AgentRuntimeInstaller.installPackages) {
+         packageInstaller: @escaping PackageInstaller = AgentRuntimeInstaller.installPackages,
+         runtimeVerifier: @escaping RuntimeVerifier = { root, manifest in
+             await AgentRuntimeInstaller.verifyInstalledRuntime(root: root, manifest: manifest)
+         }) {
         self.root = root
         self.session = session
         self.runtimeTemplate = runtimeTemplate
             ?? Bundle.main.resourceURL?.appendingPathComponent("pi/runtime", isDirectory: true)
             ?? URL(fileURLWithPath: "pi/runtime", isDirectory: true)
         self.packageInstaller = packageInstaller
-        if AgentRuntimeLayout.isInstalled(under: root) { phase = .installed }
+        self.runtimeVerifier = runtimeVerifier
+        phase = .checking
+    }
+
+    /// Called when Agent Mode first appears. Runtime hashing can cover Bun,
+    /// pi, and the lockfile, so verification runs on a utility executor rather
+    /// than blocking AppState construction and the first SwiftUI frame.
+    func refreshInstalledState(manifest: AgentRuntimeManifest = .current) async {
+        guard phase == .checking, !operationInProgress else { return }
+        operationInProgress = true
+        let installed = await runtimeVerifier(root, manifest)
+        operationInProgress = false
+        guard phase == .checking else { return }
+        phase = installed ? .installed : .idle
     }
 
     func installIfNeeded(manifest: AgentRuntimeManifest = .current) async {
-        guard !AgentRuntimeLayout.isInstalled(under: root) else {
+        guard !operationInProgress else { return }
+        operationInProgress = true
+        defer { operationInProgress = false }
+        phase = .checking
+        guard !(await runtimeVerifier(root, manifest)) else {
             phase = .installed
             return
         }
@@ -59,6 +83,13 @@ final class AgentRuntimeInstaller: ObservableObject {
             }
             try FileManager.default.setAttributes([.posixPermissions: 0o755],
                                                   ofItemAtPath: bunBinary.path)
+            let bunBinaryDigest = try SHA256Verifier.hexDigest(of: bunBinary)
+            if let expected = manifest.bunBinarySHA256,
+               bunBinaryDigest != expected.lowercased() {
+                throw InstallError.checksum(manifest.bun.name)
+            }
+
+            try Self.verifyTemplate(runtimeTemplate, manifest: manifest)
 
             phase = .installing(name: "pi \(AgentRuntimeManifest.piVersion)")
             let piStage = staging.appendingPathComponent("pi-install", isDirectory: true)
@@ -67,6 +98,16 @@ final class AgentRuntimeInstaller: ObservableObject {
                 "node_modules/@earendil-works/pi-coding-agent/dist/cli.js")
             guard FileManager.default.fileExists(atPath: stagedCLI.path) else {
                 throw InstallError.layout("pi cli.js missing from bundle")
+            }
+            let piCLIDigest = try SHA256Verifier.hexDigest(of: stagedCLI)
+            if let expected = manifest.piCLISHA256,
+               piCLIDigest != expected.lowercased() {
+                throw InstallError.checksum("pi \(AgentRuntimeManifest.piVersion)")
+            }
+            let piRuntimeTreeDigest = try SHA256Verifier.treeHexDigest(of: piStage)
+            if let expected = manifest.piRuntimeTreeSHA256,
+               piRuntimeTreeDigest != expected.lowercased() {
+                throw InstallError.checksum("pi \(AgentRuntimeManifest.piVersion) runtime")
             }
 
             let assembled = staging.appendingPathComponent("agent-runtime", isDirectory: true)
@@ -78,11 +119,23 @@ final class AgentRuntimeInstaller: ObservableObject {
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: installedBun.path)
             try FileManager.default.moveItem(at: piStage, to: assembled.appendingPathComponent("pi"))
 
-            let marker = try JSONSerialization.data(
-                withJSONObject: ["bun": AgentRuntimeManifest.bunVersion,
-                                 "pi": AgentRuntimeManifest.piVersion],
-                options: [.sortedKeys])
-            try marker.write(to: AgentRuntimeLayout.versionMarker(under: assembled))
+            let packageDigest = try SHA256Verifier.hexDigest(
+                of: assembled.appendingPathComponent("pi/package.json"))
+            let lockDigest = try SHA256Verifier.hexDigest(
+                of: assembled.appendingPathComponent("pi/bun.lock"))
+            let marker = AgentRuntimeVersionMarker(
+                bunVersion: AgentRuntimeManifest.bunVersion,
+                piVersion: AgentRuntimeManifest.piVersion,
+                bunArchiveSHA256: manifest.bun.sha256.lowercased(),
+                bunBinarySHA256: bunBinaryDigest,
+                piCLISHA256: piCLIDigest,
+                packageJSONSHA256: packageDigest,
+                lockfileSHA256: lockDigest,
+                piRuntimeTreeSHA256: piRuntimeTreeDigest)
+            let markerURL = AgentRuntimeLayout.versionMarker(under: assembled)
+            try JSONEncoder().encode(marker).write(to: markerURL, options: .atomic)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600], ofItemAtPath: markerURL.path)
 
             try? FileManager.default.removeItem(at: root)
             try FileManager.default.createDirectory(at: root.deletingLastPathComponent(),
@@ -92,6 +145,15 @@ final class AgentRuntimeInstaller: ObservableObject {
         } catch {
             phase = .failed(Self.userMessage(for: error))
         }
+    }
+
+    nonisolated static func verifyInstalledRuntime(
+        root: URL,
+        manifest: AgentRuntimeManifest
+    ) async -> Bool {
+        await Task.detached(priority: .utility) {
+            AgentRuntimeLayout.isInstalled(under: root, manifest: manifest)
+        }.value
     }
 
     // MARK: - Frozen package install
@@ -145,34 +207,38 @@ final class AgentRuntimeInstaller: ObservableObject {
         }
     }
 
+    private static func verifyTemplate(
+        _ template: URL,
+        manifest: AgentRuntimeManifest
+    ) throws {
+        let packageJSON = template.appendingPathComponent("package.json")
+        let lockfile = template.appendingPathComponent("bun.lock")
+        if let expected = manifest.packageJSONSHA256,
+           try SHA256Verifier.hexDigest(of: packageJSON) != expected.lowercased() {
+            throw InstallError.checksum("pi package manifest")
+        }
+        if let expected = manifest.lockfileSHA256,
+           try SHA256Verifier.hexDigest(of: lockfile) != expected.lowercased() {
+            throw InstallError.checksum("pi lockfile")
+        }
+    }
+
     // MARK: - Download + verify
 
     private func download(_ artifact: AgentRuntimeArtifact, into staging: URL) async throws -> URL {
         phase = .downloading(name: artifact.name, progress: 0)
         let destination = staging.appendingPathComponent(artifact.url.lastPathComponent)
-        let (bytes, response) = try await session.bytes(from: artifact.url)
-        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
-            throw InstallError.download(artifact.name, "HTTP \(http.statusCode)")
-        }
-        let expected = response.expectedContentLength
-        FileManager.default.createFile(atPath: destination.path, contents: nil)
-        let handle = try FileHandle(forWritingTo: destination)
-        defer { try? handle.close() }
-        var received: Int64 = 0
-        var chunk = Data()
-        chunk.reserveCapacity(1 << 16)
-        for try await byte in bytes {
-            chunk.append(byte)
-            if chunk.count == 1 << 16 {
-                try handle.write(contentsOf: chunk)
-                received += Int64(chunk.count)
-                chunk.removeAll(keepingCapacity: true)
-                phase = .downloading(name: artifact.name,
-                                     progress: expected > 0 ? Double(received) / Double(expected) : -1)
+        if artifact.url.isFileURL {
+            try FileManager.default.copyItem(at: artifact.url, to: destination)
+        } else {
+            phase = .downloading(name: artifact.name, progress: -1)
+            let (temporary, response) = try await session.download(from: artifact.url)
+            if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+                throw InstallError.download(artifact.name, "HTTP \(http.statusCode)")
             }
+            try FileManager.default.moveItem(at: temporary, to: destination)
         }
-        try handle.write(contentsOf: chunk)
-        try handle.close()
+        phase = .downloading(name: artifact.name, progress: 1)
 
         guard try SHA256Verifier.hexDigest(of: destination).lowercased() == artifact.sha256.lowercased() else {
             throw InstallError.checksum(artifact.name)

--- a/LokalBot/Agent/AgentSessionController.swift
+++ b/LokalBot/Agent/AgentSessionController.swift
@@ -24,7 +24,7 @@ final class AgentSessionController: ObservableObject {
     @Published var workspace: URL
     @Published var draft = ""
     @Published var autoApproveSession = false {
-        didSet { policy.autoApproveAll = autoApproveSession }
+        didSet { policy.autoApproveFileChanges = autoApproveSession }
     }
 
     private let settings: () -> AppSettings
@@ -33,6 +33,7 @@ final class AgentSessionController: ObservableObject {
     private let sessionsDirectory: URL
     private let broker: InferenceBroker
     private let makeTransport: ((PiLaunchPlan) async throws -> PiLineTransport)?
+    private let accessGate: AgentAccessGate
 
     private var policy = AgentApprovalPolicy()
     private var folder = AgentTranscriptFolder()
@@ -47,22 +48,29 @@ final class AgentSessionController: ObservableObject {
     /// Without this, a close during model warm-up could finish spawning pi
     /// after shutdown() had already returned.
     private var lifecycleGeneration = 0
+    /// Serializes failure cleanup with shutdown/restart. A failed state is not
+    /// published until this returns to false, so a replacement process can
+    /// never launch while its predecessor is still being terminated.
+    private var failureTeardownInProgress = false
     /// Held from resolveEndpoint (built-in engine only) until shutdown or
     /// failure, so the Main LLM cannot be evicted mid-conversation by an
     /// unrelated model load.
     private var llmLease: InferenceLease?
+    private var accessCapability: AgentAccessCapability?
 
     init(settings: @escaping () -> AppSettings,
          storage: StorageManager,
          runtimeRoot: URL = AgentRuntimeLayout.defaultRoot,
          sessionsDirectory: URL = AgentRuntimeLayout.sessionsDirectory,
          broker: InferenceBroker = .shared,
+         accessGate: AgentAccessGate? = nil,
          makeTransport: ((PiLaunchPlan) async throws -> PiLineTransport)? = nil) {
         self.settings = settings
         self.storage = storage
         self.runtimeRoot = runtimeRoot
         self.sessionsDirectory = sessionsDirectory
         self.broker = broker
+        self.accessGate = accessGate ?? AgentAccessGate(root: storage.rootURL)
         self.makeTransport = makeTransport
         self.workspace = storage.rootURL
     }
@@ -70,7 +78,8 @@ final class AgentSessionController: ObservableObject {
     // MARK: - Lifecycle
 
     func start() async {
-        guard state == .idle || isFailed else { return }
+        guard !failureTeardownInProgress,
+              state == .idle || isFailed else { return }
         lifecycleGeneration += 1
         let generation = lifecycleGeneration
         state = .starting
@@ -83,7 +92,14 @@ final class AgentSessionController: ObservableObject {
                 releaseLLMLease()
                 return
             }
-            let plan = makePlan(endpoint: endpoint)
+            var capabilityToken: String?
+            if makeTransport == nil {
+                accessGate.removeExpiredCapabilities()
+                let capability = try accessGate.issueScopedCapability()
+                accessCapability = capability
+                capabilityToken = capability.token
+            }
+            let plan = makePlan(endpoint: endpoint, capabilityToken: capabilityToken)
             let transport: PiLineTransport
             var spawnedProcess: PiProcess?
             if let makeTransport {
@@ -106,25 +122,36 @@ final class AgentSessionController: ObservableObject {
                 return
             }
             client = rpc
-            consumeEvents(from: rpc)
+            consumeEvents(from: rpc, generation: generation)
             if launchMode == .continueRecent {
                 await restorePreviousMessages(using: rpc)
             }
             state = .ready
         } catch {
             guard generation == lifecycleGeneration else { return }
+            revokeAccessCapability()
             setFailure(error)
         }
     }
 
     func shutdown() async {
+        while failureTeardownInProgress {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
         lifecycleGeneration += 1
+        await cancelPendingApprovals()
         eventTask?.cancel()
         eventTask = nil
         discardPendingTextDelta()
+        // Revoke access before giving a hung child its SIGTERM grace period.
+        // Closing a tab must close the meeting-library capability immediately,
+        // even if pi ignores termination until the SIGKILL fallback.
+        revokeAccessCapability()
         await process?.stop()
         process = nil
         client = nil
+        policy.resetSession()
+        autoApproveSession = false
         releaseLLMLease()
         state = .idle
     }
@@ -147,7 +174,7 @@ final class AgentSessionController: ObservableObject {
                 publish()
             }
         } catch {
-            fail(with: error)
+            await fail(with: error)
         }
     }
 
@@ -169,7 +196,7 @@ final class AgentSessionController: ObservableObject {
             publish()
             state = .ready
         } catch {
-            fail(with: error)
+            await fail(with: error)
         }
     }
 
@@ -191,36 +218,51 @@ final class AgentSessionController: ObservableObject {
 
     func respondToApproval(id: String, approved: Bool, scope: ApprovalScope) async {
         guard let client else { return }
-        let tool = pendingApprovalTool(requestID: id)
-        if approved, scope == .session,
-           let tool {
-            policy.allowForSession(tool: tool)
+        guard let request = pendingApprovalRequest(requestID: id) else { return }
+        if approved, scope == .session {
+            policy.allowForSession(
+                tool: request.tool,
+                path: request.path,
+                requestWorkspace: request.workspace,
+                selectedWorkspace: workspace)
         }
         folder.resolveApproval(requestID: id)
         if !approved {
-            folder.appendNotice("You denied this \(tool ?? "tool") request. Nothing changed.")
+            folder.appendNotice("You denied this \(request.tool) request. Nothing changed.")
         }
         publish()
         try? await client.sendResponse(.uiConfirmResponse(requestID: id, confirmed: approved))
     }
 
+    /// Unattended callers have nobody available to inspect sensitive requests.
+    /// Resolve every card as a one-time denial so the pi turn cannot hang.
+    func denyAllPendingApprovals() async {
+        for id in folder.pendingApprovalIDs {
+            await respondToApproval(id: id, approved: false, scope: .once)
+        }
+    }
+
     // MARK: - Event loop
 
-    private func consumeEvents(from client: PiRPCClient) {
+    private func consumeEvents(from client: PiRPCClient, generation: Int) {
+        eventTask?.cancel()
         eventTask = Task { [weak self] in
             guard let self else { return }
             for await event in client.events {
                 guard !Task.isCancelled else { return }
-                await self.handle(event)
+                await self.handle(event, generation: generation)
             }
             // shutdown() cancels this task and only later sets .idle; a
             // cancelled iteration ending must not fold a spurious failure.
             guard !Task.isCancelled else { return }
-            await self.handleStreamEnd()
+            await self.handleStreamEnd(generation: generation)
         }
     }
 
-    private func handle(_ event: PiEvent) async {
+    private func handle(_ event: PiEvent, generation: Int) async {
+        guard generation == lifecycleGeneration,
+              state != .idle,
+              !isFailed else { return }
         // Pi can emit hundreds of token deltas per second. Fold and publish
         // those as one string at display cadence; structural events flush the
         // pending text first so message/tool/approval ordering stays exact.
@@ -252,27 +294,35 @@ final class AgentSessionController: ObservableObject {
             return
         }
         let approval = Self.parseApprovalPayload(request)
-        switch policy.verdict(tool: approval.tool) {
+        switch policy.verdict(
+            tool: approval.tool,
+            path: approval.path,
+            requestWorkspace: approval.workspace,
+            selectedWorkspace: workspace) {
         case .allow:
             try? await client.sendResponse(.uiConfirmResponse(requestID: request.id, confirmed: true))
         case .ask:
-            folder.addApproval(approval)
+            if !folder.addApproval(approval) {
+                folder.appendNotice(
+                    "The newest tool approval exceeded safety limits or too many are already waiting; it was declined.",
+                    isError: true)
+                try? await client.sendResponse(.uiCancelResponse(requestID: request.id))
+            }
         }
     }
 
-    private func handleStreamEnd() async {
-        guard state != .idle else { return }
+    private func handleStreamEnd(generation: Int) async {
+        guard generation == lifecycleGeneration,
+              state != .idle,
+              !isFailed else { return }
         flushPendingTextDelta()
         var detail = "The agent process exited unexpectedly."
         if let process {
             let tail = await process.stderrTail
             if !tail.isEmpty { detail += "\n" + tail.suffix(5).joined(separator: "\n") }
         }
-        folder.appendNotice(detail, isError: true)
-        publish()
-        releaseLLMLease()
-        state = .failed(detail)
-        recoveryAction = .restart
+        guard generation == lifecycleGeneration else { return }
+        await transitionToFailure(message: detail, recovery: .restart)
     }
 
     // MARK: - Endpoint + plan
@@ -291,16 +341,17 @@ final class AgentSessionController: ObservableObject {
             llmLease = try await broker.lease(.mainLLM, model: modelURL,
                                               priority: .interactive,
                                               purpose: "agent session")
+            let authenticationToken = await LlamaServer.shared.authenticationToken()
             return AgentLLMEndpoint(baseURL: LlamaServer.shared.baseURL,
                                     model: entry.id,
                                     contextTokens: AgentLLMEndpoint.defaultContextTokens,
-                                    apiKey: nil)
+                                    apiKey: authenticationToken)
         case .unsupported(let reason):
             throw StartError.modelConfiguration(reason)
         }
     }
 
-    private func makePlan(endpoint: AgentLLMEndpoint) -> PiLaunchPlan {
+    private func makePlan(endpoint: AgentLLMEndpoint, capabilityToken: String?) -> PiLaunchPlan {
         let resources = Bundle.main.resourceURL
         let extensionDir = resources?.appendingPathComponent("pi/lokalbot-extension")
             ?? URL(fileURLWithPath: "pi/lokalbot-extension")
@@ -318,6 +369,7 @@ final class AgentSessionController: ObservableObject {
             workspace: workspace,
             endpoint: endpoint,
             helpersDirectory: FileManager.default.fileExists(atPath: helpers.path) ? helpers : nil,
+            agentAccessCapability: capabilityToken,
             continuePreviousSession: launchMode == .continueRecent)
     }
 
@@ -328,11 +380,13 @@ final class AgentSessionController: ObservableObject {
     }
 
     private func publish() {
+        folder.enforceResourceLimits()
         items = folder.items
     }
 
     private func enqueueTextDelta(_ delta: String) {
-        pendingTextDelta.append(delta)
+        let room = max(0, AgentTranscriptFolder.maximumMessageCharacters - pendingTextDelta.count)
+        if room > 0 { pendingTextDelta.append(contentsOf: delta.prefix(room)) }
         guard deltaFlushTask == nil else { return }
         deltaFlushTask = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(33))
@@ -366,29 +420,86 @@ final class AgentSessionController: ObservableObject {
         Task { await broker.release(lease) }
     }
 
+    private func revokeAccessCapability() {
+        guard let capability = accessCapability else { return }
+        accessCapability = nil
+        accessGate.revoke(capability)
+    }
+
+    private func cancelPendingApprovals() async {
+        let ids = folder.pendingApprovalIDs
+        if let client {
+            for id in ids {
+                try? await client.sendResponse(.uiCancelResponse(requestID: id))
+            }
+        }
+        folder.resolveAllApprovals()
+        publish()
+    }
+
     private func freshID(_ prefix: String) -> String {
         nextRequestID += 1
         return "\(prefix)\(nextRequestID)"
     }
 
-    private func pendingApprovalTool(requestID: String) -> String? {
+    private func pendingApprovalRequest(requestID: String) -> AgentApprovalRequest? {
         for item in folder.items {
-            if case .approval(let request) = item, request.id == requestID { return request.tool }
+            if case .approval(let request) = item, request.id == requestID { return request }
         }
         return nil
     }
 
-    private func fail(with error: Error) {
+    func canAllowForSession(_ request: AgentApprovalRequest) -> Bool {
+        AgentApprovalPolicy.canPersistApproval(
+            tool: request.tool,
+            path: request.path,
+            requestWorkspace: request.workspace,
+            selectedWorkspace: workspace)
+    }
+
+    private func fail(with error: Error) async {
         flushPendingTextDelta()
         let message = Self.message(for: error)
+        await transitionToFailure(message: message, recovery: .restart)
+    }
+
+    /// Invalidates the current event generation before awaiting subprocess
+    /// shutdown. That prevents already-buffered frames from reviving `.ready`
+    /// or `.running` while teardown yields, and keeps restart disabled until
+    /// the old process has actually been terminated.
+    private func transitionToFailure(message: String, recovery: RecoveryAction) async {
+        guard !failureTeardownInProgress,
+              state != .idle,
+              !isFailed else { return }
+        failureTeardownInProgress = true
+        lifecycleGeneration += 1
+        let failureGeneration = lifecycleGeneration
+        recoveryAction = nil
+        eventTask?.cancel()
+        eventTask = nil
+        discardPendingTextDelta()
+        let oldProcess = process
+        process = nil
+        client = nil
+        folder.resolveAllApprovals()
+        policy.resetSession()
+        autoApproveSession = false
+        revokeAccessCapability()
         folder.appendNotice(message, isError: true)
         publish()
         releaseLLMLease()
+        await oldProcess?.stop()
+        failureTeardownInProgress = false
+        guard failureGeneration == lifecycleGeneration else { return }
         state = .failed(message)
-        recoveryAction = .restart
+        recoveryAction = recovery
     }
 
     private func setFailure(_ error: Error) {
+        folder.resolveAllApprovals()
+        policy.resetSession()
+        autoApproveSession = false
+        revokeAccessCapability()
         releaseLLMLease()
         state = .failed(Self.message(for: error))
         if case StartError.modelConfiguration = error {

--- a/LokalBot/Agent/AgentSessionController.swift
+++ b/LokalBot/Agent/AgentSessionController.swift
@@ -333,8 +333,11 @@ final class AgentSessionController: ObservableObject {
             return endpoint
         case .builtIn(let modelID):
             guard let entry = ModelCatalog.entry(id: modelID, custom: settings().customBuiltInModels)
-                    ?? ModelCatalog.entry(id: modelID),
-                  let modelURL = ModelCatalog.localURL(for: entry, storage: storage) else {
+                    ?? ModelCatalog.entry(id: modelID) else {
+                throw StartError.modelConfiguration("The built-in model isn't downloaded yet. Download it under Settings → Models.")
+            }
+            guard let modelURL = await ModelDownloadManager.shared.verifiedExistingURL(
+                entry, storage: storage) else {
                 throw StartError.modelConfiguration("The built-in model isn't downloaded yet. Download it under Settings → Models.")
             }
             releaseLLMLease()

--- a/LokalBot/Agent/AgentSessionTabs.swift
+++ b/LokalBot/Agent/AgentSessionTabs.swift
@@ -4,6 +4,7 @@ import Foundation
 /// subprocess, so switching tabs never pauses or replaces another session.
 @MainActor
 final class AgentSessionTabs: ObservableObject {
+    static let maximumLiveSessions = 4
 
     struct Tab: Identifiable {
         let id: UUID
@@ -47,6 +48,9 @@ final class AgentSessionTabs: ObservableObject {
 
     @discardableResult
     func addSession() -> Tab {
+        if tabs.count >= Self.maximumLiveSessions, let selectedTab {
+            return selectedTab
+        }
         let tab = Tab(id: UUID(), number: nextNumber, controller: makeController())
         nextNumber += 1
         tabs.append(tab)

--- a/LokalBot/Agent/AgentTranscript.swift
+++ b/LokalBot/Agent/AgentTranscript.swift
@@ -50,9 +50,18 @@ enum AgentTranscriptItem: Equatable, Identifiable {
 /// machine — no async, no UI — so every folding rule is unit-testable
 /// (same decomposition philosophy as the Cotyping policy types).
 struct AgentTranscriptFolder: Equatable {
+    static let maximumItems = 500
+    static let maximumMessageCharacters = 1_000_000
+    static let maximumToolCharacters = 256 * 1_024
+    static let maximumTotalCharacters = 8 * 1_024 * 1_024
+    static let maximumPendingApprovals = 16
+    static let maximumApprovalIdentifierCharacters = 1_024
+
     private(set) var items: [AgentTranscriptItem] = []
     private(set) var isAgentRunning = false
     private var streamingAssistantID: String?
+    private var streamingAssistantCharacters = 0
+    private var retainedCharacterCount = 0
     private var counter = 0
 
     /// Resolved fresh on every use so removals elsewhere in the array
@@ -65,25 +74,60 @@ struct AgentTranscriptFolder: Equatable {
     // MARK: - Local inserts (not driven by pi events)
 
     mutating func noteUserPrompt(_ text: String) {
-        items.append(.user(id: nextID("user"), text: text))
+        appendItem(.user(id: nextID("user"), text: Self.boundedMessage(text)))
     }
 
     mutating func appendAssistantMessage(_ text: String) {
-        items.append(.assistant(id: nextID("assistant"), text: text, isStreaming: false))
+        appendItem(.assistant(
+            id: nextID("assistant"), text: Self.boundedMessage(text), isStreaming: false))
     }
 
     mutating func appendNotice(_ text: String, isError: Bool = false) {
-        items.append(.notice(id: nextID("notice"), text: text, isError: isError))
+        appendItem(.notice(
+            id: nextID("notice"), text: Self.boundedMessage(text), isError: isError))
     }
 
-    mutating func addApproval(_ request: AgentApprovalRequest) {
-        items.append(.approval(request))
+    var canAcceptApproval: Bool {
+        pendingApprovalIDs.count < Self.maximumPendingApprovals
+    }
+
+    @discardableResult
+    mutating func addApproval(_ request: AgentApprovalRequest) -> Bool {
+        guard canAcceptApproval,
+              request.id.count <= Self.maximumApprovalIdentifierCharacters else { return false }
+        appendItem(.approval(Self.boundedApproval(request)))
+        return true
     }
 
     mutating func resolveApproval(requestID: String) {
-        items.removeAll {
+        guard let index = items.firstIndex(where: {
             if case .approval(let request) = $0 { return request.id == requestID }
             return false
+        }) else { return }
+        removeItem(at: index)
+    }
+
+    var pendingApprovalIDs: [String] {
+        items.compactMap {
+            if case .approval(let request) = $0 { return request.id }
+            return nil
+        }
+    }
+
+    mutating func resolveAllApprovals() {
+        for index in items.indices.reversed() {
+            if case .approval = items[index] { removeItem(at: index) }
+        }
+    }
+
+    mutating func enforceResourceLimits() {
+        while items.count > Self.maximumItems
+            || retainedCharacterCount > Self.maximumTotalCharacters {
+            guard let index = items.firstIndex(where: {
+                if case .approval = $0 { return false }
+                return true
+            }) else { break }
+            removeItem(at: index)
         }
     }
 
@@ -99,26 +143,40 @@ struct AgentTranscriptFolder: Equatable {
         case .messageStart(let role):
             guard role == "assistant" else { return }
             let id = nextID("assistant")
-            items.append(.assistant(id: id, text: "", isStreaming: true))
+            appendItem(.assistant(id: id, text: "", isStreaming: true))
             streamingAssistantID = id
+            streamingAssistantCharacters = 0
         case .messageUpdate(.textDelta(let delta)):
             appendToStreamingAssistant(delta)
         case .messageEnd(let role, let text):
             guard role == "assistant" else { return }
-            defer { streamingAssistantID = nil }
+            defer {
+                streamingAssistantID = nil
+                streamingAssistantCharacters = 0
+            }
             if let index = streamingAssistantIndex,
                case .assistant(let id, let streamed, _) = items[index] {
-                let final = text.isEmpty ? streamed : text
+                let final = Self.boundedMessage(text.isEmpty ? streamed : text)
                 if final.isEmpty {
-                    items.remove(at: index)   // tool-call-only turn: drop the empty bubble
+                    removeItem(at: index)   // tool-call-only turn: drop the empty bubble
                 } else {
-                    items[index] = .assistant(id: id, text: final, isStreaming: false)
+                    replaceItem(
+                        at: index,
+                        with: .assistant(id: id, text: final, isStreaming: false))
                 }
             } else if !text.isEmpty {
-                items.append(.assistant(id: nextID("assistant"), text: text, isStreaming: false))
+                appendItem(.assistant(
+                    id: nextID("assistant"),
+                    text: Self.boundedMessage(text),
+                    isStreaming: false))
             }
         case .toolExecutionStart(let callID, let name, let argsJSON):
-            items.append(.tool(id: callID, name: name, argsJSON: argsJSON, output: "", status: .running))
+            appendItem(.tool(
+                id: callID,
+                name: String(name.prefix(256)),
+                argsJSON: String(argsJSON.prefix(Self.maximumToolCharacters)),
+                output: "",
+                status: .running))
         case .toolExecutionUpdate(let callID, let output):
             updateTool(callID) { _, _ in (output, .running) }
         case .toolExecutionEnd(let callID, let output, let isError):
@@ -137,24 +195,110 @@ struct AgentTranscriptFolder: Equatable {
         return "\(prefix)-\(counter)"
     }
 
+    private static func boundedMessage(_ text: String) -> String {
+        String(text.prefix(maximumMessageCharacters))
+    }
+
+    private static func boundedApproval(_ request: AgentApprovalRequest) -> AgentApprovalRequest {
+        var remaining = maximumToolCharacters
+        var truncated = request.isTruncated
+
+        func consume(_ value: String?) -> String? {
+            guard let value else { return nil }
+            let bounded = String(value.prefix(remaining))
+            if bounded.count < value.count { truncated = true }
+            remaining -= bounded.count
+            return bounded
+        }
+
+        let workspace = consume(request.workspace)
+        let path = consume(request.path)
+        let command = consume(request.command)
+        let content = consume(request.content)
+        var edits: [AgentApprovalRequest.Edit] = []
+        for edit in request.edits where remaining > 0 {
+            let oldText = consume(edit.oldText) ?? ""
+            let newText = consume(edit.newText) ?? ""
+            edits.append(.init(oldText: oldText, newText: newText))
+        }
+        if edits.count < request.edits.count { truncated = true }
+        let summary = consume(request.summary)
+        return AgentApprovalRequest(
+            id: request.id,
+            tool: String(request.tool.prefix(256)),
+            workspace: workspace,
+            path: path,
+            command: command,
+            content: content,
+            edits: edits,
+            summary: summary,
+            isTruncated: truncated)
+    }
+
+    private static func characterCount(in item: AgentTranscriptItem) -> Int {
+        switch item {
+        case .user(let id, let text), .assistant(let id, let text, _),
+             .notice(let id, let text, _):
+            return id.count + text.count
+        case .tool(let id, let name, let args, let output, _):
+            return id.count + name.count + args.count + output.count
+        case .approval(let request):
+            return request.id.count + request.tool.count
+                + (request.workspace?.count ?? 0)
+                + (request.path?.count ?? 0)
+                + (request.command?.count ?? 0)
+                + (request.content?.count ?? 0)
+                + (request.summary?.count ?? 0)
+                + request.edits.reduce(0) { $0 + $1.oldText.count + $1.newText.count }
+        }
+    }
+
+    private mutating func appendItem(_ item: AgentTranscriptItem) {
+        retainedCharacterCount += Self.characterCount(in: item)
+        items.append(item)
+    }
+
+    private mutating func replaceItem(at index: Int, with item: AgentTranscriptItem) {
+        retainedCharacterCount -= Self.characterCount(in: items[index])
+        retainedCharacterCount += Self.characterCount(in: item)
+        items[index] = item
+    }
+
+    private mutating func removeItem(at index: Int) {
+        retainedCharacterCount -= Self.characterCount(in: items[index])
+        items.remove(at: index)
+    }
+
     private mutating func appendToStreamingAssistant(_ delta: String) {
         if streamingAssistantIndex == nil {
             let id = nextID("assistant")
-            items.append(.assistant(id: id, text: "", isStreaming: true))
+            appendItem(.assistant(id: id, text: "", isStreaming: true))
             streamingAssistantID = id
+            streamingAssistantCharacters = 0
         }
         if let index = streamingAssistantIndex,
            case .assistant(let id, let text, _) = items[index] {
-            items[index] = .assistant(id: id, text: text + delta, isStreaming: true)
+            let room = max(0, Self.maximumMessageCharacters - streamingAssistantCharacters)
+            guard room > 0 else { return }
+            let boundedDelta = String(delta.prefix(room))
+            streamingAssistantCharacters += boundedDelta.count
+            retainedCharacterCount += boundedDelta.count
+            items[index] = .assistant(
+                id: id,
+                text: text + boundedDelta,
+                isStreaming: true)
         }
     }
 
     private mutating func finishStreamingAssistant() {
-        defer { streamingAssistantID = nil }
+        defer {
+            streamingAssistantID = nil
+            streamingAssistantCharacters = 0
+        }
         guard let index = streamingAssistantIndex,
               case .assistant(let id, let text, _) = items[index] else { return }
         if text.isEmpty {
-            items.remove(at: index)
+            removeItem(at: index)
         } else {
             items[index] = .assistant(id: id, text: text, isStreaming: false)
         }
@@ -165,6 +309,13 @@ struct AgentTranscriptFolder: Equatable {
         guard let index = items.firstIndex(where: { $0.id == callID }),
               case .tool(let id, let name, let args, let output, let status) = items[index] else { return }
         let (newOutput, newStatus) = transform(output, status)
-        items[index] = .tool(id: id, name: name, argsJSON: args, output: newOutput, status: newStatus)
+        replaceItem(
+            at: index,
+            with: .tool(
+                id: id,
+                name: name,
+                argsJSON: args,
+                output: String(newOutput.prefix(Self.maximumToolCharacters)),
+                status: newStatus))
     }
 }

--- a/LokalBot/Agent/AgentTranscript.swift
+++ b/LokalBot/Agent/AgentTranscript.swift
@@ -243,13 +243,16 @@ struct AgentTranscriptFolder: Equatable {
         case .tool(let id, let name, let args, let output, _):
             return id.count + name.count + args.count + output.count
         case .approval(let request):
-            return request.id.count + request.tool.count
+            let scalarCount = request.id.count + request.tool.count
                 + (request.workspace?.count ?? 0)
                 + (request.path?.count ?? 0)
                 + (request.command?.count ?? 0)
                 + (request.content?.count ?? 0)
                 + (request.summary?.count ?? 0)
-                + request.edits.reduce(0) { $0 + $1.oldText.count + $1.newText.count }
+            let editCount = request.edits.reduce(0) {
+                $0 + $1.oldText.count + $1.newText.count
+            }
+            return scalarCount + editCount
         }
     }
 

--- a/LokalBot/Agent/AgentTranscript.swift
+++ b/LokalBot/Agent/AgentTranscript.swift
@@ -243,16 +243,18 @@ struct AgentTranscriptFolder: Equatable {
         case .tool(let id, let name, let args, let output, _):
             return id.count + name.count + args.count + output.count
         case .approval(let request):
-            let scalarCount = request.id.count + request.tool.count
-                + (request.workspace?.count ?? 0)
-                + (request.path?.count ?? 0)
-                + (request.command?.count ?? 0)
-                + (request.content?.count ?? 0)
-                + (request.summary?.count ?? 0)
-            let editCount = request.edits.reduce(0) {
-                $0 + $1.oldText.count + $1.newText.count
+            var count = request.id.count
+            count += request.tool.count
+            if let workspace = request.workspace { count += workspace.count }
+            if let path = request.path { count += path.count }
+            if let command = request.command { count += command.count }
+            if let content = request.content { count += content.count }
+            if let summary = request.summary { count += summary.count }
+            for edit in request.edits {
+                count += edit.oldText.count
+                count += edit.newText.count
             }
-            return scalarCount + editCount
+            return count
         }
     }
 

--- a/LokalBot/Agent/PiJSONLFrameSplitter.swift
+++ b/LokalBot/Agent/PiJSONLFrameSplitter.swift
@@ -6,19 +6,44 @@ import Foundation
 /// which is why this operates on raw bytes and why `PiProcess` must never
 /// use a String-based line reader.
 struct PiJSONLFrameSplitter {
+    static let defaultMaximumFrameBytes = 4 * 1_024 * 1_024
+
     private var buffer = Data()
+    private var discardingOversizedFrame = false
+    let maximumFrameBytes: Int
+
+    init(maximumFrameBytes: Int = Self.defaultMaximumFrameBytes) {
+        self.maximumFrameBytes = max(1_024, maximumFrameBytes)
+    }
 
     /// Feed a chunk; returns every complete record it terminates.
     mutating func append(_ chunk: Data) -> [String] {
         buffer.append(chunk)
         var lines: [String] = []
+        if discardingOversizedFrame {
+            guard let lf = buffer.firstIndex(of: 0x0A) else {
+                buffer.removeAll(keepingCapacity: true)
+                return []
+            }
+            buffer.removeSubrange(buffer.startIndex...lf)
+            discardingOversizedFrame = false
+        }
         while let lf = buffer.firstIndex(of: 0x0A) {
             var record = buffer[buffer.startIndex..<lf]
             if record.last == 0x0D { record = record.dropLast() }
-            if let line = String(data: record, encoding: .utf8), !line.isEmpty {
+            if record.count > maximumFrameBytes {
+                lines.append(Self.oversizedFrameError)
+            } else if let line = String(data: record, encoding: .utf8), !line.isEmpty {
                 lines.append(line)
+            } else if !record.isEmpty {
+                lines.append(Self.invalidUTF8FrameError)
             }
             buffer.removeSubrange(buffer.startIndex...lf)
+        }
+        if buffer.count > maximumFrameBytes {
+            buffer.removeAll(keepingCapacity: true)
+            discardingOversizedFrame = true
+            lines.append(Self.oversizedFrameError)
         }
         return lines
     }
@@ -26,8 +51,20 @@ struct PiJSONLFrameSplitter {
     /// Drain an unterminated final record (call on EOF).
     mutating func flush() -> String? {
         defer { buffer.removeAll() }
+        guard !discardingOversizedFrame else {
+            discardingOversizedFrame = false
+            return nil
+        }
+        guard buffer.count <= maximumFrameBytes else { return Self.oversizedFrameError }
         guard !buffer.isEmpty, let line = String(data: buffer, encoding: .utf8),
-              !line.isEmpty else { return nil }
+              !line.isEmpty else {
+            return buffer.isEmpty ? nil : Self.invalidUTF8FrameError
+        }
         return line
     }
+
+    private static let oversizedFrameError =
+        #"{"type":"extension_error","error":"pi RPC frame exceeded the 4 MiB safety limit"}"#
+    private static let invalidUTF8FrameError =
+        #"{"type":"extension_error","error":"pi RPC frame was not valid UTF-8"}"#
 }

--- a/LokalBot/Agent/PiLaunchPlanner.swift
+++ b/LokalBot/Agent/PiLaunchPlanner.swift
@@ -13,8 +13,10 @@ struct PiLaunchPlan: Equatable {
 /// (--no-extensions/-e, --no-skills/--skill, --no-prompt-templates,
 /// --no-approve) and fully offline (--offline + PI_SKIP_VERSION_CHECK —
 /// pi ships install telemetry and update checks enabled by default).
-/// --no-context-files is deliberately NOT passed: project AGENTS.md /
-/// CLAUDE.md context stays on.
+/// Context files are disabled because pi's upward discovery is not confined
+/// to the selected workspace. Workspace files remain available through the
+/// read tool, whose extension hook canonicalizes paths and asks before any
+/// out-of-workspace access.
 enum PiLaunchPlanner {
 
     static func plan(bun: URL,
@@ -25,6 +27,7 @@ enum PiLaunchPlanner {
                      workspace: URL,
                      endpoint: AgentLLMEndpoint,
                      helpersDirectory: URL?,
+                     agentAccessCapability: String? = nil,
                      continuePreviousSession: Bool = false,
                      baseEnvironment: [String: String] = ProcessInfo.processInfo.environment) -> PiLaunchPlan {
         var arguments = [
@@ -43,6 +46,7 @@ enum PiLaunchPlanner {
         }
         arguments += [
             "--no-prompt-templates",
+            "--no-context-files",
             "--no-approve",
             "--session-dir", sessionDirectory.path,
             "--offline",
@@ -54,6 +58,9 @@ enum PiLaunchPlanner {
         environment["LOKALBOT_LLM_CTX"] = String(endpoint.contextTokens)
         if let apiKey = endpoint.apiKey {
             environment["LOKALBOT_LLM_API_KEY"] = apiKey
+        }
+        if let agentAccessCapability {
+            environment[AgentAccessGate.capabilityEnvironmentKey] = agentAccessCapability
         }
         environment["PI_SKIP_VERSION_CHECK"] = "1"
         environment["PI_TELEMETRY"] = "0"

--- a/LokalBot/Agent/PiProcess.swift
+++ b/LokalBot/Agent/PiProcess.swift
@@ -1,8 +1,156 @@
 import Foundation
+import Dispatch
 
-enum PiProcessError: Error {
+enum PiProcessError: LocalizedError {
     case executableNotFound(String)
     case notRunning
+    case payloadTooLarge
+    case inputBackpressure
+    case inputClosed
+    case inputWriteFailed(Int32)
+
+    var errorDescription: String? {
+        switch self {
+        case .executableNotFound(let path): "Agent executable not found: \(path)"
+        case .notRunning: "The agent process is not running."
+        case .payloadTooLarge: "The agent command exceeded the 4 MiB safety limit."
+        case .inputBackpressure: "The agent input buffer is full."
+        case .inputClosed: "The agent input stream is closed."
+        case .inputWriteFailed(let errorNumber):
+            "Writing to the agent input stream failed (errno \(errorNumber))."
+        }
+    }
+}
+
+/// A bounded, serial stdin channel. DispatchIO owns the duplicated descriptor,
+/// so writes never block the PiProcess actor and `close()` can cancel an
+/// in-flight write even when the child has stopped draining its pipe.
+final class PiStdinWriter: @unchecked Sendable {
+    private struct WriteRequest {
+        let id: UInt64
+        let data: DispatchData
+        let byteCount: Int
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
+    private let queue = DispatchQueue(label: "me.dotenv.LokalBot.pi-stdin-writer")
+    private let channel: DispatchIO
+    private let maximumBufferedBytes: Int
+    private let maximumPendingWrites: Int
+    private var pending: [WriteRequest] = []
+    private var inFlight: WriteRequest?
+    private var bufferedBytes = 0
+    private var nextIdentifier: UInt64 = 0
+    private var closed = false
+
+    init(
+        ownedFileDescriptor: Int32,
+        maximumBufferedBytes: Int = PiJSONLFrameSplitter.defaultMaximumFrameBytes,
+        maximumPendingWrites: Int = 128
+    ) {
+        self.maximumBufferedBytes = max(1, maximumBufferedBytes)
+        self.maximumPendingWrites = max(1, maximumPendingWrites)
+        channel = DispatchIO(
+            type: .stream,
+            fileDescriptor: ownedFileDescriptor,
+            queue: queue,
+            cleanupHandler: { _ in })
+        channel.setLimit(lowWater: 1)
+    }
+
+    func write(_ payload: Data) async throws {
+        guard !Task.isCancelled else { throw CancellationError() }
+        let dispatchData = payload.withUnsafeBytes { bytes in
+            DispatchData(bytes: bytes)
+        }
+        try await withCheckedThrowingContinuation { continuation in
+            queue.async { [self] in
+                enqueue(
+                    data: dispatchData,
+                    byteCount: payload.count,
+                    continuation: continuation)
+            }
+        }
+    }
+
+    /// This does not wait behind an outstanding write. `.stop` asks DispatchIO
+    /// to abort active I/O and makes every queued caller fail immediately.
+    func close() {
+        queue.async { [self] in closeOnQueue() }
+    }
+
+    private func enqueue(
+        data: DispatchData,
+        byteCount: Int,
+        continuation: CheckedContinuation<Void, Error>
+    ) {
+        guard !closed else {
+            continuation.resume(throwing: PiProcessError.inputClosed)
+            return
+        }
+        let writeCount = pending.count + (inFlight == nil ? 0 : 1)
+        guard writeCount < maximumPendingWrites,
+              byteCount <= maximumBufferedBytes - bufferedBytes else {
+            continuation.resume(throwing: PiProcessError.inputBackpressure)
+            return
+        }
+
+        nextIdentifier &+= 1
+        pending.append(WriteRequest(
+            id: nextIdentifier,
+            data: data,
+            byteCount: byteCount,
+            continuation: continuation))
+        bufferedBytes += byteCount
+        startNextWriteIfNeeded()
+    }
+
+    private func startNextWriteIfNeeded() {
+        guard !closed, inFlight == nil, !pending.isEmpty else { return }
+        let request = pending.removeFirst()
+        inFlight = request
+        channel.write(offset: 0, data: request.data, queue: queue) { [weak self] done, remaining, error in
+            guard done || error != 0 else { return }
+            self?.finishWrite(
+                id: request.id,
+                unwrittenByteCount: remaining?.count ?? 0,
+                errorNumber: error)
+        }
+    }
+
+    private func finishWrite(id: UInt64, unwrittenByteCount: Int, errorNumber: Int32) {
+        guard let request = inFlight, request.id == id else { return }
+        inFlight = nil
+        bufferedBytes -= request.byteCount
+
+        guard errorNumber == 0, unwrittenByteCount == 0 else {
+            let failure = PiProcessError.inputWriteFailed(
+                errorNumber == 0 ? EIO : errorNumber)
+            request.continuation.resume(throwing: failure)
+            closeOnQueue(failingQueuedWith: failure)
+            return
+        }
+
+        request.continuation.resume()
+        startNextWriteIfNeeded()
+    }
+
+    private func closeOnQueue(failingQueuedWith error: Error = PiProcessError.inputClosed) {
+        guard !closed else { return }
+        closed = true
+        channel.close(flags: .stop)
+
+        var waiting = pending
+        pending.removeAll(keepingCapacity: false)
+        if let inFlight {
+            waiting.append(inFlight)
+            self.inFlight = nil
+        }
+        bufferedBytes = 0
+        for request in waiting {
+            request.continuation.resume(throwing: error)
+        }
+    }
 }
 
 /// Owns one pi subprocess: spawns it from a PiLaunchPlan, feeds stdout
@@ -10,7 +158,8 @@ enum PiProcessError: Error {
 /// doc comment), exposes complete frames as an AsyncStream, and supervises
 /// shutdown (SIGTERM → 2s grace → SIGKILL). Mirrors the Process-handling
 /// approach in LlamaServer, as an actor because send/stop race with the
-/// termination handler.
+/// termination handler. Stdin is delegated to PiStdinWriter so pipe
+/// backpressure cannot pin this actor and prevent shutdown.
 actor PiProcess {
 
     private let plan: PiLaunchPlan
@@ -18,12 +167,14 @@ actor PiProcess {
     private let stdinPipe = Pipe()
     private let stdoutPipe = Pipe()
     private let stderrPipe = Pipe()
+    private var stdinWriter: PiStdinWriter?
 
     private var splitter = PiJSONLFrameSplitter()
     private var linesContinuation: AsyncStream<String>.Continuation?
     private var stdoutChunksContinuation: AsyncStream<Data>.Continuation?
     private var stdoutTask: Task<Void, Never>?
     private var stdoutReachedEOF = false
+    private var overflowStopScheduled = false
     private var started = false
     private var exited = false
     private(set) var stderrTail: [String] = []
@@ -33,7 +184,7 @@ actor PiProcess {
     init(plan: PiLaunchPlan) {
         self.plan = plan
         var continuation: AsyncStream<String>.Continuation!
-        lines = AsyncStream { continuation = $0 }
+        lines = AsyncStream(bufferingPolicy: .bufferingOldest(2_048)) { continuation = $0 }
         linesContinuation = continuation
     }
 
@@ -51,7 +202,8 @@ actor PiProcess {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
-        let (chunks, chunksContinuation) = AsyncStream<Data>.makeStream()
+        let (chunks, chunksContinuation) = AsyncStream<Data>.makeStream(
+            bufferingPolicy: .bufferingOldest(64))
         stdoutChunksContinuation = chunksContinuation
         stdoutTask = Task.detached { [weak self] in
             for await data in chunks {
@@ -65,7 +217,11 @@ actor PiProcess {
                 chunksContinuation.finish()
                 handle.readabilityHandler = nil
             } else {
-                chunksContinuation.yield(data)
+                if case .dropped = chunksContinuation.yield(data) {
+                    Task { [weak self] in
+                        await self?.failForBufferOverflow("stdout byte buffer overflow")
+                    }
+                }
             }
         }
         stderrPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
@@ -76,18 +232,35 @@ actor PiProcess {
         process.terminationHandler = { [weak self] _ in
             Task { [weak self] in await self?.handleExit() }
         }
-        try process.run()
+        let duplicateInput = dup(stdinPipe.fileHandleForWriting.fileDescriptor)
+        guard duplicateInput >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        let writer = PiStdinWriter(ownedFileDescriptor: duplicateInput)
+        stdinWriter = writer
+        do {
+            try process.run()
+        } catch {
+            stdinWriter = nil
+            writer.close()
+            throw error
+        }
+        try? stdinPipe.fileHandleForWriting.close()
         started = true
     }
 
-    func send(line: String) throws {
-        guard isRunning else { throw PiProcessError.notRunning }
+    func send(line: String) async throws {
+        guard isRunning, let stdinWriter else { throw PiProcessError.notRunning }
         let payload = Data((line + "\n").utf8)
-        try stdinPipe.fileHandleForWriting.write(contentsOf: payload)
+        guard payload.count <= PiJSONLFrameSplitter.defaultMaximumFrameBytes else {
+            throw PiProcessError.payloadTooLarge
+        }
+        try await stdinWriter.write(payload)
     }
 
     func stop() async {
         guard isRunning else { return }
+        stdinWriter?.close()
         process.terminate()
         for _ in 0..<20 where process.isRunning {   // 2s grace
             try? await Task.sleep(for: .milliseconds(100))
@@ -103,26 +276,47 @@ actor PiProcess {
 
     private func consumeStdout(_ data: Data) {
         for frame in splitter.append(data) {
-            linesContinuation?.yield(frame)
+            guard let result = linesContinuation?.yield(frame) else { return }
+            if case .dropped = result {
+                failForBufferOverflow("RPC frame buffer overflow")
+                return
+            }
         }
     }
 
     private func handleStdoutEOF() {
         guard !stdoutReachedEOF else { return }
         stdoutReachedEOF = true
-        if let last = splitter.flush() { linesContinuation?.yield(last) }
+        if let last = splitter.flush(),
+           let result = linesContinuation?.yield(last),
+           case .dropped = result {
+            failForBufferOverflow("RPC frame buffer overflow at EOF")
+        }
         finishLinesIfReady()
     }
 
     private func consumeStderr(_ text: String) {
-        stderrTail.append(contentsOf: text.split(separator: "\n").map(String.init))
+        stderrTail.append(contentsOf: text.split(separator: "\n").map {
+            String($0.prefix(8_192))
+        })
         if stderrTail.count > 50 { stderrTail.removeFirst(stderrTail.count - 50) }
+    }
+
+    private func failForBufferOverflow(_ reason: String) {
+        guard !overflowStopScheduled else { return }
+        overflowStopScheduled = true
+        stderrTail.append("LokalBot stopped pi: \(reason)")
+        if stderrTail.count > 50 { stderrTail.removeFirst(stderrTail.count - 50) }
+        stdinWriter?.close()
+        if process.isRunning { process.terminate() }
+        Task { [weak self] in await self?.stop() }
     }
 
     private func handleExit() {
         guard !exited else { return }
         exited = true
-        try? stdinPipe.fileHandleForWriting.close()
+        stdinWriter?.close()
+        stdinWriter = nil
         finishLinesIfReady()
     }
 

--- a/LokalBot/Agent/PiRPCClient.swift
+++ b/LokalBot/Agent/PiRPCClient.swift
@@ -7,14 +7,28 @@ protocol PiLineTransport: Sendable {
     var incoming: AsyncStream<String> { get }
 }
 
-// The actor's synchronous `send(line:)` witnesses the async protocol
-// requirement (callers hop onto the actor); only `incoming` needs adding.
+// PiProcess's actor-isolated async `send(line:)` is the protocol witness;
+// only `incoming` needs adapting to expose its nonisolated line stream.
 extension PiProcess: PiLineTransport {
     nonisolated var incoming: AsyncStream<String> { lines }
 }
 
-enum PiRPCError: Error {
+enum PiRPCError: LocalizedError {
     case transportClosed
+    case eventBufferOverflow
+    case requestTimedOut(String)
+    case duplicateRequestID(String)
+    case invalidCommand
+
+    var errorDescription: String? {
+        switch self {
+        case .transportClosed: "The agent transport closed."
+        case .eventBufferOverflow: "The agent event buffer overflowed."
+        case .requestTimedOut(let id): "The agent did not acknowledge request \(id) in time."
+        case .duplicateRequestID(let id): "Duplicate agent request id: \(id)."
+        case .invalidCommand: "An RPC request command did not contain an id."
+        }
+    }
 }
 
 /// Correlates pi RPC commands with their `{type:"response", id:…}` acks
@@ -24,15 +38,28 @@ enum PiRPCError: Error {
 actor PiRPCClient {
 
     private let transport: PiLineTransport
-    private var pending: [String: CheckedContinuation<PiResponse, Error>] = [:]
+    private let requestTimeout: Duration
+    private struct PendingRequest {
+        let continuation: CheckedContinuation<PiResponse, Error>
+        let timeoutTask: Task<Void, Never>
+    }
+    private var pending: [String: PendingRequest] = [:]
     private var consuming = false
+    private var terminalError: PiRPCError?
     let events: AsyncStream<PiEvent>
     private let eventContinuation: AsyncStream<PiEvent>.Continuation
 
-    init(transport: PiLineTransport) {
+    init(
+        transport: PiLineTransport,
+        requestTimeout: Duration = .seconds(30),
+        eventBufferCapacity: Int = 4_096
+    ) {
         self.transport = transport
+        self.requestTimeout = requestTimeout
         var continuation: AsyncStream<PiEvent>.Continuation!
-        events = AsyncStream { continuation = $0 }
+        events = AsyncStream(
+            bufferingPolicy: .bufferingOldest(max(1, eventBufferCapacity))
+        ) { continuation = $0 }
         eventContinuation = continuation
     }
 
@@ -41,55 +68,130 @@ actor PiRPCClient {
         consuming = true
         Task { [weak self] in
             guard let self else { return }
-            for await line in transport.incoming {
-                await self.handle(line: line)
+            for await line in self.transport.incoming {
+                guard await self.handle(line: line) else { return }
             }
             await self.handleClose()
         }
     }
 
     func request(_ command: PiCommand) async throws -> PiResponse {
+        if let terminalError { throw terminalError }
         guard let id = command.id else {
-            preconditionFailure("request() needs a command with an id")
+            throw PiRPCError.invalidCommand
         }
-        return try await withCheckedThrowingContinuation { continuation in
-            pending[id] = continuation
-            Task {
-                do {
-                    try await transport.send(line: command.jsonLine)
-                } catch {
-                    if let waiting = pending.removeValue(forKey: id) {
-                        waiting.resume(throwing: error)
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                guard pending[id] == nil else {
+                    continuation.resume(throwing: PiRPCError.duplicateRequestID(id))
+                    return
+                }
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                let timeout = requestTimeout
+                let timeoutTask = Task { [weak self] in
+                    do { try await Task.sleep(for: timeout) } catch { return }
+                    await self?.failRequest(id: id, with: PiRPCError.requestTimedOut(id))
+                }
+                pending[id] = PendingRequest(
+                    continuation: continuation,
+                    timeoutTask: timeoutTask)
+                Task { [weak self] in
+                    guard let self else { return }
+                    do {
+                        try await self.transport.send(line: command.jsonLine)
+                    } catch {
+                        await self.failRequest(id: id, with: error)
                     }
                 }
             }
+        } onCancel: {
+            Task { [weak self] in await self?.failRequest(id: id, with: CancellationError()) }
         }
+    }
+
+    private func failRequest(id: String, with error: Error) {
+        guard let waiting = pending.removeValue(forKey: id) else { return }
+        waiting.timeoutTask.cancel()
+        waiting.continuation.resume(throwing: error)
+    }
+
+    private func completeRequest(id: String, with response: PiResponse) {
+        guard let waiting = pending.removeValue(forKey: id) else { return }
+        waiting.timeoutTask.cancel()
+        waiting.continuation.resume(returning: response)
     }
 
     /// For extension_ui_response and other lines pi never acks.
     func sendResponse(_ command: PiCommand) async throws {
+        if let terminalError { throw terminalError }
         try await transport.send(line: command.jsonLine)
     }
 
     // MARK: - Private
 
-    private func handle(line: String) {
-        guard let event = PiEvent.decode(line: line) else { return }
+    private func handle(line: String) -> Bool {
+        guard let event = PiEvent.decode(line: line) else {
+            return emit(.extensionError(
+                message: "The agent emitted a malformed RPC frame; it was ignored."))
+        }
         if case .response(let response) = event,
            let id = response.id,
-           let waiting = pending.removeValue(forKey: id) {
-            waiting.resume(returning: response)
-            return
+           pending[id] != nil {
+            completeRequest(id: id, with: response)
+            return true
         }
-        eventContinuation.yield(event)
+        return emit(event)
+    }
+
+    /// The queue keeps its oldest entries so an already-buffered approval can
+    /// never be evicted by a burst. Text deltas are the sole lossy event type;
+    /// dropping any structural event terminates the stream deterministically.
+    private func emit(_ event: PiEvent) -> Bool {
+        switch eventContinuation.yield(event) {
+        case .enqueued:
+            return true
+        case .dropped(let droppedEvent):
+            guard droppedEvent.isLossyTextDelta else {
+                terminateEventStream(with: PiRPCError.eventBufferOverflow)
+                return false
+            }
+            return true
+        case .terminated:
+            terminateEventStream(with: PiRPCError.transportClosed)
+            return false
+        @unknown default:
+            terminateEventStream(with: PiRPCError.eventBufferOverflow)
+            return false
+        }
     }
 
     private func handleClose() {
+        terminateEventStream(with: PiRPCError.transportClosed)
+    }
+
+    private func terminateEventStream(with error: PiRPCError) {
+        guard terminalError == nil else { return }
+        terminalError = error
+        failPendingRequests(with: error)
+        eventContinuation.finish()
+    }
+
+    private func failPendingRequests(with error: Error) {
         for (_, waiting) in pending {
-            waiting.resume(throwing: PiRPCError.transportClosed)
+            waiting.timeoutTask.cancel()
+            waiting.continuation.resume(throwing: error)
         }
         pending.removeAll()
-        eventContinuation.finish()
+    }
+}
+
+private extension PiEvent {
+    var isLossyTextDelta: Bool {
+        if case .messageUpdate(.textDelta) = self { return true }
+        return false
     }
 }
 

--- a/LokalBot/CLISupport/AgentAccessGate.swift
+++ b/LokalBot/CLISupport/AgentAccessGate.swift
@@ -1,7 +1,26 @@
+import CryptoKit
 import Foundation
+
+struct AgentAccessCapability: Equatable, Sendable {
+    fileprivate let id: String
+    let token: String
+}
+
+enum AgentAccessError: LocalizedError {
+    case disabled
+
+    var errorDescription: String? {
+        switch self {
+        case .disabled:
+            FileLibraryToolProvider.accessDisabledMessage
+        }
+    }
+}
 
 /// Cross-process marker-file truth for external-agent access and LLM wakeup.
 struct AgentAccessGate {
+    static let capabilityEnvironmentKey = "LOKALBOT_AGENT_CAPABILITY"
+
     var root: URL
 
     init(root: URL = SessionLookup.storageRootURL) {
@@ -24,8 +43,31 @@ struct AgentAccessGate {
         controlDirectory.appendingPathComponent("agent-wake-error")
     }
 
+    var capabilityDirectory: URL {
+        controlDirectory.appendingPathComponent("agent-capabilities", isDirectory: true)
+    }
+
     var isEnabled: Bool {
         FileManager.default.fileExists(atPath: accessMarkerURL.path)
+    }
+
+    /// True for the user-controlled global toggle or for an app-issued,
+    /// short-lived capability inherited by the embedded Agent Mode process.
+    /// A normal terminal invocation has no capability and must honor the
+    /// Privacy toggle just like MCP does.
+    func isAuthorized(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        now: Date = Date()
+    ) -> Bool {
+        if isEnabled { return true }
+        guard let token = environment[Self.capabilityEnvironmentKey] else { return false }
+        return validateCapability(token, now: now)
+    }
+
+    func requireAuthorized(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws {
+        guard isAuthorized(environment: environment) else { throw AgentAccessError.disabled }
     }
 
     func enable() throws {
@@ -37,6 +79,47 @@ struct AgentAccessGate {
 
     func disable() {
         try? FileManager.default.removeItem(at: accessMarkerURL)
+    }
+
+    /// Creates a bearer capability for one embedded Agent Mode subprocess.
+    /// Only a SHA-256 digest is persisted; the bearer secret exists in the
+    /// process environment and is revoked when the tab shuts down.
+    func issueScopedCapability(validFor lifetime: TimeInterval = 24 * 60 * 60) throws
+        -> AgentAccessCapability {
+        let id = UUID().uuidString.lowercased()
+        let secret = (UUID().uuidString + UUID().uuidString)
+            .replacingOccurrences(of: "-", with: "")
+            .lowercased()
+        let record = CapabilityRecord(
+            digest: Self.digest(secret),
+            expiresAt: Date().addingTimeInterval(max(60, lifetime)))
+        try FileManager.default.createDirectory(
+            at: capabilityDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        let url = capabilityURL(id: id)
+        try JSONEncoder().encode(record).write(to: url, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        return AgentAccessCapability(id: id, token: "\(id).\(secret)")
+    }
+
+    func revoke(_ capability: AgentAccessCapability) {
+        try? FileManager.default.removeItem(at: capabilityURL(id: capability.id))
+    }
+
+    func removeExpiredCapabilities(now: Date = Date()) {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: capabilityDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]) else { return }
+        for file in files {
+            guard let data = try? Data(contentsOf: file),
+                  let record = try? JSONDecoder().decode(CapabilityRecord.self, from: data),
+                  record.expiresAt > now else {
+                try? FileManager.default.removeItem(at: file)
+                continue
+            }
+        }
     }
 
     func touchWake() throws {
@@ -72,5 +155,34 @@ struct AgentAccessGate {
         let message = String(decoding: data, as: UTF8.self)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return message.isEmpty ? nil : message
+    }
+
+    private func validateCapability(_ token: String, now: Date) -> Bool {
+        let parts = token.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return false }
+        let id = String(parts[0])
+        let secret = String(parts[1])
+        guard UUID(uuidString: id) != nil,
+              secret.count == 64,
+              secret.allSatisfy({ $0.isHexDigit }),
+              let data = try? Data(contentsOf: capabilityURL(id: id)),
+              let record = try? JSONDecoder().decode(CapabilityRecord.self, from: data),
+              record.expiresAt > now else { return false }
+        return record.digest == Self.digest(secret)
+    }
+
+    private func capabilityURL(id: String) -> URL {
+        capabilityDirectory.appendingPathComponent("\(id.lowercased()).json")
+    }
+
+    private static func digest(_ secret: String) -> String {
+        SHA256.hash(data: Data(secret.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    private struct CapabilityRecord: Codable {
+        let digest: String
+        let expiresAt: Date
     }
 }

--- a/LokalBot/CLISupport/AskLibraryContext.swift
+++ b/LokalBot/CLISupport/AskLibraryContext.swift
@@ -3,6 +3,10 @@ import Foundation
 /// Pure retrieval, citation, and prompt construction for `ask_library`.
 enum AskLibraryContext {
     static let maxSnippets = 12
+    static let maxTitleSummaryMatches = 4
+    static let maxSummaryUTF8Bytes = 6 * 1_024
+    static let maxSnippetLineUTF8Bytes = 1_024
+    static let maxContextUTF8Bytes = 32 * 1_024
 
     struct Citation: Encodable, Equatable {
         var meeting_id: String
@@ -34,43 +38,70 @@ enum AskLibraryContext {
         let byShortID = Dictionary(
             meetings.map { (SessionLookup.shortID($0.id), $0) },
             uniquingKeysWith: { first, _ in first })
-        var sections: [String] = []
+        var context = ContextWriter()
         var citedShortIDs: [String] = []
 
         let lowered = question.lowercased()
-        for meeting in meetings {
+        let titleMatches = meetings.compactMap { meeting -> (meeting: Meeting, title: String)? in
             let title = meeting.title.trimmingCharacters(in: .whitespaces)
             guard title.count >= 4,
-                  lowered.contains(title.lowercased()),
-                  let summary = SessionLookup.summaryMarkdown(for: meeting) else {
-                continue
+                  lowered.contains(title.lowercased()) else { return nil }
+            return (meeting, title)
+        }
+        .sorted { lhs, rhs in
+            if lhs.title.count != rhs.title.count { return lhs.title.count > rhs.title.count }
+            if lhs.meeting.startedAt != rhs.meeting.startedAt {
+                return lhs.meeting.startedAt > rhs.meeting.startedAt
             }
-            sections.append(
-                "## \(meeting.title) — \(dayString(meeting.startedAt)) — full summary\n\(summary)")
-            citedShortIDs.append(SessionLookup.shortID(meeting.id))
+            return lhs.meeting.id.uuidString < rhs.meeting.id.uuidString
         }
 
-        var snippetLines: [String] = []
+        var appendedSummaries = 0
+        for match in titleMatches {
+            guard appendedSummaries < maxTitleSummaryMatches,
+                  !context.isFull else { break }
+            guard let summary = SessionLookup.summaryMarkdown(for: match.meeting) else { continue }
+            let boundedSummary = truncatedUTF8(
+                summary,
+                maxBytes: maxSummaryUTF8Bytes,
+                marker: "\n[… summary truncated …]")
+            let section = "## \(match.meeting.title) — \(dayString(match.meeting.startedAt)) — full summary\n\(boundedSummary)"
+            if context.appendSection(section) {
+                appendedSummaries += 1
+                citedShortIDs.append(SessionLookup.shortID(match.meeting.id))
+            }
+        }
+
+        var snippetCount = 0
+        var hasSnippetSection = false
         var seenSnippets: Set<String> = []
-        for term in searchTerms(from: question) {
-            guard snippetLines.count < maxSnippets else { break }
+        search: for term in searchTerms(from: question) {
+            guard snippetCount < maxSnippets, !context.isFull else { break }
             let hits = (try? LibrarySearch.hits(
                 query: term,
                 limit: maxSnippets,
                 meetings: meetings)) ?? []
             for hit in hits {
-                guard snippetLines.count < maxSnippets else { break }
+                guard snippetCount < maxSnippets, !context.isFull else { break search }
                 guard seenSnippets.insert("\(hit.meeting_id)|\(hit.snippet)").inserted else {
                     continue
                 }
                 let stamp = hit.timestamp.map { " @\($0)" } ?? ""
-                snippetLines.append(
-                    "- [\(hit.match_kind)\(stamp)] \(hit.meeting_title): \(hit.snippet)")
+                let line = truncatedUTF8(
+                    "- [\(hit.match_kind)\(stamp)] \(hit.meeting_title): \(hit.snippet)",
+                    maxBytes: maxSnippetLineUTF8Bytes,
+                    marker: "…")
+                let prefix: String
+                if hasSnippetSection {
+                    prefix = "\n"
+                } else {
+                    prefix = context.text.isEmpty ? "## Snippets\n" : "\n\n## Snippets\n"
+                }
+                guard context.appendFragment(prefix + line) else { break search }
+                hasSnippetSection = true
+                snippetCount += 1
                 citedShortIDs.append(hit.meeting_id)
             }
-        }
-        if !snippetLines.isEmpty {
-            sections.append("## Snippets\n" + snippetLines.joined(separator: "\n"))
         }
 
         var seenIDs: Set<String> = []
@@ -86,7 +117,7 @@ enum AskLibraryContext {
             }
 
         return ContextBundle(
-            contextText: sections.joined(separator: "\n\n"),
+            contextText: context.text,
             citations: citations)
     }
 
@@ -113,5 +144,48 @@ enum AskLibraryContext {
 
     private static func dayString(_ date: Date) -> String {
         dayFormatter.string(from: date)
+    }
+
+    private struct ContextWriter {
+        private(set) var text = ""
+        private var usedBytes = 0
+
+        var isFull: Bool { usedBytes >= maxContextUTF8Bytes }
+
+        mutating func appendSection(_ section: String) -> Bool {
+            appendFragment((text.isEmpty ? "" : "\n\n") + section)
+        }
+
+        mutating func appendFragment(_ fragment: String) -> Bool {
+            let available = maxContextUTF8Bytes - usedBytes
+            guard available > 0, !fragment.isEmpty else { return false }
+            let bounded = truncatedUTF8(
+                fragment,
+                maxBytes: available,
+                marker: "\n[… context budget reached …]")
+            guard !bounded.isEmpty else { return false }
+            text += bounded
+            usedBytes += bounded.utf8.count
+            return true
+        }
+    }
+
+    private static func truncatedUTF8(
+        _ value: String,
+        maxBytes: Int,
+        marker: String
+    ) -> String {
+        guard maxBytes > 0 else { return "" }
+        guard value.utf8.count > maxBytes else { return value }
+        let markerBytes = marker.utf8.count
+        let canAppendMarker = markerBytes <= maxBytes
+        let prefixBudget = canAppendMarker ? maxBytes - markerBytes : maxBytes
+        var prefixData = Data(value.utf8.prefix(prefixBudget))
+        while !prefixData.isEmpty,
+              String(data: prefixData, encoding: .utf8) == nil {
+            prefixData.removeLast()
+        }
+        let prefix = String(data: prefixData, encoding: .utf8) ?? ""
+        return canAppendMarker ? prefix + marker : prefix
     }
 }

--- a/LokalBot/CLISupport/AskLibraryEngine.swift
+++ b/LokalBot/CLISupport/AskLibraryEngine.swift
@@ -1,4 +1,71 @@
+import Darwin
 import Foundation
+
+/// Shared on-disk identity and bearer contract for the private llama-server.
+/// The marker is mode 0600, the token rotates on every subprocess start, and
+/// CLI callers validate that its PID is alive, is the recorded executable,
+/// and owns the expected listening port before trusting localhost.
+struct LocalLlamaServerMarker: Codable {
+    var pid: pid_t
+    var port: Int
+    var binaryPath: String
+    var modelPath: String
+    var contextTokens: Int?
+    var extraArgs: [String]?
+    var authenticationToken: String?
+}
+
+enum LocalLlamaServerAuthentication {
+    static func markerURL(port: Int) -> URL {
+        AppDirectories.applicationSupport
+            .appendingPathComponent("llama-server-\(port).pid.json")
+    }
+
+    static func readMarker(port: Int) -> LocalLlamaServerMarker? {
+        guard let data = try? Data(contentsOf: markerURL(port: port)),
+              let marker = try? JSONDecoder().decode(LocalLlamaServerMarker.self, from: data),
+              marker.port == port else { return nil }
+        return marker
+    }
+
+    static func validatedToken(port: Int) -> String? {
+        guard let marker = readMarker(port: port),
+              let token = marker.authenticationToken,
+              token.count >= 32,
+              kill(marker.pid, 0) == 0,
+              processPath(for: marker.pid) == marker.binaryPath,
+              marker.binaryPath.hasSuffix("/llama-server"),
+              listeningPIDs(onPort: port).contains(marker.pid) else { return nil }
+        return token
+    }
+
+    static func apply(to request: inout URLRequest, token: String) {
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    }
+
+    private static func processPath(for pid: pid_t) -> String? {
+        var buffer = [CChar](repeating: 0, count: 4_096)
+        let result = buffer.withUnsafeMutableBufferPointer { pointer in
+            proc_pidpath(pid, pointer.baseAddress, UInt32(pointer.count))
+        }
+        return result > 0 ? String(cString: buffer) : nil
+    }
+
+    private static func listeningPIDs(onPort port: Int) -> [pid_t] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
+        process.arguments = ["-nP", "-iTCP:\(port)", "-sTCP:LISTEN", "-t"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        guard (try? process.run()) != nil else { return [] }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return String(decoding: data, as: UTF8.self)
+            .split(whereSeparator: { $0.isWhitespace })
+            .compactMap { pid_t($0) }
+    }
+}
 
 /// Minimal local llama-server chat surface so tests can substitute a mock.
 protocol LlamaChatClient {
@@ -10,9 +77,14 @@ struct URLSessionLlamaChatClient: LlamaChatClient {
     static let mainServerBaseURL = URL(string: "http://127.0.0.1:17872")!
 
     var baseURL = URLSessionLlamaChatClient.mainServerBaseURL
+    var authenticationToken: () -> String? = {
+        LocalLlamaServerAuthentication.validatedToken(port: 17872)
+    }
 
     func healthy() async -> Bool {
+        guard let token = authenticationToken() else { return false }
         var request = URLRequest(url: baseURL.appendingPathComponent("health"))
+        LocalLlamaServerAuthentication.apply(to: &request, token: token)
         request.timeoutInterval = 2
         guard let (_, response) = try? await URLSession.shared.data(for: request) else {
             return false
@@ -21,9 +93,13 @@ struct URLSessionLlamaChatClient: LlamaChatClient {
     }
 
     func complete(messages: [[String: String]]) async throws -> String {
+        guard let token = authenticationToken() else {
+            throw URLError(.userAuthenticationRequired)
+        }
         var request = URLRequest(url: baseURL.appendingPathComponent("v1/chat/completions"))
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        LocalLlamaServerAuthentication.apply(to: &request, token: token)
         request.timeoutInterval = 300
         request.httpBody = try JSONSerialization.data(withJSONObject: [
             "messages": messages,
@@ -54,7 +130,7 @@ struct AskLibraryEngine {
     var maxPollAttempts = 60
 
     func ask(_ question: String) async -> ToolResult {
-        guard gate.isEnabled else {
+        guard gate.isAuthorized() else {
             return .error(.accessDisabled, FileLibraryToolProvider.accessDisabledMessage)
         }
         let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -62,6 +138,11 @@ struct AskLibraryEngine {
             return .error(
                 .invalidArguments,
                 "ask_library requires a non-empty \"question\" string.")
+        }
+        guard trimmed.count <= LibraryInputPolicy.maximumQuestionCharacters else {
+            return .error(
+                .invalidArguments,
+                "ask_library questions are limited to \(LibraryInputPolicy.maximumQuestionCharacters) characters.")
         }
 
         if await !client.healthy(), let failure = await wakeAndWait() {
@@ -100,7 +181,10 @@ struct AskLibraryEngine {
                 "Could not signal the LokalBot app (\(error.localizedDescription)). Open LokalBot and try again.")
         }
 
-        for _ in 0..<maxPollAttempts {
+        for _ in 0..<max(0, maxPollAttempts) {
+            if Task.isCancelled {
+                return .error(.appNotRunning, "ask_library was cancelled.")
+            }
             await pollDelay()
             if await client.healthy() { return nil }
             if let reason = gate.readWakeError() {

--- a/LokalBot/CLISupport/FileLibraryToolProvider.swift
+++ b/LokalBot/CLISupport/FileLibraryToolProvider.swift
@@ -77,7 +77,7 @@ struct FileLibraryToolProvider: LibraryToolProvider {
     }
 
     func call(name: String, arguments: JSONValue?) async -> ToolResult {
-        guard gate.isEnabled else {
+        guard gate.isAuthorized() else {
             return .error(.accessDisabled, Self.accessDisabledMessage)
         }
 
@@ -127,7 +127,12 @@ struct FileLibraryToolProvider: LibraryToolProvider {
                 }
                 meetings = meetings.filter { $0.startedAt >= day }
             }
-            let limit = max(1, arguments?["limit"]?.intValue ?? 20)
+            let limit: Int
+            switch boundedLimit(arguments?["limit"], default: 20,
+                                maximum: LibraryInputPolicy.maximumMeetingCount) {
+            case .success(let value): limit = value
+            case .failure(let result): return result
+            }
             return .text(SessionFormatter.listJSON(Array(meetings.prefix(limit))))
         } catch {
             return .error(
@@ -137,7 +142,8 @@ struct FileLibraryToolProvider: LibraryToolProvider {
     }
 
     private func getMeeting(_ arguments: JSONValue?) -> ToolResult {
-        guard let id = arguments?["id"]?.stringValue, !id.isEmpty else {
+        guard let id = arguments?["id"]?.stringValue, !id.isEmpty,
+              id.count <= 64 else {
             return .error(
                 .invalidArguments,
                 "get_meeting requires an \"id\" string (short id, full UUID, or \"latest\").")
@@ -184,13 +190,21 @@ struct FileLibraryToolProvider: LibraryToolProvider {
     }
 
     private func searchMeetings(_ arguments: JSONValue?) -> ToolResult {
-        guard let query = arguments?["query"]?.stringValue, !query.isEmpty else {
+        guard let query = arguments?["query"]?.stringValue?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !query.isEmpty,
+              query.count <= LibraryInputPolicy.maximumQueryCharacters else {
             return .error(
                 .invalidArguments,
-                "search_meetings requires a non-empty \"query\" string.")
+                "search_meetings requires a non-empty \"query\" string of at most \(LibraryInputPolicy.maximumQueryCharacters) characters.")
         }
         do {
-            let limit = max(1, arguments?["limit"]?.intValue ?? LibrarySearch.defaultLimit)
+            let limit: Int
+            switch boundedLimit(arguments?["limit"], default: LibrarySearch.defaultLimit,
+                                maximum: LibraryInputPolicy.maximumSearchHits) {
+            case .success(let value): limit = value
+            case .failure(let result): return result
+            }
             return .text(SessionFormatter.searchJSON(
                 try LibrarySearch.hits(query: query, limit: limit)))
         } catch {
@@ -198,5 +212,21 @@ struct FileLibraryToolProvider: LibraryToolProvider {
                 .meetingNotFound,
                 "Could not read the meeting library: \(error.localizedDescription)")
         }
+    }
+
+    private enum LimitResult {
+        case success(Int)
+        case failure(ToolResult)
+    }
+
+    private func boundedLimit(_ raw: JSONValue?, default defaultValue: Int,
+                              maximum: Int) -> LimitResult {
+        guard let raw else { return .success(defaultValue) }
+        guard let value = raw.intValue, (1...maximum).contains(value) else {
+            return .failure(.error(
+                .invalidArguments,
+                "\"limit\" must be an integer between 1 and \(maximum)."))
+        }
+        return .success(value)
     }
 }

--- a/LokalBot/CLISupport/LibrarySearch.swift
+++ b/LokalBot/CLISupport/LibrarySearch.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+enum LibraryInputPolicy {
+    static let maximumMeetingCount = 1_000
+    static let maximumSearchHits = 500
+    static let maximumQueryCharacters = 4_096
+    static let maximumQuestionCharacters = 16_384
+}
+
 /// Shared substring search over on-disk meeting artifacts. Case-insensitive,
 /// recency-ordered, and capped so the CLI and MCP expose one behavior.
 enum LibrarySearch {

--- a/LokalBot/CLISupport/MCPProtocol.swift
+++ b/LokalBot/CLISupport/MCPProtocol.swift
@@ -60,7 +60,13 @@ enum JSONValue: Codable, Equatable {
     }
 
     var intValue: Int? {
-        if case .number(let value) = self { return Int(value) }
+        if case .number(let value) = self,
+           value.isFinite,
+           value.rounded(.towardZero) == value,
+           value >= Double(Int.min),
+           value <= Double(Int.max) {
+            return Int(value)
+        }
         return nil
     }
 
@@ -85,8 +91,92 @@ extension JSONValue: ExpressibleByStringLiteral, ExpressibleByIntegerLiteral,
     init(nilLiteral: ()) { self = .null }
 }
 
+enum MCPTransportLimits {
+    static let maximumRecordBytes = 1_048_576
+}
+
+/// Incremental newline-delimited stdin reader for the MCP helper. Its buffer
+/// never grows with an unterminated record: once the byte limit is crossed it
+/// reports one rejection and discards bytes until LF/EOF without constructing
+/// an oversized `String`.
+struct MCPStdioLineReader {
+    enum Record: Equatable {
+        case line(String)
+        case oversized
+        case end
+    }
+
+    private let input: FileHandle
+    private let maximumRecordBytes: Int
+    private let chunkBytes: Int
+    private var pending = Data()
+    private var reachedEOF = false
+    private var discardingOversizedRecord = false
+
+    init(
+        input: FileHandle = .standardInput,
+        maximumRecordBytes: Int = MCPTransportLimits.maximumRecordBytes,
+        chunkBytes: Int = 64 * 1_024
+    ) {
+        self.input = input
+        self.maximumRecordBytes = max(1, maximumRecordBytes)
+        self.chunkBytes = max(1, chunkBytes)
+    }
+
+    mutating func next() throws -> Record {
+        while true {
+            if discardingOversizedRecord {
+                if let newline = pending.firstIndex(of: 0x0A) {
+                    pending.removeSubrange(pending.startIndex...newline)
+                    discardingOversizedRecord = false
+                    continue
+                }
+                pending.removeAll(keepingCapacity: true)
+                if reachedEOF {
+                    discardingOversizedRecord = false
+                    return .end
+                }
+            } else {
+                if let newline = pending.firstIndex(of: 0x0A) {
+                    let byteCount = pending.distance(from: pending.startIndex, to: newline)
+                    guard byteCount <= maximumRecordBytes else {
+                        pending.removeSubrange(pending.startIndex...newline)
+                        return .oversized
+                    }
+                    var data = pending.prefix(upTo: newline)
+                    pending.removeSubrange(pending.startIndex...newline)
+                    if data.last == 0x0D { data.removeLast() }
+                    return .line(String(decoding: data, as: UTF8.self))
+                }
+
+                if pending.count > maximumRecordBytes {
+                    pending.removeAll(keepingCapacity: true)
+                    discardingOversizedRecord = true
+                    return .oversized
+                }
+
+                if reachedEOF {
+                    guard !pending.isEmpty else { return .end }
+                    var data = pending
+                    pending.removeAll(keepingCapacity: true)
+                    if data.last == 0x0D { data.removeLast() }
+                    return .line(String(decoding: data, as: UTF8.self))
+                }
+            }
+
+            let chunk = try input.read(upToCount: chunkBytes) ?? Data()
+            if chunk.isEmpty {
+                reachedEOF = true
+            } else {
+                pending.append(chunk)
+            }
+        }
+    }
+}
+
 /// One decoded JSON-RPC 2.0 message from an MCP client.
 struct MCPRequest: Equatable {
+    static let maximumLineBytes = MCPTransportLimits.maximumRecordBytes
     enum RequestID: Equatable {
         case number(Int)
         case string(String)
@@ -110,6 +200,9 @@ struct MCPRequest: Equatable {
     }
 
     static func parse(_ line: String) -> ParseOutcome {
+        guard line.utf8.count <= maximumLineBytes else {
+            return .failure(code: -32600, message: "Request exceeds the 1 MiB limit", id: nil)
+        }
         guard let raw = try? JSONDecoder().decode(JSONValue.self, from: Data(line.utf8)),
               let object = raw.objectValue else {
             return .failure(code: -32700, message: "Parse error", id: nil)
@@ -117,7 +210,14 @@ struct MCPRequest: Equatable {
 
         let id: RequestID?
         switch object["id"] {
-        case .some(.number(let value)): id = .number(Int(value))
+        case .some(.number(let value)):
+            guard value.isFinite,
+                  value.rounded(.towardZero) == value,
+                  value >= Double(Int.min),
+                  value <= Double(Int.max) else {
+                return .failure(code: -32600, message: "Invalid numeric request id", id: nil)
+            }
+            id = .number(Int(value))
         case .some(.string(let value)): id = .string(value)
         default: id = nil
         }

--- a/LokalBot/Cotyping/CotypingAXHelper.swift
+++ b/LokalBot/Cotyping/CotypingAXHelper.swift
@@ -1,5 +1,221 @@
 import AppKit
 import ApplicationServices
+import Foundation
+
+/// Options for one Accessibility snapshot. Keeping these as an option set lets
+/// the executor merge queued requests into one superset capture.
+struct CotypingAXCaptureOptions: OptionSet, Sendable {
+    let rawValue: UInt8
+
+    static let surface = Self(rawValue: 1 << 0)
+    static let url = Self(rawValue: 1 << 1)
+    static let style = Self(rawValue: 1 << 2)
+}
+
+struct CotypingAXCaptureResult: Sendable {
+    let focus: CotypingFocus?
+    let timedOut: Bool
+
+    static let timeout = Self(focus: nil, timedOut: true)
+}
+
+/// Thread-safe one-entry surface cache with one active resolver. The resolver
+/// runs outside the cache lock, so a slow cross-process AX call cannot block
+/// unrelated cache/state readers. Same-key callers share the active result;
+/// different-key callers wait outside the lock and retry against the one-entry
+/// cache, keeping capture concurrency bounded to one.
+final class CotypingSurfaceCaptureSingleFlight: @unchecked Sendable {
+    private final class Flight {
+        let key: String
+        let completion = DispatchGroup()
+        var result: CotypingSurfaceCapture?
+
+        init(key: String) {
+            self.key = key
+            completion.enter()
+        }
+    }
+
+    private let lock = NSLock()
+    private var cachedKey: String?
+    private var cachedCapture: CotypingSurfaceCapture = .empty
+    private var activeFlight: Flight?
+
+    func cachedValue(forKey key: String) -> CotypingSurfaceCapture? {
+        lock.withLock {
+            cachedKey == key ? cachedCapture : nil
+        }
+    }
+
+    func capture(
+        forKey key: String,
+        resolve: () -> CotypingSurfaceCapture
+    ) -> CotypingSurfaceCapture {
+        while true {
+            lock.lock()
+            if cachedKey == key {
+                let value = cachedCapture
+                lock.unlock()
+                return value
+            }
+            if let activeFlight {
+                let sharesResult = activeFlight.key == key
+                lock.unlock()
+                activeFlight.completion.wait()
+                if sharesResult,
+                   let result = lock.withLock({ activeFlight.result }) {
+                    return result
+                }
+                continue
+            }
+
+            let flight = Flight(key: key)
+            activeFlight = flight
+            lock.unlock()
+
+            let resolved = resolve()
+
+            lock.withLock {
+                cachedKey = key
+                cachedCapture = resolved
+                flight.result = resolved
+                if activeFlight === flight {
+                    activeFlight = nil
+                }
+            }
+            flight.completion.leave()
+            return resolved
+        }
+    }
+}
+
+/// Runs all routine AX snapshots on one background queue. There can be at most
+/// one active capture and one latest-wins pending batch; callers that arrive
+/// while a compatible capture is active share its result. Each caller has one
+/// wall-clock deadline for the *whole* snapshot, rather than multiplying the AX
+/// per-message timeout by every attribute read.
+final class CotypingAXSnapshotExecutor: @unchecked Sendable {
+    typealias Resolver = @Sendable (CotypingAXCaptureOptions) -> CotypingFocus
+
+    static let shared = CotypingAXSnapshotExecutor()
+    static let defaultDeadlineMilliseconds = 120
+
+    private struct Waiter {
+        let id: UInt64
+        let continuation: CheckedContinuation<CotypingAXCaptureResult, Never>
+    }
+
+    private struct Batch {
+        let id: UInt64
+        var options: CotypingAXCaptureOptions
+        var waiters: [UInt64: Waiter]
+    }
+
+    private let stateQueue = DispatchQueue(label: "me.dotenv.LokalBot.cotyping.ax-snapshot-state")
+    private let workerQueue = DispatchQueue(
+        label: "me.dotenv.LokalBot.cotyping.ax-snapshot-worker",
+        qos: .userInitiated)
+    private let deadlineMilliseconds: Int
+    private let resolver: Resolver
+    private var nextIdentifier: UInt64 = 0
+    private var active: Batch?
+    private var pending: Batch?
+
+    init(
+        deadlineMilliseconds: Int = defaultDeadlineMilliseconds,
+        resolver: @escaping Resolver = { options in
+            CotypingAXHelper.resolveFocus(
+                includeSurface: options.contains(.surface),
+                includeURL: options.contains(.url),
+                includeStyle: options.contains(.style))
+        }
+    ) {
+        self.deadlineMilliseconds = max(1, deadlineMilliseconds)
+        self.resolver = resolver
+    }
+
+    func capture(options: CotypingAXCaptureOptions = []) async -> CotypingAXCaptureResult {
+        await withCheckedContinuation { continuation in
+            stateQueue.async { [self] in
+                nextIdentifier &+= 1
+                let waiterID = nextIdentifier
+                let waiter = Waiter(id: waiterID, continuation: continuation)
+                enqueue(waiter: waiter, options: options)
+                stateQueue.asyncAfter(deadline: .now() + .milliseconds(deadlineMilliseconds)) { [weak self] in
+                    self?.expire(waiterID: waiterID)
+                }
+            }
+        }
+    }
+
+    private func enqueue(waiter: Waiter, options: CotypingAXCaptureOptions) {
+        if var active, options.isSubset(of: active.options) {
+            active.waiters[waiter.id] = waiter
+            self.active = active
+            return
+        }
+
+        if var pending {
+            pending.options.formUnion(options)
+            pending.waiters[waiter.id] = waiter
+            self.pending = pending
+            return
+        }
+
+        nextIdentifier &+= 1
+        let batch = Batch(id: nextIdentifier, options: options, waiters: [waiter.id: waiter])
+        if active == nil {
+            start(batch)
+        } else {
+            pending = batch
+        }
+    }
+
+    private func start(_ batch: Batch) {
+        active = batch
+        let batchID = batch.id
+        let options = batch.options
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            let focus = resolver(options)
+            stateQueue.async { [weak self] in
+                self?.finish(batchID: batchID, focus: focus)
+            }
+        }
+    }
+
+    private func finish(batchID: UInt64, focus: CotypingFocus) {
+        guard let completed = active, completed.id == batchID else { return }
+        active = nil
+        for waiter in completed.waiters.values {
+            waiter.continuation.resume(returning: CotypingAXCaptureResult(focus: focus, timedOut: false))
+        }
+        startPendingIfNeeded()
+    }
+
+    private func expire(waiterID: UInt64) {
+        if var active, let waiter = active.waiters.removeValue(forKey: waiterID) {
+            self.active = active
+            waiter.continuation.resume(returning: .timeout)
+            return
+        }
+        if var pending, let waiter = pending.waiters.removeValue(forKey: waiterID) {
+            if pending.waiters.isEmpty {
+                self.pending = nil
+            } else {
+                self.pending = pending
+            }
+            waiter.continuation.resume(returning: .timeout)
+        }
+    }
+
+    private func startPendingIfNeeded() {
+        guard active == nil, let pending else { return }
+        self.pending = nil
+        guard !pending.waiters.isEmpty else { return }
+        start(pending)
+    }
+}
 
 /// The Accessibility boundary for cotyping. Resolves the system-wide focused
 /// element into a value-type `CotypingField` (preceding/trailing text, caret
@@ -46,16 +262,95 @@ enum CotypingAXHelper {
     /// Per-element cache of resolved field styles so the focus poll (every ~200 ms)
     /// doesn't re-read `AXAttributedStringForRange` for a field it already styled.
     /// Keyed by the element's stable `AXIdentifier`; cleared wholesale at 64 entries.
-    @MainActor private static var fieldStyleCache: [String: CotypingFieldStyle] = [:]
-    @MainActor private static var surfaceCaptureCache = CotypingSurfaceCaptureCache()
-    @MainActor private static var primedWebAccessibilityPIDs: Set<pid_t> = []
-    @MainActor private static var unsupportedWebAccessibilityPIDs: Set<pid_t> = []
-    @MainActor private static var lastFrontmostPrimePID: pid_t?
-    @MainActor private static var chromiumHitTestCache: (element: AXUIElement, pid: pid_t)?
+    /// Mutable caches are boxed behind a lock because routine reads now happen
+    /// on the snapshot queue while the event-tap acceptance check remains a
+    /// synchronous main-thread read.
+    private final class CacheState: @unchecked Sendable {
+        let lock = NSLock()
+        var fieldStyles: [String: CotypingFieldStyle] = [:]
+        let surfaceCaptures = CotypingSurfaceCaptureSingleFlight()
+        var primedWebAccessibilityPIDs: Set<pid_t> = []
+        var unsupportedWebAccessibilityPIDs: Set<pid_t> = []
+        var lastFrontmostPrimePID: pid_t?
+        var chromiumHitTest: (element: AXUIElement, pid: pid_t)?
 
-    /// Resolve the current focus into a cotyping snapshot. Pure read; safe to
-    /// call from the focus-tracker timer on the main thread.
-    @MainActor
+        func withLock<T>(_ operation: () -> T) -> T {
+            lock.lock()
+            defer { lock.unlock() }
+            return operation()
+        }
+    }
+
+    private static let cacheState = CacheState()
+
+    /// A bounded-cost identity/privacy snapshot for dictation delivery. Unlike
+    /// `resolveFocus`, this never reads the field value, surrounding text,
+    /// caret geometry, window surface, URL, or style.
+    static func resolveDictationFocusSnapshot() -> DictationFocusSnapshot? {
+        guard isTrusted else { return nil }
+        let frontmost = NSWorkspace.shared.frontmostApplication
+        guard let element = focusedElement() else {
+            return frontmost.map {
+                DictationFocusSnapshot(
+                    processID: $0.processIdentifier,
+                    bundleID: $0.bundleIdentifier,
+                    focusIdentityKey: nil,
+                    isSecureOrBlocked: false)
+            }
+        }
+
+        let owner = owningApp(of: element)
+        let processID = owner?.pid ?? frontmost?.processIdentifier ?? 0
+        guard processID > 0 else { return nil }
+        let bundleID = owner?.bundleID ?? frontmost?.bundleIdentifier
+        let role = stringAttribute(element, kAXRoleAttribute as String) ?? ""
+        let subrole = stringAttribute(element, kAXSubroleAttribute as String)
+
+        let roleDescription = stringAttribute(element, kAXRoleDescriptionAttribute as String)
+        let title = stringAttribute(element, kAXTitleAttribute as String)
+        let descriptionLabel = stringAttribute(element, kAXDescriptionAttribute as String)
+        let isSecure = CotypingSecureFieldDetector.isSecure(
+            role: role,
+            subrole: subrole,
+            roleDescription: roleDescription,
+            title: title,
+            descriptionLabel: descriptionLabel)
+        if isSecure {
+            return DictationFocusSnapshot(
+                processID: processID,
+                bundleID: bundleID,
+                focusIdentityKey: nil,
+                isSecureOrBlocked: true)
+        }
+
+        let isEditable = editableRoles.contains(role)
+            || isAttributeSettable(element, kAXValueAttribute as String)
+        guard isEditable else {
+            return DictationFocusSnapshot(
+                processID: processID,
+                bundleID: bundleID,
+                focusIdentityKey: nil,
+                isSecureOrBlocked: false)
+        }
+
+        let focusIdentityKey = focusIdentityKey(
+            for: element,
+            processID: processID,
+            bundleID: bundleID,
+            role: role,
+            subrole: subrole)
+        let hasSelection = selectionRange(element).map { $0.length > 0 } ?? false
+        return DictationFocusSnapshot(
+            processID: processID,
+            bundleID: bundleID,
+            focusIdentityKey: focusIdentityKey,
+            isSecureOrBlocked: hasSelection)
+    }
+
+    /// Resolve the current focus into a cotyping snapshot. Routine callers use
+    /// `CotypingAXSnapshotExecutor`; the synchronous entry point is retained for
+    /// the event-tap acceptance check, where returning before accepting is
+    /// required to avoid inserting into the wrong field.
     static func resolveFocus(includeSurface: Bool = false, includeURL: Bool = false, includeStyle: Bool = false) -> CotypingFocus {
         guard isTrusted else {
             return CotypingFocus(appName: "", bundleID: nil,
@@ -193,21 +488,21 @@ enum CotypingAXHelper {
     /// CoTabby's focus pipeline. Safe to call on every poll: successful and
     /// unsupported PIDs are cached, while named Electron editors get one
     /// re-assertion per activation edge.
-    @MainActor
     private static func primeWebAccessibilityIfNeeded(application: NSRunningApplication) {
         let pid = application.processIdentifier
         let bundleID = application.bundleIdentifier
-        let isActivationEdge = pid != lastFrontmostPrimePID
-        lastFrontmostPrimePID = pid
-
-        guard pid > 0,
-              needsWebAccessibilityPriming(bundleID: bundleID),
-              !unsupportedWebAccessibilityPIDs.contains(pid) else {
-            return
+        let shouldPrime = cacheState.withLock {
+            let isActivationEdge = pid != cacheState.lastFrontmostPrimePID
+            cacheState.lastFrontmostPrimePID = pid
+            guard pid > 0,
+                  needsWebAccessibilityPriming(bundleID: bundleID),
+                  !cacheState.unsupportedWebAccessibilityPIDs.contains(pid) else {
+                return false
+            }
+            let reassertForElectronEditor = isActivationEdge && isElectronEditor(bundleID: bundleID)
+            return !cacheState.primedWebAccessibilityPIDs.contains(pid) || reassertForElectronEditor
         }
-
-        let reassertForElectronEditor = isActivationEdge && isElectronEditor(bundleID: bundleID)
-        guard !primedWebAccessibilityPIDs.contains(pid) || reassertForElectronEditor else {
+        guard shouldPrime else {
             return
         }
 
@@ -216,9 +511,9 @@ enum CotypingAXHelper {
         let value: CFBoolean = kCFBooleanTrue
         switch AXUIElementSetAttributeValue(appElement, "AXManualAccessibility" as CFString, value) {
         case .success:
-            primedWebAccessibilityPIDs.insert(pid)
+            _ = cacheState.withLock { cacheState.primedWebAccessibilityPIDs.insert(pid) }
         case .attributeUnsupported:
-            unsupportedWebAccessibilityPIDs.insert(pid)
+            _ = cacheState.withLock { cacheState.unsupportedWebAccessibilityPIDs.insert(pid) }
         default:
             break
         }
@@ -314,11 +609,12 @@ enum CotypingAXHelper {
     /// the ghost overlay can match it. Best-effort: nil on any miss → overlay
     /// defaults. The parameterized attributed-string read is a synchronous
     /// cross-process call, so it is cached and gated behind `includeStyle`.
-    @MainActor
     private static func resolveFieldStyle(for element: AXUIElement, caretLocation: Int, textLength: Int) -> CotypingFieldStyle? {
         guard textLength > 0 else { return nil }
         let identifier = stringAttribute(element, kAXIdentifierAttribute as String)
-        if let identifier, !identifier.isEmpty, let cached = fieldStyleCache[identifier] {
+        if let identifier,
+           !identifier.isEmpty,
+           let cached = cacheState.withLock({ cacheState.fieldStyles[identifier] }) {
             return cached
         }
         // Prefer the character just before the caret (what the user is extending),
@@ -334,8 +630,10 @@ enum CotypingAXHelper {
             break
         }
         if let identifier, !identifier.isEmpty, let resolved {
-            fieldStyleCache[identifier] = resolved
-            if fieldStyleCache.count > 64 { fieldStyleCache.removeAll() }
+            cacheState.withLock {
+                cacheState.fieldStyles[identifier] = resolved
+                if cacheState.fieldStyles.count > 64 { cacheState.fieldStyles.removeAll() }
+            }
         }
         return resolved
     }
@@ -399,7 +697,6 @@ enum CotypingAXHelper {
         return stringAttribute(raw as! AXUIElement, kAXTitleAttribute as String)
     }
 
-    @MainActor
     private static func resolveSurfaceCapture(
         element: AXUIElement,
         processID: pid_t,
@@ -421,10 +718,12 @@ enum CotypingAXHelper {
             inputFrameRect: inputFrameRect,
             includeSurface: includeSurface,
             includeURL: includeURL)
-        return surfaceCaptureCache.capture(forKey: key) {
+        return cacheState.surfaceCaptures.capture(forKey: key) {
             CotypingSurfaceCapture(
                 windowTitle: includeSurface ? windowTitle(near: element) : nil,
-                fieldPlaceholder: includeSurface ? stringAttribute(element, kAXPlaceholderValueAttribute as String) : nil,
+                fieldPlaceholder: includeSurface
+                    ? stringAttribute(element, kAXPlaceholderValueAttribute as String)
+                    : nil,
                 urlString: includeURL ? webURL(near: element) : nil)
         }
     }
@@ -461,7 +760,6 @@ enum CotypingAXHelper {
 
     // MARK: - Element + owner
 
-    @MainActor
     static func focusedElement() -> AXUIElement? {
         if let element = focusedElement(from: systemWide) {
             return element
@@ -472,7 +770,7 @@ enum CotypingAXHelper {
             return nil
         }
         if let element = focusedElement(forApplicationPID: frontmost.processIdentifier) {
-            chromiumHitTestCache = nil
+            cacheState.withLock { cacheState.chromiumHitTest = nil }
             return element
         }
         return chromiumHitTestFallback(for: frontmost)
@@ -497,27 +795,26 @@ enum CotypingAXHelper {
         return element
     }
 
-    @MainActor
     private static func chromiumHitTestFallback(for application: NSRunningApplication) -> AXUIElement? {
         let pid = application.processIdentifier
         guard pid > 0,
               needsWebAccessibilityPriming(bundleID: application.bundleIdentifier) else {
-            chromiumHitTestCache = nil
+            cacheState.withLock { cacheState.chromiumHitTest = nil }
             return nil
         }
 
-        if let cache = chromiumHitTestCache,
+        if let cache = cacheState.withLock({ cacheState.chromiumHitTest }),
            cache.pid == pid,
            isFocused(cache.element) {
             return cache.element
         }
-        chromiumHitTestCache = nil
+        cacheState.withLock { cacheState.chromiumHitTest = nil }
 
         guard let hit = element(atCocoaPoint: NSEvent.mouseLocation) else {
             return nil
         }
         let editable = nearestEditable(from: hit)
-        chromiumHitTestCache = (editable, pid)
+        cacheState.withLock { cacheState.chromiumHitTest = (editable, pid) }
         return editable
     }
 

--- a/LokalBot/Cotyping/CotypingCoordinator.swift
+++ b/LokalBot/Cotyping/CotypingCoordinator.swift
@@ -39,13 +39,15 @@ final class CotypingCoordinator: ObservableObject {
     private var focusPrewarmTask: Task<Void, Never>?
     private var focusPrewarmFieldIdentity: String?
     private var hostPublishPollGeneration: UInt64 = 0
+    private var hostPublishPollTask: Task<Void, Never>?
     private var wired = false
     private var lastLatencyMilliseconds: Int?
     private var isPostExhaustionAcceptanceArmed = false
     private var hasQueuedPostExhaustionAccept = false
     private var postExhaustionAcceptanceGeneration: UInt64 = 0
     private var pendingStreamPartial: PendingStreamPartial?
-    private var isStreamDrainScheduled = false
+    private var streamValidationTask: Task<Void, Never>?
+    private var streamValidationGeneration: UInt64 = 0
     private var lastAcceptedTail: AcceptedSuggestionTail?
     private var lastAcceptanceAt: Date?
     private var pendingInsertionConsumedCount: Int?
@@ -274,8 +276,11 @@ final class CotypingCoordinator: ObservableObject {
         let pollGeneration = hostPublishPollGeneration
         let keystrokeUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(Self.hostPublishFirstPollIntervalMs)) { [weak self] in
-            self?.pollForHostPublish(
+        hostPublishPollTask?.cancel()
+        hostPublishPollTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(Self.hostPublishFirstPollIntervalMs))
+            guard !Task.isCancelled else { return }
+            await self?.pollForHostPublish(
                 baseline: baseline,
                 pollGeneration: pollGeneration,
                 elapsedMs: Self.hostPublishFirstPollIntervalMs,
@@ -289,9 +294,9 @@ final class CotypingCoordinator: ObservableObject {
         pollGeneration: UInt64,
         elapsedMs: Int,
         keystrokeUptimeNanoseconds: UInt64
-    ) {
+    ) async {
         guard isRunning, pollGeneration == hostPublishPollGeneration else { return }
-        let focus = focusTracker.refreshNow()
+        let focus = await focusTracker.refreshNow()
         guard isRunning, pollGeneration == hostPublishPollGeneration else { return }
         let nextElapsed = elapsedMs + Self.hostPublishPollIntervalMs
 
@@ -314,14 +319,13 @@ final class CotypingCoordinator: ObservableObject {
                    liveField: focus.field,
                    pendingInsertionConsumedCount: pendingInsertionConsumedCount),
                nextElapsed < Self.hostPublishWaitCeilingMs {
-                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(Self.hostPublishPollIntervalMs)) { [weak self] in
-                    self?.pollForHostPublish(
-                        baseline: baseline,
-                        pollGeneration: pollGeneration,
-                        elapsedMs: nextElapsed,
-                        keystrokeUptimeNanoseconds: keystrokeUptimeNanoseconds
-                    )
-                }
+                try? await Task.sleep(for: .milliseconds(Self.hostPublishPollIntervalMs))
+                guard !Task.isCancelled else { return }
+                await pollForHostPublish(
+                    baseline: baseline,
+                    pollGeneration: pollGeneration,
+                    elapsedMs: nextElapsed,
+                    keystrokeUptimeNanoseconds: keystrokeUptimeNanoseconds)
                 return
             }
             scheduleGeneration(consumedDelayMilliseconds: consumed)
@@ -335,14 +339,13 @@ final class CotypingCoordinator: ObservableObject {
             return
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(Self.hostPublishPollIntervalMs)) { [weak self] in
-            self?.pollForHostPublish(
-                baseline: baseline,
-                pollGeneration: pollGeneration,
-                elapsedMs: nextElapsed,
-                keystrokeUptimeNanoseconds: keystrokeUptimeNanoseconds
-            )
-        }
+        try? await Task.sleep(for: .milliseconds(Self.hostPublishPollIntervalMs))
+        guard !Task.isCancelled else { return }
+        await pollForHostPublish(
+            baseline: baseline,
+            pollGeneration: pollGeneration,
+            elapsedMs: nextElapsed,
+            keystrokeUptimeNanoseconds: keystrokeUptimeNanoseconds)
     }
 
     private nonisolated static func elapsedMilliseconds(since uptimeNanoseconds: UInt64) -> Int {
@@ -353,6 +356,8 @@ final class CotypingCoordinator: ObservableObject {
         focusPrewarmTask?.cancel()
         focusPrewarmTask = nil
         hostPublishPollGeneration &+= 1
+        hostPublishPollTask?.cancel()
+        hostPublishPollTask = nil
         pendingSpeculativeSignature = nil
         pendingSpeculativeResult = nil
         debounceTask?.cancel()
@@ -447,7 +452,8 @@ final class CotypingCoordinator: ObservableObject {
             state = .disabled(CotypingMeetingPause.reason)
             return
         }
-        let focus = refreshFocusForPrediction(settings: settings)
+        let focus = await refreshFocusForPrediction(settings: settings)
+        guard work == generation, isRunning, !Task.isCancelled else { return }
 
         if let reason = CotypingAvailability.disabledReason(
             enabled: settings.cotypingEnabled,
@@ -514,7 +520,7 @@ final class CotypingCoordinator: ObservableObject {
                 guard streamPartials else { return }
                 Task { @MainActor in self?.queueStreamPartial(partial, work: work, field: field) }
             }
-            completeGeneration(
+            await completeGeneration(
                 result,
                 targetField: field,
                 work: work,
@@ -538,16 +544,27 @@ final class CotypingCoordinator: ObservableObject {
         work: UInt64,
         latencyMilliseconds: Int,
         holdSignature: String?
-    ) {
+    ) async {
         guard work == generation, isRunning else { return }
         let settings = settingsProvider()
 
         if let signature = holdSignature {
             guard pendingSpeculativeSignature == signature else { return }
-            let focus = focusTracker.refreshNow(
+            guard let focus = await focusTracker.refreshForValidation(
                 includeSurface: settings.cotypingUseAppContext,
                 includeURL: !settings.cotypingExcludedDomainList.isEmpty,
-                includeStyle: settings.cotypingMatchHostStyle)
+                includeStyle: settings.cotypingMatchHostStyle) else {
+                guard work == generation, pendingSpeculativeSignature == signature else { return }
+                pendingSpeculativeResult = PendingSpeculativeResult(
+                    result: result,
+                    work: work,
+                    optimisticField: targetField,
+                    latencyMilliseconds: latencyMilliseconds)
+                return
+            }
+            guard work == generation,
+                  isRunning,
+                  pendingSpeculativeSignature == signature else { return }
             if let publishedField = focus.field,
                publishedField.contentSignature == signature {
                 _ = applySpeculativeResult(
@@ -566,9 +583,11 @@ final class CotypingCoordinator: ObservableObject {
             return
         }
 
-        guard let liveField = validatedLiveFieldForGeneratedResult(
+        guard let liveField = await validatedLiveFieldForGeneratedResult(
             originalField: targetField,
-            settings: settings) else {
+            settings: settings,
+            work: work) else {
+            guard work == generation, isRunning else { return }
             clearStaleGeneratedResult()
             return
         }
@@ -652,25 +671,36 @@ final class CotypingCoordinator: ObservableObject {
         return resolution.value
     }
 
-    private func refreshFocusForPrediction(settings: AppSettings) -> CotypingFocus {
+    private func refreshFocusForPrediction(settings: AppSettings) async -> CotypingFocus {
         let includeSurface = settings.cotypingUseAppContext
         let includeURL = !settings.cotypingExcludedDomainList.isEmpty
         let includeStyle = settings.cotypingMatchHostStyle
         guard !includeSurface, !includeURL, !includeStyle else {
-            return focusTracker.refreshNow(
+            return await focusTracker.refreshNow(
                 includeSurface: includeSurface,
                 includeURL: includeURL,
                 includeStyle: includeStyle)
         }
-        return focusTracker.refreshIfStale(
+        return await focusTracker.refreshIfStale(
             maxAgeMilliseconds: Self.freshSnapshotReuseWindowMilliseconds)
     }
 
     private func validatedLiveFieldForGeneratedResult(
         originalField: CotypingField,
-        settings: AppSettings
-    ) -> CotypingField? {
-        let focus = refreshFocusForPrediction(settings: settings)
+        settings: AppSettings,
+        work: UInt64
+    ) async -> CotypingField? {
+        guard work == generation, isRunning else { return nil }
+        let includeSurface = settings.cotypingUseAppContext
+        let includeURL = !settings.cotypingExcludedDomainList.isEmpty
+        let includeStyle = settings.cotypingMatchHostStyle
+        guard let focus = await focusTracker.refreshForValidation(
+            includeSurface: includeSurface,
+            includeURL: includeURL,
+            includeStyle: includeStyle) else {
+            return nil
+        }
+        guard work == generation, isRunning else { return nil }
         if let reason = CotypingAvailability.disabledReason(
             enabled: settings.cotypingEnabled,
             excludedApps: settings.cotypingExcludedAppList,
@@ -810,7 +840,7 @@ final class CotypingCoordinator: ObservableObject {
             do {
                 let result = try await self.engine.generate(request)
                 guard !Task.isCancelled else { return }
-                self.completeGeneration(
+                await self.completeGeneration(
                     result,
                     targetField: optimisticField,
                     work: work,
@@ -862,28 +892,41 @@ final class CotypingCoordinator: ObservableObject {
     private func queueStreamPartial(_ result: CotypingNormalizationResult, work: UInt64, field: CotypingField) {
         guard work == generation, isRunning else { return }
         pendingStreamPartial = PendingStreamPartial(result: result, work: work, field: field)
-        guard !isStreamDrainScheduled else { return }
-        isStreamDrainScheduled = true
-        DispatchQueue.main.async { [weak self] in
-            self?.drainStreamPartial()
+        guard streamValidationTask == nil else { return }
+        streamValidationGeneration &+= 1
+        let validationGeneration = streamValidationGeneration
+        streamValidationTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled,
+                  self.streamValidationGeneration == validationGeneration,
+                  let pending = self.pendingStreamPartial {
+                self.pendingStreamPartial = nil
+                await self.renderStreamPartial(
+                    pending.result,
+                    work: pending.work,
+                    field: pending.field)
+            }
+            if self.streamValidationGeneration == validationGeneration {
+                self.streamValidationTask = nil
+            }
         }
-    }
-
-    private func drainStreamPartial() {
-        isStreamDrainScheduled = false
-        guard let pending = pendingStreamPartial else { return }
-        pendingStreamPartial = nil
-        renderStreamPartial(pending.result, work: pending.work, field: pending.field)
     }
 
     /// Renders a streamed partial. Monotonic: ignores reordered/shorter partials
     /// so the ghost only grows.
-    private func renderStreamPartial(_ result: CotypingNormalizationResult, work: UInt64, field: CotypingField) {
+    private func renderStreamPartial(
+        _ result: CotypingNormalizationResult,
+        work: UInt64,
+        field: CotypingField
+    ) async {
         guard work == generation, isRunning, !result.text.isEmpty else { return }
         let settings = settingsProvider()
-        guard let liveField = validatedLiveFieldForGeneratedResult(
+        let liveField = await validatedLiveFieldForGeneratedResult(
             originalField: field,
-            settings: settings) else {
+            settings: settings,
+            work: work)
+        guard work == generation, isRunning, !Task.isCancelled else { return }
+        guard let liveField else {
             clearStaleGeneratedResult()
             return
         }
@@ -1125,7 +1168,7 @@ final class CotypingCoordinator: ObservableObject {
                 guard let self, self.overlay.isVisible, let liveSession = self.session,
                       liveSession.remainingText == remainingText else { return }
                 guard !self.isAwaitingPostInsertionSync else { return }
-                let focus = self.focusTracker.refreshNow()
+                let focus = await self.focusTracker.refreshNow()
                 if let field = focus.field {
                     let placement = self.placement(for: field)
                     if self.overlay.shouldHoldInlineReanchor(
@@ -1181,6 +1224,9 @@ final class CotypingCoordinator: ObservableObject {
         pendingInsertionConsumedCount = nil
         overlay.hide()
         pendingStreamPartial = nil
+        streamValidationGeneration &+= 1
+        streamValidationTask?.cancel()
+        streamValidationTask = nil
         if releasePostExhaustionWindow {
             clearPostExhaustionAcceptanceWindow()
         }

--- a/LokalBot/Cotyping/CotypingFocusTracker.swift
+++ b/LokalBot/Cotyping/CotypingFocusTracker.swift
@@ -20,11 +20,20 @@ final class CotypingFocusTracker: ObservableObject {
     private var pollBackoff = CotypingFocusPollBackoff()
     private var capabilityFlickerGate = CotypingFocusCapabilityFlickerGate()
     private var lastCaptureUptimeNanoseconds: UInt64?
+    private let snapshotExecutor: CotypingAXSnapshotExecutor
+    private var timerCaptureTask: Task<Void, Never>?
+    private var timerCaptureRequested = false
+    private var timerCaptureGeneration: UInt64 = 0
+    private var captureLifecycleGeneration: UInt64 = 0
 
     nonisolated static let defaultIntervalMs = 200
 
-    init(intervalMs: Int = defaultIntervalMs) {
+    init(
+        intervalMs: Int = defaultIntervalMs,
+        snapshotExecutor: CotypingAXSnapshotExecutor = .shared
+    ) {
         self.baseIntervalMs = intervalMs
+        self.snapshotExecutor = snapshotExecutor
     }
 
     var isRunning: Bool { timer != nil }
@@ -41,8 +50,8 @@ final class CotypingFocusTracker: ObservableObject {
     func start() {
         guard timer == nil else { return }
         pollBackoff.reset()
-        refreshNow()
         scheduleTimer()
+        requestTimerCapture()
     }
 
     private var effectiveIntervalMs: Int {
@@ -67,6 +76,11 @@ final class CotypingFocusTracker: ObservableObject {
     func stop() {
         timer?.invalidate()
         timer = nil
+        captureLifecycleGeneration &+= 1
+        timerCaptureGeneration &+= 1
+        timerCaptureTask?.cancel()
+        timerCaptureTask = nil
+        timerCaptureRequested = false
         scheduledIntervalMs = nil
         lastCaptureUptimeNanoseconds = nil
         pollBackoff.reset()
@@ -78,18 +92,55 @@ final class CotypingFocusTracker: ObservableObject {
     }
 
     private func handleTimerTick() {
-        let previous = focus
-        let latest = captureFocus(includeSurface: false, includeURL: false, includeStyle: false)
-        pollBackoff.recordCapture(didChange: latest != previous)
-        rescheduleTimerIfNeeded()
+        requestTimerCapture()
     }
 
-    /// Synchronous capture. Publishes only on a real change so SwiftUI surfaces
-    /// and the coordinator do not churn every tick.
+    /// Latest-wins timer polling. A slow target app can never build an unbounded
+    /// stack of timer tasks while the serialized AX executor is still working.
+    private func requestTimerCapture() {
+        guard timer != nil else { return }
+        if timerCaptureTask != nil {
+            timerCaptureRequested = true
+            return
+        }
+        timerCaptureGeneration &+= 1
+        let captureGeneration = timerCaptureGeneration
+        timerCaptureTask = Task { [weak self] in
+            guard let self else { return }
+            repeat {
+                self.timerCaptureRequested = false
+                let previous = self.focus
+                let capture = await self.captureFocus(
+                    includeSurface: false,
+                    includeURL: false,
+                    includeStyle: false)
+                guard !Task.isCancelled,
+                      self.timer != nil,
+                      self.timerCaptureGeneration == captureGeneration else { break }
+                if capture.completed {
+                    self.pollBackoff.recordCapture(didChange: capture.focus != previous)
+                    self.rescheduleTimerIfNeeded()
+                }
+            } while self.timerCaptureRequested
+            if self.timerCaptureGeneration == captureGeneration {
+                self.timerCaptureTask = nil
+            }
+        }
+    }
+
+    /// Asynchronous background capture. Publishes only on a real change so
+    /// SwiftUI surfaces and the coordinator do not churn every tick.
     @discardableResult
-    func refreshNow(includeSurface: Bool = false, includeURL: Bool = false, includeStyle: Bool = false) -> CotypingFocus {
+    func refreshNow(
+        includeSurface: Bool = false,
+        includeURL: Bool = false,
+        includeStyle: Bool = false
+    ) async -> CotypingFocus {
         pollBackoff.reset()
-        let latest = captureFocus(includeSurface: includeSurface, includeURL: includeURL, includeStyle: includeStyle)
+        let latest = await captureFocus(
+            includeSurface: includeSurface,
+            includeURL: includeURL,
+            includeStyle: includeStyle).focus
         rescheduleTimerIfNeeded()
         return latest
     }
@@ -100,19 +151,50 @@ final class CotypingFocusTracker: ObservableObject {
         includeSurface: Bool = false,
         includeURL: Bool = false,
         includeStyle: Bool = false
-    ) -> CotypingFocus {
+    ) async -> CotypingFocus {
         guard Self.shouldRefreshCapture(
             lastCaptureUptimeNanoseconds: lastCaptureUptimeNanoseconds,
             nowUptimeNanoseconds: DispatchTime.now().uptimeNanoseconds,
             maxAgeMilliseconds: maxAgeMilliseconds) else {
             return focus
         }
-        return refreshNow(includeSurface: includeSurface, includeURL: includeURL, includeStyle: includeStyle)
+        return await refreshNow(
+            includeSurface: includeSurface,
+            includeURL: includeURL,
+            includeStyle: includeStyle)
     }
 
-    private func captureFocus(includeSurface: Bool, includeURL: Bool, includeStyle: Bool) -> CotypingFocus {
-        let latestRaw = CotypingAXHelper.resolveFocus(
-            includeSurface: includeSurface, includeURL: includeURL, includeStyle: includeStyle)
+    /// A validation capture fails closed on a whole-snapshot timeout. Callers
+    /// that are about to display generated text must not validate against a
+    /// cached field after the live target becomes unresponsive.
+    func refreshForValidation(
+        includeSurface: Bool = false,
+        includeURL: Bool = false,
+        includeStyle: Bool = false
+    ) async -> CotypingFocus? {
+        let capture = await captureFocus(
+            includeSurface: includeSurface,
+            includeURL: includeURL,
+            includeStyle: includeStyle)
+        return capture.completed ? capture.focus : nil
+    }
+
+    private func captureFocus(
+        includeSurface: Bool,
+        includeURL: Bool,
+        includeStyle: Bool
+    ) async -> (focus: CotypingFocus, completed: Bool) {
+        var options: CotypingAXCaptureOptions = []
+        if includeSurface { options.insert(.surface) }
+        if includeURL { options.insert(.url) }
+        if includeStyle { options.insert(.style) }
+        let lifecycleGeneration = captureLifecycleGeneration
+        let capture = await snapshotExecutor.capture(options: options)
+        guard lifecycleGeneration == captureLifecycleGeneration,
+              !capture.timedOut,
+              let latestRaw = capture.focus else {
+            return (focus, false)
+        }
         lastCaptureUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
         let latest: CotypingFocus
         switch capabilityFlickerGate.evaluate(latestRaw) {
@@ -125,7 +207,7 @@ final class CotypingFocusTracker: ObservableObject {
             focus = latest
             onChange?(latest)
         }
-        return latest
+        return (latest, true)
     }
 
     nonisolated static func millisecondsSinceCapture(

--- a/LokalBot/Cotyping/Llama/CotypingEngineSelector.swift
+++ b/LokalBot/Cotyping/Llama/CotypingEngineSelector.swift
@@ -6,6 +6,8 @@ import Foundation
 /// Conforms to `CotypingCompleting`, so `CotypingCoordinator` is unchanged.
 @MainActor
 final class CotypingEngineSelector: CotypingCompleting {
+    typealias ModelVerifier = (ModelCatalog.Entry, StorageManager) async -> URL?
+
     /// How long completions stay on HTTP after an in-process failure before
     /// the local engine is rebuilt and retried. Long enough that a persistent
     /// failure doesn't reload the ~6.66 GB weights on every keystroke, short
@@ -17,6 +19,7 @@ final class CotypingEngineSelector: CotypingCompleting {
     private let settings: () -> AppSettings
     private let storage: StorageManager
     private let now: () -> Date
+    private let verifyModel: ModelVerifier
     private var local: CotypingCompleting?
     private var localModelPath: String?
     /// Set after the first in-process failure so the HTTP fallback is logged
@@ -32,13 +35,17 @@ final class CotypingEngineSelector: CotypingCompleting {
         makeLocal: @escaping (String) -> CotypingCompleting,
         settings: @escaping () -> AppSettings,
         storage: StorageManager,
-        now: @escaping () -> Date = { Date() }
+        now: @escaping () -> Date = { Date() },
+        verifyModel: @escaping ModelVerifier = { entry, storage in
+            await ModelDownloadManager.shared.verifiedExistingURL(entry, storage: storage)
+        }
     ) {
         self.http = http
         self.makeLocal = makeLocal
         self.settings = settings
         self.storage = storage
         self.now = now
+        self.verifyModel = verifyModel
     }
 
     static var isAppleSilicon: Bool {
@@ -54,26 +61,24 @@ final class CotypingEngineSelector: CotypingCompleting {
     }
 
     /// Resolves the built-in cotyping model path the same way `makeTextEngine` does.
-    private func resolvedModelURL(_ s: AppSettings) -> URL? {
+    private func resolvedModelURL(_ s: AppSettings) async -> URL? {
         guard let entry = ModelCatalog.entry(id: s.cotypingBuiltInModelID, custom: s.customBuiltInModels)
                 ?? ModelCatalog.entry(id: ModelCatalog.recommendedCotypingID) else { return nil }
-        return ModelCatalog.localURL(for: entry, storage: storage)
+        return await verifyModel(entry, storage)
     }
 
     /// Returns the local engine if eligible, lazily (re)building it when the
     /// resolved model path changes; nil → use HTTP.
-    private func localIfEligible() -> CotypingCompleting? {
+    private func localIfEligible() async -> CotypingCompleting? {
         let s = settings()
-        // Short-circuit the cheap gating conditions before the synchronous GGUF
-        // disk read in `resolvedModelURL`: a built-in-backend user with the runtime
-        // toggle off (or on Intel) would otherwise pay that read for nothing. This
-        // is behavior-identical to gating in `shouldUseLocal` — which still returns
-        // false in exactly these cases — we just avoid resolving the path first.
+        // Short-circuit the cheap gating conditions before resolving and, for a
+        // legacy download, hashing the GGUF. Users with local cotyping disabled
+        // should not pay that integrity-check cost.
         guard s.cotypingInProcessRuntime, Self.isAppleSilicon else { dropLocalEngine(); return nil }
         // Failure cooldown: the engine was already dropped (weights freed) in
         // handleLocalFailure, so just route to HTTP until the retry instant.
         if let retryLocalAt, now() < retryLocalAt { return nil }
-        guard let url = resolvedModelURL(s),
+        guard let url = await resolvedModelURL(s),
               Self.shouldUseLocal(settings: s, modelURL: url, isAppleSilicon: Self.isAppleSilicon)
         else { dropLocalEngine(); return nil }
         if local == nil || localModelPath != url.path {
@@ -105,12 +110,12 @@ final class CotypingEngineSelector: CotypingCompleting {
     }
 
     func prewarm() async {
-        guard let engine = localIfEligible() else { return }
+        guard let engine = await localIfEligible() else { return }
         try? await engine.prewarm()
     }
 
     func prewarm(for request: CotypingRequest) async {
-        guard let engine = localIfEligible() else { return }
+        guard let engine = await localIfEligible() else { return }
         try? await engine.prewarm(for: request)
     }
 
@@ -120,7 +125,7 @@ final class CotypingEngineSelector: CotypingCompleting {
     }
 
     func generate(_ request: CotypingRequest) async throws -> CotypingNormalizationResult {
-        guard let engine = localIfEligible() else { return try await http.generate(request) }
+        guard let engine = await localIfEligible() else { return try await http.generate(request) }
         do {
             let result = try await engine.generate(request)
             noteLocalSuccess()
@@ -135,7 +140,7 @@ final class CotypingEngineSelector: CotypingCompleting {
         _ request: CotypingRequest,
         onPartial: @escaping @Sendable (CotypingNormalizationResult) -> Void
     ) async throws -> CotypingNormalizationResult {
-        guard let engine = localIfEligible() else {
+        guard let engine = await localIfEligible() else {
             return try await http.generateStreaming(request, onPartial: onPartial)
         }
         do {

--- a/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
+++ b/LokalBot/Cotyping/Llama/LlamaCotypingRuntime.swift
@@ -10,16 +10,28 @@ enum LlamaRuntimeError: Error, Equatable {
 private final class LlamaDecodeAbortState: @unchecked Sendable {
     private let lock = NSLock()
     private var abortRequested = false
+    private var decodeActive = false
 
-    func reset() {
+    /// Starts one decode scope. Abort requests made while no decode is active
+    /// are intentionally ignored, so cancelling an old request cannot poison
+    /// the next generation.
+    func beginDecode() {
         lock.lock()
+        decodeActive = true
+        abortRequested = false
+        lock.unlock()
+    }
+
+    func endDecode() {
+        lock.lock()
+        decodeActive = false
         abortRequested = false
         lock.unlock()
     }
 
     func requestAbort() {
         lock.lock()
-        abortRequested = true
+        if decodeActive { abortRequested = true }
         lock.unlock()
     }
 
@@ -56,6 +68,11 @@ actor LlamaCotypingRuntime {
     private var vocab: OpaquePointer?
     private var loadedModelPath: String?
     private var residencyGeneration: UUID?
+    /// Actor methods are reentrant at `await` points. Serialize model loads so
+    /// concurrent prewarm and first-generation calls cannot mmap the same
+    /// weights twice while `willLoad` is suspended.
+    private var loadInProgress = false
+    private var loadWaiters: [CheckedContinuation<Void, Never>] = []
     /// The prompt most recently prefilled into the context (basis for the
     /// incremental KV-reuse probe against the next prompt).
     private var cachedTokens: [Int32] = []
@@ -87,23 +104,45 @@ actor LlamaCotypingRuntime {
     // MARK: - Lifecycle
 
     func loadIfNeeded(modelPath: String) async throws {
+        while loadInProgress {
+            await withCheckedContinuation { continuation in
+                loadWaiters.append(continuation)
+            }
+        }
+        try Task.checkCancellation()
         if isLoaded, loadedModelPath == modelPath {
             await ModelResidency.shared.touch(id: Self.residencyID)
             return
         }
+        loadInProgress = true
+        defer { finishLoad() }
         unload()
         // Make room before llama mmaps the weights: evict LRU models first
         // if this load would push total resident weights past the budget.
-        await ModelResidency.shared.willLoad(
+        let loadReservation = await ModelResidency.shared.willLoad(
             id: Self.residencyID,
             bytes: ModelResidency.weightBytes(at: URL(fileURLWithPath: modelPath)))
+        do {
+            try Task.checkCancellation()
+        } catch {
+            await ModelResidency.shared.cancelLoad(loadReservation)
+            throw error
+        }
 
         _ = Self.backendReady   // forces the run-once backend init (idempotent)
 
         var mparams = llama_model_default_params()
         mparams.n_gpu_layers = 99   // full Metal offload (matches LlamaServer's -ngl 99)
         guard let m = llama_model_load_from_file(modelPath, mparams) else {
+            await ModelResidency.shared.cancelLoad(loadReservation)
             throw LlamaRuntimeError.modelLoadFailed(modelPath)
+        }
+        do {
+            try Task.checkCancellation()
+        } catch {
+            llama_model_free(m)
+            await ModelResidency.shared.cancelLoad(loadReservation)
+            throw error
         }
 
         var cparams = llama_context_default_params()
@@ -114,9 +153,17 @@ actor LlamaCotypingRuntime {
         cparams.n_threads_batch = threads
         guard let c = llama_init_from_model(m, cparams) else {
             llama_model_free(m)
+            await ModelResidency.shared.cancelLoad(loadReservation)
             throw LlamaRuntimeError.contextInitFailed
         }
-        decodeAbortState.reset()
+        do {
+            try Task.checkCancellation()
+        } catch {
+            llama_free(c)
+            llama_model_free(m)
+            await ModelResidency.shared.cancelLoad(loadReservation)
+            throw error
+        }
         llama_set_abort_callback(
             c,
             llamaCotypingAbortCallback,
@@ -149,8 +196,23 @@ actor LlamaCotypingRuntime {
     /// this the Metal backend's residency set is still live at process exit,
     /// which trips a teardown assertion in the vendored ggml-metal build.
     deinit {
+        let generation = residencyGeneration
         if let c = ctx { llama_free(c) }
         if let m = model { llama_model_free(m) }
+        if let generation {
+            Task { @MainActor in
+                ModelResidency.shared.unregister(
+                    id: Self.residencyID,
+                    ifGenerationMatches: generation)
+            }
+        }
+    }
+
+    private func finishLoad() {
+        loadInProgress = false
+        let waiters = loadWaiters
+        loadWaiters.removeAll(keepingCapacity: true)
+        waiters.forEach { $0.resume() }
     }
 
     /// Prewarm == load + the priming decode `loadIfNeeded` already performs.
@@ -161,8 +223,8 @@ actor LlamaCotypingRuntime {
     /// masquerade as the prompt represented by `cachedTokens`.
     func prefill(promptTokens: [Int32]) throws {
         guard let ctx, !promptTokens.isEmpty else { return }
-        decodeAbortState.reset()
-        defer { decodeAbortState.reset() }
+        decodeAbortState.beginDecode()
+        defer { decodeAbortState.endDecode() }
         try Task.checkCancellation()
         guard supportsPartialReuse else {
             // CoTabby avoids speculative prefills once a model cannot reuse a
@@ -232,8 +294,8 @@ actor LlamaCotypingRuntime {
     /// keystroke, then clears the KV so generation starts from a clean cache.
     private func warmup() {
         guard let vocab, let ctx else { return }
-        decodeAbortState.reset()
-        defer { decodeAbortState.reset() }
+        decodeAbortState.beginDecode()
+        defer { decodeAbortState.endDecode() }
         let bos = llama_vocab_bos(vocab)
         _ = decode([bos], startPos: 0, logitsLastOnly: true)
         llama_memory_clear(llama_get_memory(ctx), true)
@@ -353,8 +415,8 @@ actor LlamaCotypingRuntime {
     ) throws -> String {
         guard let ctx, let vocab, !promptTokens.isEmpty else { return "" }
         guard let sampler = makeSampler(samplerSpecs) else { return "" }
-        decodeAbortState.reset()
-        defer { decodeAbortState.reset() }
+        decodeAbortState.beginDecode()
+        defer { decodeAbortState.endDecode() }
         defer { llama_sampler_free(sampler) }
 
         let mem = llama_get_memory(ctx)

--- a/LokalBot/Dictation/DictationCoordinator.swift
+++ b/LokalBot/Dictation/DictationCoordinator.swift
@@ -31,6 +31,7 @@ final class DictationCoordinator: ObservableObject {
     }
 
     @Published private(set) var state: State = .idle
+    @Published private(set) var isStarting = false
     @Published private(set) var now = Date()
     @Published private(set) var isShortcutMonitoringActive = false
     @Published private(set) var lastTranscript: String?
@@ -45,15 +46,22 @@ final class DictationCoordinator: ObservableObject {
     private let canStart: () -> Bool
     private let onBusy: () -> Void
     private let onError: (String) -> Void
+    private let focusSnapshotExecutor: DictationFocusSnapshotExecutor
     private let recorder = MicRecorder()
     private let inputMonitor = DictationInputMonitor()
     private let overlay = DictationOverlayController()
     private lazy var inserter = CotypingInserter()
     private var tick: AnyCancellable?
     private var prewarmTask: Task<Void, Never>?
+    private var startTask: Task<Void, Never>?
+    private var startTaskGeneration: Int?
     private var livePreviewTask: Task<Void, Never>?
     private var transcribeTask: Task<Void, Never>?
+    private var mediaCleanupTask: Task<Void, Never>?
+    private var mediaCleanupGeneration = 0
     private var activeAudioURL: URL?
+    private var pausedMediaSession: MediaPlaybackController.PauseSession?
+    private var deliveryTarget: DictationDeliveryTarget?
     private var generation = 0
 
     init(
@@ -61,13 +69,15 @@ final class DictationCoordinator: ObservableObject {
         settingsProvider: @escaping () -> AppSettings,
         canStart: @escaping () -> Bool,
         onBusy: @escaping () -> Void,
-        onError: @escaping (String) -> Void
+        onError: @escaping (String) -> Void,
+        focusSnapshotExecutor: DictationFocusSnapshotExecutor = .shared
     ) {
         self.storageRoot = storageRoot
         self.settingsProvider = settingsProvider
         self.canStart = canStart
         self.onBusy = onBusy
         self.onError = onError
+        self.focusSnapshotExecutor = focusSnapshotExecutor
         inputMonitor.triggerModeProvider = { [weak self] in
             self?.settingsProvider().dictationTriggerMode ?? .pushToTalk
         }
@@ -75,6 +85,7 @@ final class DictationCoordinator: ObservableObject {
         inputMonitor.onStart = { [weak self] in self?.start(source: "shortcut") }
         inputMonitor.onStop = { [weak self] in self?.finishRecordingAndTranscribe(source: "shortcut") }
         inputMonitor.onToggle = { [weak self] in self?.toggle(source: "shortcut") }
+        Self.sweepOrphanedPreviewFiles(storageRoot: storageRoot)
     }
 
     var elapsed: TimeInterval {
@@ -121,7 +132,7 @@ final class DictationCoordinator: ObservableObject {
                         generation: generation)
                 }
             } else {
-                stopLivePreview(reset: true)
+                _ = cancelLivePreview(reset: true)
             }
         }
         refreshOverlay()
@@ -136,6 +147,10 @@ final class DictationCoordinator: ObservableObject {
     }
 
     func toggle(source: String = "ui") {
+        if isStarting {
+            invalidateStartingSession()
+            return
+        }
         switch state {
         case .idle:
             start(source: source)
@@ -147,7 +162,7 @@ final class DictationCoordinator: ObservableObject {
     }
 
     func start(source: String = "ui") {
-        guard case .idle = state else { return }
+        guard case .idle = state, startTask == nil else { return }
         guard canStart() else {
             onBusy()
             return
@@ -155,22 +170,61 @@ final class DictationCoordinator: ObservableObject {
         let startedAt = Date()
         generation += 1
         let session = generation
+        startTaskGeneration = session
+        isStarting = true
+        let outputMode = settingsProvider().dictationOutputMode
+        let deliveryTargetTask = Task { [focusSnapshotExecutor] in
+            await Self.captureDeliveryTarget(
+                for: outputMode,
+                using: focusSnapshotExecutor)
+        }
+        deliveryTarget = nil
         resetLivePreview()
-        Task {
+        refreshOverlay()
+        let pendingMediaCleanup = mediaCleanupTask
+        startTask = Task { [weak self] in
+            guard let self else { return }
+            defer {
+                deliveryTargetTask.cancel()
+                if self.startTaskGeneration == session {
+                    self.startTask = nil
+                    self.startTaskGeneration = nil
+                    if self.isStarting {
+                        self.isStarting = false
+                        self.refreshOverlay()
+                    }
+                }
+            }
             guard await MicRecorder.requestPermission() else {
-                guard self.generation == session else { return }
+                guard self.generation == session, !Task.isCancelled else { return }
                 self.onError("Microphone permission denied.")
                 return
             }
-            guard self.generation == session else { return }
+            let capturedDeliveryTarget = await deliveryTargetTask.value
+            // An earlier cancel may still be restoring the exact players it
+            // paused. Finish that bounded transition before taking a new media
+            // snapshot, otherwise its late resume could interrupt this capture.
+            if let pendingMediaCleanup { await pendingMediaCleanup.value }
+            guard self.generation == session, !Task.isCancelled else { return }
+            self.deliveryTarget = capturedDeliveryTarget
+            var localMediaSession: MediaPlaybackController.PauseSession?
             do {
                 let audioURL = try self.nextAudioURL(startedAt: startedAt)
-                let pausedMedia = MediaPlaybackController.pauseActiveMediaPlayers(reason: "dictation")
+                let pausedMedia = await MediaPlaybackController.pauseActiveMediaPlayers(
+                    reason: "dictation")
+                localMediaSession = pausedMedia
                 if !pausedMedia.isEmpty {
                     try await Task.sleep(for: .milliseconds(250))
                 }
-                guard self.generation == session else { return }
+                guard self.generation == session, !Task.isCancelled else {
+                    await MediaPlaybackController.resume(pausedMedia, reason: "cancelled dictation start")
+                    return
+                }
                 try await self.startRecorder(writingTo: audioURL)
+                try Task.checkCancellation()
+                guard self.generation == session else { throw CancellationError() }
+                self.pausedMediaSession = pausedMedia
+                localMediaSession = nil
                 self.activeAudioURL = audioURL
                 self.state = .recording(startedAt: startedAt)
                 self.startTick()
@@ -181,7 +235,22 @@ final class DictationCoordinator: ObservableObject {
                 self.prewarmSelectedModel(reason: source)
                 self.startLivePreviewIfNeeded(audioURL: audioURL, config: config, generation: session)
                 lokalbotLog("dictation recording started source=\(source)")
+            } catch is CancellationError {
+                if let localMediaSession {
+                    await MediaPlaybackController.resume(
+                        localMediaSession, reason: "cancelled dictation start")
+                } else {
+                    await self.resumePausedMedia(reason: "cancelled dictation start")
+                }
+                self.recorder.stop()
+                self.activeAudioURL = nil
             } catch {
+                if let localMediaSession {
+                    await MediaPlaybackController.resume(
+                        localMediaSession, reason: "failed dictation start")
+                } else {
+                    await self.resumePausedMedia(reason: "failed dictation start")
+                }
                 self.onError("Could not start dictation: \(error.localizedDescription)")
                 self.activeAudioURL = nil
                 self.state = .idle
@@ -193,8 +262,14 @@ final class DictationCoordinator: ObservableObject {
     }
 
     func finishRecordingAndTranscribe(source: String = "ui") {
+        if isStarting {
+            invalidateStartingSession()
+            return
+        }
         guard case .recording(let startedAt) = state, let audioURL = activeAudioURL else { return }
-        stopLivePreview(reset: false)
+        let previewTask = cancelLivePreview(reset: false)
+        let mediaSession = pausedMediaSession
+        pausedMediaSession = nil
         recorder.stop()
         activeAudioURL = nil
         stopTick()
@@ -205,20 +280,32 @@ final class DictationCoordinator: ObservableObject {
         refreshOverlay()
         generation += 1
         let session = generation
+        let mediaCleanup = mediaSession.map {
+            scheduleMediaResume($0, reason: "dictation capture finished")
+        }
         transcribeTask?.cancel()
         transcribeTask = Task { [weak self] in
+            if let mediaCleanup { await mediaCleanup.value }
+            if let previewTask { await previewTask.value }
+            guard !Task.isCancelled else { return }
             await self?.transcribeAndDeliver(audioURL: audioURL, startedAt: startedAt,
                                              source: source, generation: session)
         }
     }
 
     func cancel() {
+        if startTask != nil {
+            invalidateStartingSession()
+            prewarmTask?.cancel()
+            prewarmTask = nil
+            return
+        }
         generation += 1
         transcribeTask?.cancel()
         transcribeTask = nil
         prewarmTask?.cancel()
         prewarmTask = nil
-        stopLivePreview(reset: true)
+        _ = cancelLivePreview(reset: true)
         if case .recording = state {
             recorder.stop()
         }
@@ -228,7 +315,13 @@ final class DictationCoordinator: ObservableObject {
         activeAudioURL = nil
         state = .idle
         stopTick()
+        deliveryTarget = nil
+        let mediaSession = pausedMediaSession
+        pausedMediaSession = nil
         refreshOverlay()
+        if let mediaSession {
+            scheduleMediaResume(mediaSession, reason: "cancelled dictation")
+        }
         lokalbotLog("dictation cancelled")
     }
 
@@ -258,8 +351,12 @@ final class DictationCoordinator: ObservableObject {
 
             lastTranscript = text
             lastEngine = transcript.engine
-            let delivered = deliver(text, mode: config.dictationOutputMode)
-            if !delivered {
+            switch await deliver(text, mode: config.dictationOutputMode) {
+            case .inserted, .copied:
+                break
+            case .focusChanged:
+                onError("Dictation finished after focus moved, so the text was copied to the clipboard instead of being inserted into another app.")
+            case .failed:
                 onError("Dictation finished, but LokalBot could not insert the text. It was copied to the clipboard.")
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(text, forType: .string)
@@ -275,13 +372,25 @@ final class DictationCoordinator: ObservableObject {
         }
     }
 
-    private func deliver(_ text: String, mode: DictationOutputMode) -> Bool {
+    private enum DeliveryResult {
+        case inserted
+        case copied
+        case focusChanged
+        case failed
+    }
+
+    private func deliver(_ text: String, mode: DictationOutputMode) async -> DeliveryResult {
         switch mode {
         case .pasteIntoFocusedApp:
-            return inserter.insertViaPaste(text) || inserter.insert(text)
+            guard await deliveryTargetMatchesCurrentFocus() else {
+                NSPasteboard.general.clearContents()
+                return NSPasteboard.general.setString(text, forType: .string)
+                    ? .focusChanged : .failed
+            }
+            return inserter.insertViaPaste(text) || inserter.insert(text) ? .inserted : .failed
         case .copyToClipboard:
             NSPasteboard.general.clearContents()
-            return NSPasteboard.general.setString(text, forType: .string)
+            return NSPasteboard.general.setString(text, forType: .string) ? .copied : .failed
         }
     }
 
@@ -289,7 +398,65 @@ final class DictationCoordinator: ObservableObject {
         state = .idle
         stopTick()
         resetLivePreview()
+        deliveryTarget = nil
         refreshOverlay()
+    }
+
+    nonisolated private static func captureDeliveryTarget(
+        for mode: DictationOutputMode,
+        using executor: DictationFocusSnapshotExecutor
+    ) async -> DictationDeliveryTarget? {
+        guard mode == .pasteIntoFocusedApp else { return nil }
+        let capture = await executor.capture()
+        guard !capture.timedOut, let snapshot = capture.snapshot else { return nil }
+        return DictationDeliveryTarget.captured(from: snapshot)
+    }
+
+    private func deliveryTargetMatchesCurrentFocus() async -> Bool {
+        guard let deliveryTarget else { return false }
+        let capture = await focusSnapshotExecutor.capture()
+        guard !capture.timedOut, let snapshot = capture.snapshot else { return false }
+        return deliveryTarget.matches(snapshot)
+    }
+
+    private func invalidateStartingSession() {
+        generation += 1
+        // Do not cancel an in-flight media pause: it is bounded, and allowing
+        // it to return gives that task the exact resume token it needs. The
+        // generation guard prevents the recorder from starting afterward. Keep
+        // the task retained until that pause-and-resume cleanup finishes so a
+        // new start cannot race ahead of its late media restoration.
+        isStarting = false
+        state = .idle
+        stopTick()
+        deliveryTarget = nil
+        resetLivePreview()
+        refreshOverlay()
+        lokalbotLog("dictation start cancelled before capture")
+    }
+
+    private func resumePausedMedia(reason: String) async {
+        guard let pausedMediaSession else { return }
+        self.pausedMediaSession = nil
+        await MediaPlaybackController.resume(pausedMediaSession, reason: reason)
+    }
+
+    @discardableResult
+    private func scheduleMediaResume(
+        _ session: MediaPlaybackController.PauseSession,
+        reason: String
+    ) -> Task<Void, Never> {
+        mediaCleanupGeneration += 1
+        let cleanupGeneration = mediaCleanupGeneration
+        let precedingCleanup = mediaCleanupTask
+        let task = Task { [weak self] in
+            if let precedingCleanup { await precedingCleanup.value }
+            await MediaPlaybackController.resume(session, reason: reason)
+            guard let self, self.mediaCleanupGeneration == cleanupGeneration else { return }
+            self.mediaCleanupTask = nil
+        }
+        mediaCleanupTask = task
+        return task
     }
 
     private func completeWithMessage(_ message: String) {
@@ -414,13 +581,16 @@ final class DictationCoordinator: ObservableObject {
         }
     }
 
-    private func stopLivePreview(reset: Bool) {
-        livePreviewTask?.cancel()
+    @discardableResult
+    private func cancelLivePreview(reset: Bool) -> Task<Void, Never>? {
+        let task = livePreviewTask
+        task?.cancel()
         livePreviewTask = nil
         isLivePreviewWorking = false
         if reset {
             resetLivePreview()
         }
+        return task
     }
 
     private func resetLivePreview() {
@@ -434,17 +604,11 @@ final class DictationCoordinator: ObservableObject {
         min(4.0, max(1.4, duration / 8.0))
     }
 
-    private nonisolated static func copyLivePreviewSnapshot(
-        from audioURL: URL,
-        storageRoot: URL
-    ) throws -> URL {
-        let dir = storageRoot.appendingPathComponent("dictation-previews", isDirectory: true)
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let ext = audioURL.pathExtension.isEmpty ? "caf" : audioURL.pathExtension
-        let destination = dir.appendingPathComponent(
-            "\(audioURL.deletingPathExtension().lastPathComponent)-live-\(UUID().uuidString).\(ext)")
-        try FileManager.default.copyItem(at: audioURL, to: destination)
-        return destination
+    nonisolated static let previewScratchDirectoryName = "dictation-previews"
+
+    nonisolated static func sweepOrphanedPreviewFiles(storageRoot: URL) {
+        try? FileManager.default.removeItem(at: storageRoot.appendingPathComponent(
+            previewScratchDirectoryName, isDirectory: true))
     }
 
     private struct IncrementalLivePreviewWindow: Sendable {
@@ -453,9 +617,9 @@ final class DictationCoordinator: ObservableObject {
         let endTime: TimeInterval
     }
 
-    /// Copies the append-only CAF to get a stable header, then materializes only
-    /// the unprocessed suffix plus a short overlap. The full snapshot is deleted
-    /// before returning; the caller owns and removes the much smaller window.
+    /// Opens the append-safe CAF at its current length and materializes only the
+    /// unprocessed suffix plus a short overlap. This keeps preview I/O bounded
+    /// as dictation grows instead of copying the full recording on every pass.
     private static func makeIncrementalLivePreviewWindow(
         from audioURL: URL,
         storageRoot: URL,
@@ -474,10 +638,7 @@ final class DictationCoordinator: ObservableObject {
         storageRoot: URL,
         previousEnd: TimeInterval
     ) throws -> IncrementalLivePreviewWindow {
-        let snapshot = try copyLivePreviewSnapshot(from: audioURL, storageRoot: storageRoot)
-        defer { try? FileManager.default.removeItem(at: snapshot) }
-
-        let reader = try AVAudioFile(forReading: snapshot)
+        let reader = try AVAudioFile(forReading: audioURL)
         let format = reader.processingFormat
         guard format.sampleRate > 0 else { throw DictationError.noAudio }
         let currentEnd = Double(reader.length) / format.sampleRate
@@ -493,8 +654,11 @@ final class DictationCoordinator: ObservableObject {
         let endFrame = reader.length
         guard endFrame > startFrame else { throw DictationError.noAudio }
 
-        let ext = snapshot.pathExtension.isEmpty ? "caf" : snapshot.pathExtension
-        let windowURL = snapshot.deletingLastPathComponent().appendingPathComponent(
+        let scratch = storageRoot.appendingPathComponent(
+            previewScratchDirectoryName, isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        let ext = audioURL.pathExtension.isEmpty ? "caf" : audioURL.pathExtension
+        let windowURL = scratch.appendingPathComponent(
             "dictation-live-window-\(UUID().uuidString).\(ext)")
         var keepWindow = false
         defer {

--- a/LokalBot/Dictation/DictationInputMonitor.swift
+++ b/LokalBot/Dictation/DictationInputMonitor.swift
@@ -57,7 +57,13 @@ final class DictationInputMonitor {
     /// Returns true when the original event should be swallowed.
     fileprivate func handle(type: CGEventType, event: CGEvent) -> Bool {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            // A disabled event tap can swallow the physical key-up. Treat the
+            // disable notification as a fail-safe release before re-enabling,
+            // otherwise push-to-talk may record indefinitely.
+            let shouldStop = shortcutIsDown && triggerModeProvider() == .pushToTalk
+            shortcutIsDown = false
             if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            if shouldStop { onStop?() }
             return false
         }
         guard type == .keyDown || type == .keyUp else { return false }

--- a/LokalBot/Dictation/DictationModels.swift
+++ b/LokalBot/Dictation/DictationModels.swift
@@ -75,6 +75,171 @@ struct DictationLiveTranscript: Equatable, Sendable {
     }
 }
 
+/// The app/field that owned focus when dictation began. Final transcription
+/// may take long enough for focus to move; insertion is allowed only when the
+/// same destination still owns focus, otherwise the text is copied safely.
+struct DictationDeliveryTarget: Equatable, Sendable {
+    let processID: pid_t
+    let bundleID: String?
+    let focusIdentityKey: String?
+
+    func matches(processID currentProcessID: pid_t,
+                 bundleID currentBundleID: String?,
+                 focusIdentityKey currentFocusIdentityKey: String?) -> Bool {
+        guard processID == currentProcessID else { return false }
+        if let bundleID, let currentBundleID, bundleID != currentBundleID { return false }
+        if let focusIdentityKey, !focusIdentityKey.isEmpty {
+            return focusIdentityKey == currentFocusIdentityKey
+        }
+        return true
+    }
+
+    /// A blocked snapshot always wins over the app-only fallback. In
+    /// particular, a target captured before AX exposed a field must never
+    /// become permission to paste into a same-app password field later.
+    func matches(_ snapshot: DictationFocusSnapshot) -> Bool {
+        guard !snapshot.isSecureOrBlocked else { return false }
+        return matches(
+            processID: snapshot.processID,
+            bundleID: snapshot.bundleID,
+            focusIdentityKey: snapshot.focusIdentityKey)
+    }
+
+    static func captured(from snapshot: DictationFocusSnapshot) -> Self? {
+        guard !snapshot.isSecureOrBlocked else { return nil }
+        return Self(
+            processID: snapshot.processID,
+            bundleID: snapshot.bundleID,
+            focusIdentityKey: snapshot.focusIdentityKey)
+    }
+}
+
+/// The minimum Accessibility state needed to bind and later validate a
+/// dictation destination. It intentionally carries no field text or geometry.
+struct DictationFocusSnapshot: Equatable, Sendable {
+    let processID: pid_t
+    let bundleID: String?
+    let focusIdentityKey: String?
+    let isSecureOrBlocked: Bool
+}
+
+struct DictationFocusCaptureResult: Equatable, Sendable {
+    let snapshot: DictationFocusSnapshot?
+    let timedOut: Bool
+
+    static let timeout = Self(snapshot: nil, timedOut: true)
+}
+
+/// Serializes lightweight dictation focus reads on a background queue and
+/// gives every caller one wall-clock deadline. A wedged target app therefore
+/// fails closed without blocking the main actor or accumulating AX workers.
+final class DictationFocusSnapshotExecutor: @unchecked Sendable {
+    typealias Resolver = @Sendable () -> DictationFocusSnapshot?
+
+    static let shared = DictationFocusSnapshotExecutor()
+    static let defaultDeadlineMilliseconds = 120
+
+    private struct Waiter {
+        let id: UInt64
+        let continuation: CheckedContinuation<DictationFocusCaptureResult, Never>
+    }
+
+    private struct Batch {
+        let id: UInt64
+        var waiters: [UInt64: Waiter]
+    }
+
+    private let stateQueue = DispatchQueue(label: "me.dotenv.LokalBot.dictation.ax-snapshot-state")
+    private let workerQueue = DispatchQueue(
+        label: "me.dotenv.LokalBot.dictation.ax-snapshot-worker",
+        qos: .userInitiated)
+    private let deadlineMilliseconds: Int
+    private let resolver: Resolver
+    private var nextIdentifier: UInt64 = 0
+    private var active: Batch?
+    private var pending: Batch?
+
+    init(
+        deadlineMilliseconds: Int = defaultDeadlineMilliseconds,
+        resolver: @escaping Resolver = { CotypingAXHelper.resolveDictationFocusSnapshot() }
+    ) {
+        self.deadlineMilliseconds = max(1, deadlineMilliseconds)
+        self.resolver = resolver
+    }
+
+    func capture() async -> DictationFocusCaptureResult {
+        await withCheckedContinuation { continuation in
+            stateQueue.async { [self] in
+                nextIdentifier &+= 1
+                let waiterID = nextIdentifier
+                let waiter = Waiter(id: waiterID, continuation: continuation)
+                enqueue(waiter)
+                stateQueue.asyncAfter(
+                    deadline: .now() + .milliseconds(deadlineMilliseconds)
+                ) { [weak self] in
+                    self?.expire(waiterID: waiterID)
+                }
+            }
+        }
+    }
+
+    private func enqueue(_ waiter: Waiter) {
+        guard active != nil else {
+            nextIdentifier &+= 1
+            start(Batch(id: nextIdentifier, waiters: [waiter.id: waiter]))
+            return
+        }
+        if var pending {
+            pending.waiters[waiter.id] = waiter
+            self.pending = pending
+        } else {
+            nextIdentifier &+= 1
+            pending = Batch(id: nextIdentifier, waiters: [waiter.id: waiter])
+        }
+    }
+
+    private func start(_ batch: Batch) {
+        active = batch
+        let batchID = batch.id
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            let snapshot = resolver()
+            stateQueue.async { [weak self] in
+                self?.finish(batchID: batchID, snapshot: snapshot)
+            }
+        }
+    }
+
+    private func finish(batchID: UInt64, snapshot: DictationFocusSnapshot?) {
+        guard let completed = active, completed.id == batchID else { return }
+        active = nil
+        let result = DictationFocusCaptureResult(snapshot: snapshot, timedOut: false)
+        for waiter in completed.waiters.values {
+            waiter.continuation.resume(returning: result)
+        }
+        startPendingIfNeeded()
+    }
+
+    private func expire(waiterID: UInt64) {
+        if var active, let waiter = active.waiters.removeValue(forKey: waiterID) {
+            self.active = active
+            waiter.continuation.resume(returning: .timeout)
+            return
+        }
+        if var pending, let waiter = pending.waiters.removeValue(forKey: waiterID) {
+            self.pending = pending.waiters.isEmpty ? nil : pending
+            waiter.continuation.resume(returning: .timeout)
+        }
+    }
+
+    private func startPendingIfNeeded() {
+        guard active == nil, let pending else { return }
+        self.pending = nil
+        guard !pending.waiters.isEmpty else { return }
+        start(pending)
+    }
+}
+
 struct DictationPreviewAudioRange: Equatable, Sendable {
     let start: TimeInterval
     let end: TimeInterval

--- a/LokalBot/Engines/InferenceBroker.swift
+++ b/LokalBot/Engines/InferenceBroker.swift
@@ -23,6 +23,18 @@ actor InferenceBroker {
     private var generations: [InferenceRole: UInt64] = [:]
     private var lingerTasks: [InferenceRole: Task<Void, Never>] = [:]
     private var expiryTasks: [UUID: Task<Void, Never>] = [:]
+    private struct ModelWaiter {
+        let id: UUID
+        let modelPath: String
+        let priority: InferencePriority
+        let order: UInt64
+        let continuation: CheckedContinuation<Void, Error>
+    }
+    private var modelWaiters: [InferenceRole: [ModelWaiter]] = [:]
+    private var nextWaiterOrder: UInt64 = 0
+    /// Claims the role for a model before the first lease record is inserted,
+    /// closing the actor-reentrancy gap between waking a cohort and acquisition.
+    private var selectedModelPaths: [InferenceRole: String] = [:]
 
     init(hooks: [InferenceRole: RuntimeHooks]? = nil,
          lingerSeconds: [InferenceRole: TimeInterval] = [:],
@@ -49,18 +61,35 @@ actor InferenceBroker {
     func lease(_ role: InferenceRole, model: URL, priority: InferencePriority,
                purpose: String,
                expiresAfter ttl: TimeInterval? = nil) async throws -> InferenceLease {
+        let modelPath = Self.canonicalModelPath(model)
+        try await waitUntilCompatible(role: role, modelPath: modelPath, priority: priority)
+        do {
+            try Task.checkCancellation()
+        } catch {
+            releaseModelTurnIfUnused(role)
+            throw error
+        }
         generations[role, default: 0] += 1
         lingerTasks[role]?.cancel()
         lingerTasks[role] = nil
         let expiresAt = ttl.map { Date().addingTimeInterval($0) }
-        let lease = book.acquire(role: role, priority: priority, purpose: purpose,
+        let lease = book.acquire(role: role, modelPath: modelPath,
+                                 priority: priority, purpose: purpose,
                                  expiresAt: expiresAt)
         await pushLeaseState()
         do {
             try await runtimeHooks(for: role).ensure(model)
+            try Task.checkCancellation()
         } catch {
             book.release(id: lease.id)
             await pushLeaseState()
+            if book.activeCount(for: role) == 0 {
+                // ensure may already have started the runtime before the task
+                // was cancelled. Treat rollback like the final release so a
+                // zero-lease server cannot remain resident indefinitely.
+                scheduleLinger(for: role)
+                releaseModelTurnIfUnused(role)
+            }
             throw error
         }
         if let ttl { scheduleExpiry(for: lease, after: ttl) }
@@ -74,6 +103,7 @@ actor InferenceBroker {
         await pushLeaseState()
         if book.activeCount(for: lease.role) == 0 {
             scheduleLinger(for: lease.role)
+            releaseModelTurnIfUnused(lease.role)
         }
     }
 
@@ -95,6 +125,75 @@ actor InferenceBroker {
 
     func activeLeaseCount(_ role: InferenceRole) -> Int {
         book.activeCount(for: role)
+    }
+
+    func activeModelPath(_ role: InferenceRole) -> String? {
+        selectedModelPaths[role]
+    }
+
+    private func waitUntilCompatible(
+        role: InferenceRole,
+        modelPath: String,
+        priority: InferencePriority
+    ) async throws {
+        while let active = selectedModelPaths[role], active != modelPath {
+            let waiterID = UUID()
+            nextWaiterOrder &+= 1
+            let order = nextWaiterOrder
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    guard !Task.isCancelled else {
+                        continuation.resume(throwing: CancellationError())
+                        return
+                    }
+                    modelWaiters[role, default: []].append(ModelWaiter(
+                        id: waiterID,
+                        modelPath: modelPath,
+                        priority: priority,
+                        order: order,
+                        continuation: continuation))
+                }
+            } onCancel: {
+                Task { [weak self] in await self?.cancelWaiter(id: waiterID, role: role) }
+            }
+        }
+        if selectedModelPaths[role] == nil {
+            selectedModelPaths[role] = modelPath
+        }
+    }
+
+    private func cancelWaiter(id: UUID, role: InferenceRole) {
+        guard let index = modelWaiters[role]?.firstIndex(where: { $0.id == id }),
+              let waiter = modelWaiters[role]?.remove(at: index) else { return }
+        waiter.continuation.resume(throwing: CancellationError())
+        if modelWaiters[role]?.isEmpty == true { modelWaiters[role] = nil }
+    }
+
+    /// When a role becomes free, admit one model cohort. All callers waiting
+    /// for those same weights can share the server; different weights remain
+    /// queued until the cohort releases every lease.
+    private func resumeEligibleWaiters(for role: InferenceRole) {
+        guard selectedModelPaths[role] == nil,
+              book.activeCount(for: role) == 0,
+              let waiting = modelWaiters[role], !waiting.isEmpty else { return }
+        let selected = waiting.min {
+            ($0.priority.rawValue, $0.order) < ($1.priority.rawValue, $1.order)
+        }!
+        let admitted = waiting.filter { $0.modelPath == selected.modelPath }
+        selectedModelPaths[role] = selected.modelPath
+        modelWaiters[role] = waiting.filter { $0.modelPath != selected.modelPath }
+        if modelWaiters[role]?.isEmpty == true { modelWaiters[role] = nil }
+        for waiter in admitted { waiter.continuation.resume() }
+    }
+
+    private func releaseModelTurnIfUnused(_ role: InferenceRole) {
+        guard book.activeCount(for: role) == 0 else { return }
+        selectedModelPaths[role] = nil
+        resumeEligibleWaiters(for: role)
+    }
+
+    private nonisolated static func canonicalModelPath(_ url: URL) -> String {
+        url.standardizedFileURL.resolvingSymlinksInPath().path
     }
 
     private func scheduleLinger(for role: InferenceRole) {

--- a/LokalBot/Engines/InferenceLease.swift
+++ b/LokalBot/Engines/InferenceLease.swift
@@ -67,6 +67,9 @@ enum InferenceRole: String, CaseIterable, Sendable {
 struct InferenceLease: Identifiable, Equatable, Sendable {
     let id: UUID
     let role: InferenceRole
+    /// Canonical weights path served for the entire lifetime of this lease.
+    /// Leases on the same role but a different model are queued by the broker.
+    let modelPath: String
     let priority: InferencePriority
     let purpose: String
 }
@@ -82,9 +85,12 @@ struct LeaseBook {
 
     private(set) var records: [Record] = []
 
-    mutating func acquire(role: InferenceRole, priority: InferencePriority,
-                          purpose: String, expiresAt: Date? = nil) -> InferenceLease {
-        let lease = InferenceLease(id: UUID(), role: role, priority: priority, purpose: purpose)
+    mutating func acquire(role: InferenceRole, modelPath: String = "",
+                          priority: InferencePriority, purpose: String,
+                          expiresAt: Date? = nil) -> InferenceLease {
+        let lease = InferenceLease(
+            id: UUID(), role: role, modelPath: modelPath,
+            priority: priority, purpose: purpose)
         records.append(Record(lease: lease, expiresAt: expiresAt))
         return lease
     }
@@ -102,6 +108,10 @@ struct LeaseBook {
 
     func activeCount(for role: InferenceRole) -> Int {
         records.filter { $0.lease.role == role }.count
+    }
+
+    func activeModelPath(for role: InferenceRole) -> String? {
+        records.first { $0.lease.role == role }?.lease.modelPath
     }
 
     /// Residency ids that must never be eviction victims right now.

--- a/LokalBot/Engines/LlamaServer.swift
+++ b/LokalBot/Engines/LlamaServer.swift
@@ -40,8 +40,32 @@ actor LlamaServer {
 
     private var process: Process?
     private var loadedModelPath: String?
+    private var loadedAuthenticationToken: String?
     private var residencyGeneration: UUID?
     private let startup = AsyncSingleFlight()
+
+    /// Shared bearer required by this private localhost server. It is created
+    /// with 256 bits of randomness, stored mode 0600, and can be obtained
+    /// before the lazy server boot so leased engines carry the right header.
+    func authenticationToken() -> String {
+        if let loadedAuthenticationToken { return loadedAuthenticationToken }
+        if let markerToken = readPidMarker()?.authenticationToken {
+            loadedAuthenticationToken = markerToken
+            persistAuthenticationToken(markerToken)
+            return markerToken
+        }
+        if let data = try? Data(contentsOf: authenticationTokenURL),
+           let saved = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           saved.count >= 32 {
+            loadedAuthenticationToken = saved
+            return saved
+        }
+        let created = Self.makeAuthenticationToken()
+        loadedAuthenticationToken = created
+        persistAuthenticationToken(created)
+        return created
+    }
 
     enum ServerError: LocalizedError {
         case binaryMissing
@@ -86,6 +110,7 @@ actor LlamaServer {
         }
         if await healthyServingExpectedConfiguration(modelAt: url) {
             loadedModelPath = url.path
+            loadedAuthenticationToken = readPidMarker()?.authenticationToken
             return
         }
         try await start(modelAt: url)
@@ -139,12 +164,14 @@ actor LlamaServer {
         let binary = try installedBinary()
         if await healthyServingExpectedConfiguration(modelAt: url) {
             loadedModelPath = url.path
+            loadedAuthenticationToken = readPidMarker()?.authenticationToken
             return
         }
         if await healthy() {
             await stopRecordedServerIfOwned(expectedBinary: binary)
             if await healthyServingExpectedConfiguration(modelAt: url) {
                 loadedModelPath = url.path
+                loadedAuthenticationToken = readPidMarker()?.authenticationToken
                 return
             }
         }
@@ -161,47 +188,56 @@ actor LlamaServer {
         // Make room before the subprocess mmaps the weights: evict the
         // least-recently-used other models if this one would bust the budget.
         let nonEvictableBytes = await ModelRuntimeRegistry.shared.totalEstimatedBytes
-        await ModelResidency.shared.willLoad(
+        let loadReservation = await ModelResidency.shared.willLoad(
             id: residencyID,
             bytes: estimatedResidentBytes(modelAt: url),
             reservedBytes: Int64(clamping: nonEvictableBytes))
-        let process = Process()
-        process.executableURL = binary
-        process.arguments = [
-            "-m", url.path,
-            "--host", "127.0.0.1", "--port", String(port),
-            "-c", String(contextTokens),
-            "-ngl", "99",           // full Metal offload
-            "--jinja",              // correct chat templates (qwen3, gpt-oss)
-            "--no-webui",
-        ] + extraArgs
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        process.terminationHandler = { [weak self] process in
-            let processIdentifier = process.processIdentifier
-            Task { await self?.processDidTerminate(processIdentifier) }
-        }
-        try process.run()
-        self.process = process
-        loadedModelPath = url.path
-        writePidMarker(ServerPidMarker(
-            pid: process.processIdentifier,
-            port: port,
-            binaryPath: binary.path,
-            modelPath: url.path,
-            contextTokens: contextTokens,
-            extraArgs: extraArgs))
-
-        // Model load can take a while for the big ones; poll /health.
-        for _ in 0..<240 {
-            try await Task.sleep(for: .milliseconds(500))
-            if !process.isRunning {
-                throw ServerError.failedToStart("llama-server exited during startup")
+        do {
+            let authenticationToken = authenticationToken()
+            let process = Process()
+            process.executableURL = binary
+            process.arguments = [
+                "-m", url.path,
+                "--host", "127.0.0.1", "--port", String(port),
+                "-c", String(contextTokens),
+                "-ngl", "99",           // full Metal offload
+                "--jinja",              // correct chat templates (qwen3, gpt-oss)
+                "--no-webui",
+                "--api-key", authenticationToken,
+            ] + extraArgs
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            process.terminationHandler = { [weak self] process in
+                let processIdentifier = process.processIdentifier
+                Task { await self?.processDidTerminate(processIdentifier) }
             }
-            if await healthy() { return }
+            try process.run()
+            self.process = process
+            loadedModelPath = url.path
+            loadedAuthenticationToken = authenticationToken
+            writePidMarker(LocalLlamaServerMarker(
+                pid: process.processIdentifier,
+                port: port,
+                binaryPath: binary.path,
+                modelPath: url.path,
+                contextTokens: contextTokens,
+                extraArgs: extraArgs,
+                authenticationToken: authenticationToken))
+
+            // Model load can take a while for the big ones; poll /health.
+            for _ in 0..<240 {
+                try await Task.sleep(for: .milliseconds(500))
+                if !process.isRunning {
+                    throw ServerError.failedToStart("llama-server exited during startup")
+                }
+                if await healthy() { return }
+            }
+            throw ServerError.failedToStart("server did not become healthy in time")
+        } catch {
+            await ModelResidency.shared.cancelLoad(loadReservation)
+            await stop()
+            throw error
         }
-        await stop()
-        throw ServerError.failedToStart("server did not become healthy in time")
     }
 
     /// Weight files are not the whole llama footprint: prompt cache, KV, and
@@ -229,6 +265,7 @@ actor LlamaServer {
         let generation = residencyGeneration
         process = nil
         loadedModelPath = nil
+        loadedAuthenticationToken = nil
         residencyGeneration = nil
         if let old {
             removePidMarker(ifMatching: old.processIdentifier)
@@ -263,6 +300,7 @@ actor LlamaServer {
         let generation = residencyGeneration
         process = nil
         loadedModelPath = nil
+        loadedAuthenticationToken = nil
         residencyGeneration = nil
         removePidMarker(ifMatching: processIdentifier)
         if let generation {
@@ -300,18 +338,20 @@ actor LlamaServer {
         removePidMarker(ifMatching: pid)
     }
 
-    private func readPidMarker() -> ServerPidMarker? {
+    private func readPidMarker() -> LocalLlamaServerMarker? {
         guard let data = try? Data(contentsOf: pidMarkerURL) else { return nil }
-        return try? JSONDecoder().decode(ServerPidMarker.self, from: data)
+        return try? JSONDecoder().decode(LocalLlamaServerMarker.self, from: data)
     }
 
-    private func writePidMarker(_ marker: ServerPidMarker) {
+    private func writePidMarker(_ marker: LocalLlamaServerMarker) {
         do {
             try FileManager.default.createDirectory(
                 at: pidMarkerURL.deletingLastPathComponent(),
                 withIntermediateDirectories: true)
             let data = try JSONEncoder().encode(marker)
             try data.write(to: pidMarkerURL, options: .atomic)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600], ofItemAtPath: pidMarkerURL.path)
         } catch {
             // Best-effort orphan recovery only; startup must not depend on it.
         }
@@ -323,11 +363,32 @@ actor LlamaServer {
     }
 
     private var pidMarkerURL: URL {
-        AppDirectories.applicationSupport.appendingPathComponent("llama-server-\(port).pid.json")
+        LocalLlamaServerAuthentication.markerURL(port: port)
+    }
+
+    private var authenticationTokenURL: URL {
+        AppDirectories.applicationSupport
+            .appendingPathComponent("llama-server-\(port).auth-token")
+    }
+
+    private func persistAuthenticationToken(_ token: String) {
+        do {
+            try FileManager.default.createDirectory(
+                at: authenticationTokenURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true)
+            try Data(token.utf8).write(to: authenticationTokenURL, options: .atomic)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600], ofItemAtPath: authenticationTokenURL.path)
+        } catch {
+            lokalbotLog("llama-server: could not persist localhost authentication token")
+        }
     }
 
     private func healthy() async -> Bool {
         var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/health")!)
+        if let token = loadedAuthenticationToken ?? readPidMarker()?.authenticationToken {
+            LocalLlamaServerAuthentication.apply(to: &request, token: token)
+        }
         request.timeoutInterval = 2
         guard let (_, response) = try? await URLSession.shared.data(for: request) else { return false }
         return (response as? HTTPURLResponse)?.statusCode == 200
@@ -335,6 +396,10 @@ actor LlamaServer {
 
     private func healthyServing(modelAt url: URL) async -> Bool {
         var request = URLRequest(url: baseURL.appendingPathComponent("models"))
+        guard let token = loadedAuthenticationToken ?? readPidMarker()?.authenticationToken else {
+            return false
+        }
+        LocalLlamaServerAuthentication.apply(to: &request, token: token)
         request.timeoutInterval = 2
         guard let (data, response) = try? await URLSession.shared.data(for: request),
               (response as? HTTPURLResponse)?.statusCode == 200 else { return false }
@@ -414,13 +479,10 @@ actor LlamaServer {
             .compactMap { pid_t($0) }
     }
 
-    private struct ServerPidMarker: Codable {
-        var pid: pid_t
-        var port: Int
-        var binaryPath: String
-        var modelPath: String
-        var contextTokens: Int?
-        var extraArgs: [String]?
+    private nonisolated static func makeAuthenticationToken() -> String {
+        (UUID().uuidString + UUID().uuidString)
+            .replacingOccurrences(of: "-", with: "")
+            .lowercased()
     }
 
     private struct ModelListPayload: Decodable {

--- a/LokalBot/Engines/ModelCatalog.swift
+++ b/LokalBot/Engines/ModelCatalog.swift
@@ -16,22 +16,52 @@ struct ModelCatalog {
         let fileName: String
         let url: String
         let sha256: String?
+        let sizeBytes: Int64?
         let sizeGB: Double
         let blurb: String
         /// Qwen3 (non-2507) thinks by default; we turn that off for summaries.
         let disablesThinking: Bool
 
         init(id: String, displayName: String, fileName: String, url: String,
-             sha256: String? = nil, sizeGB: Double, blurb: String,
+             sha256: String? = nil, sizeBytes: Int64? = nil,
+             sizeGB: Double, blurb: String,
              disablesThinking: Bool) {
             self.id = id
             self.displayName = displayName
             self.fileName = fileName
             self.url = url
             self.sha256 = sha256
+            self.sizeBytes = sizeBytes
             self.sizeGB = sizeGB
             self.blurb = blurb
             self.disablesThinking = disablesThinking
+        }
+
+        /// Built-ins store the digest directly. Older custom entries carried it
+        /// in the URL fragment, so preserve that migration path as well.
+        var expectedSHA256: String? {
+            if let digest = Self.normalizedSHA256(sha256) { return digest }
+            guard let fragment = URLComponents(string: url)?.fragment,
+                  fragment.hasPrefix("sha256=") else { return nil }
+            return Self.normalizedSHA256(String(fragment.dropFirst("sha256=".count)))
+        }
+
+        /// New entries persist the exact byte count. Entries saved by the
+        /// previous build can recover it from the round-trippable decimal GB
+        /// value that was originally derived from Hugging Face's byte count.
+        var expectedSizeBytes: Int64? {
+            if let sizeBytes, sizeBytes > 0 { return sizeBytes }
+            guard expectedSHA256 != nil, sizeGB > 0, sizeGB.isFinite else { return nil }
+            let recovered = (sizeGB * 1_000_000_000).rounded()
+            guard recovered > 0, recovered <= Double(Int64.max) else { return nil }
+            return Int64(recovered)
+        }
+
+        private static func normalizedSHA256(_ candidate: String?) -> String? {
+            guard let digest = candidate?.lowercased(),
+                  digest.count == 64,
+                  digest.allSatisfy(\.isHexDigit) else { return nil }
+            return digest
         }
     }
 
@@ -61,60 +91,70 @@ struct ModelCatalog {
               fileName: "Qwen3.5-0.8B-Q4_K_M.gguf",
               url: "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q4_K_M.gguf",
               sha256: "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517",
+              sizeBytes: 532_517_120,
               sizeGB: 0.53, blurb: "Tiny downloadable fallback for short meetings and cotyping.",
               disablesThinking: true),
         Entry(id: "lfm2.5-1.2b-instruct", displayName: "LFM2.5 1.2B Instruct",
               fileName: "LFM2.5-1.2B-Instruct-Q4_K_M.gguf",
               url: "https://huggingface.co/unsloth/LFM2.5-1.2B-Instruct-GGUF/resolve/bf1ebe055f24ddd24f3622d933a63b42606773f3/LFM2.5-1.2B-Instruct-Q4_K_M.gguf",
               sha256: "856aeee6d85ac684b1db8dee48795b44fc06731ecda03aee36ece682413a9b9a",
+              sizeBytes: 730_895_584,
               sizeGB: 0.85, blurb: "Fast English-first cotyping mode. Under 1 GB.",
               disablesThinking: false),
         Entry(id: "qwen3.5-2b", displayName: "Qwen3.5 2B",
               fileName: "Qwen3.5-2B-Q4_K_M.gguf",
               url: "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/f6d5376be1edb4d416d56da11e5397a961aca8ae/Qwen3.5-2B-Q4_K_M.gguf",
               sha256: "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223",
+              sizeBytes: 1_280_835_840,
               sizeGB: 1.28, blurb: "Lightweight multilingual cotyping option. Any Apple Silicon Mac.",
               disablesThinking: true),
         Entry(id: "qwen3.5-4b", displayName: "Qwen3.5 4B",
               fileName: "Qwen3.5-4B-Q4_K_M.gguf",
               url: "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/e87f176479d0855a907a41277aca2f8ee7a09523/Qwen3.5-4B-Q4_K_M.gguf",
               sha256: "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4",
+              sizeBytes: 2_740_937_888,
               sizeGB: 2.8, blurb: "Balanced local summaries with long context. 16 GB Macs.",
               disablesThinking: true),
         Entry(id: "gemma4-e4b", displayName: "Gemma 4 E4B",
               fileName: "gemma-4-E4B-it-Q4_K_M.gguf",
               url: "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/0720adb23527c2cd5ea01d1db067cd960327fdac/gemma-4-E4B-it-Q4_K_M.gguf",
               sha256: "519b9793ed6ce0ff530f1b7c96e848e08e49e7af4d57bb97f76215963a54146d",
+              sizeBytes: 4_977_169_568,
               sizeGB: 4.98, blurb: "Legacy edge-optimized option. 16 GB Macs.",
               disablesThinking: false),
         Entry(id: recommendedCotypingID, displayName: "Gemma 4 · E4B",
               fileName: "gemma-4-E4B-it-UD-Q5_K_XL.gguf",
               url: "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/0720adb23527c2cd5ea01d1db067cd960327fdac/gemma-4-E4B-it-UD-Q5_K_XL.gguf",
               sha256: "5fb55145c335edd0c2e0cdd7505ed1557cd346787449479be65094c6f5b016c6",
+              sizeBytes: 6_656_152_736,
               sizeGB: 6.66, blurb: "Recommended cotyping quality target (Q5 XL quant). 16 GB+ Macs.",
               disablesThinking: false),
         Entry(id: "lfm2.5-8b-a1b", displayName: "LFM2.5 8B (MoE)",
               fileName: "LFM2.5-8B-A1B-Q4_K_M.gguf",
               url: "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-GGUF/resolve/dfd5fdcad7a1c0d31473fb4ca443b8befbacddf0/LFM2.5-8B-A1B-Q4_K_M.gguf",
               sha256: "4923ec14f06b968b74d663e5949867d2d9c3bf13a20b8be1a9f9af39989b2bb0",
+              sizeBytes: 5_155_564_768,
               sizeGB: 5.16, blurb: "Fast meeting summaries; ~1B active. 16 GB Macs.",
               disablesThinking: false),
         Entry(id: recommendedSummarizationID, displayName: "Qwen 3.6 · 35B-A3B",
               fileName: "Qwen3.6-35B-A3B-UD-IQ4_XS.gguf",
               url: "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/a483e9e6cbd595906af30beda3187c2663a1118c/Qwen3.6-35B-A3B-UD-IQ4_XS.gguf",
               sha256: "649d7508507b84638732c4f52c24c8b15843c6dca2f3ff793ae07c14a67ebbb3",
+              sizeBytes: 17_730_509_792,
               sizeGB: 17.73, blurb: "Recommended long-meeting default; ~3B active. 32 GB+ Macs.",
               disablesThinking: true),
         Entry(id: "qwen3.6-27b", displayName: "Qwen3.6 27B",
               fileName: "Qwen3.6-27B-Q4_K_M.gguf",
               url: "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/82d411acf4a06cfb8d9b073a5211bf410bfc29bf/Qwen3.6-27B-Q4_K_M.gguf",
               sha256: "5ed60d0af4650a854b1755bd392f9aef4872643dc25a254bc68043fa638392a0",
+              sizeBytes: 16_817_244_384,
               sizeGB: 16.8, blurb: "Maximum-quality dense summaries. Best on 32 GB+ Macs.",
               disablesThinking: true),
         Entry(id: "gemma4-12b", displayName: "Gemma 4 12B",
               fileName: "gemma-4-12b-it-Q4_K_M.gguf",
               url: "https://huggingface.co/unsloth/gemma-4-12B-it-GGUF/resolve/d997c805aafe035a8024f961c6e1afd6b30d79a5/gemma-4-12b-it-Q4_K_M.gguf",
               sha256: "43fec98c5102b1c446b4ddd0a9439f1db3a2e1f2e0b8cd143ce1ea619a9403d6",
+              sizeBytes: 7_121_860_000,
               sizeGB: 7.5, blurb: "Multimodal-family summary option for screenshot/slide workflows.",
               disablesThinking: false),
     ]

--- a/LokalBot/Engines/ModelDownloadManager.swift
+++ b/LokalBot/Engines/ModelDownloadManager.swift
@@ -34,6 +34,7 @@ final class ModelDownloadManager: ObservableObject {
 
     private var tasks: [String: Task<Void, Never>] = [:]
     private var generations: [String: UUID] = [:]
+    private var verificationTasks: [String: (token: UUID, task: Task<URL?, Never>)] = [:]
     private var lastProgressPublish: [String: (fraction: Double, time: TimeInterval)] = [:]
 
     private let session: URLSession
@@ -74,8 +75,66 @@ final class ModelDownloadManager: ObservableObject {
 
     func download(_ entry: ModelCatalog.Entry, storage: StorageManager) {
         download(url: entry.url, fileName: entry.fileName, id: entry.id,
-                 expectedSizeGB: entry.sizeGB, expectedSHA256: entry.sha256,
+                 expectedSizeGB: entry.sizeGB, expectedSHA256: entry.expectedSHA256,
                  storage: storage)
+    }
+
+    /// Resolve an on-disk model only after its pinned digest has been checked.
+    /// Legacy files without a marker are hashed once; the shared verification
+    /// task prevents simultaneous summary, Agent, and cotyping callers from
+    /// hashing the same multi-gigabyte model independently.
+    func verifiedExistingURL(_ entry: ModelCatalog.Entry,
+                             storage: StorageManager) async -> URL? {
+        guard ModelCatalog.localURL(for: entry, storage: storage) != nil else { return nil }
+        guard entry.expectedSHA256 != nil else {
+            return ModelCatalog.localURL(for: entry, storage: storage)
+        }
+        if let running = verificationTasks[entry.id] {
+            return await running.task.value
+        }
+
+        let token = UUID()
+        let task = Task { @MainActor [weak self] () -> URL? in
+            guard let self else { return nil }
+            return await self.verifyExistingUncoalesced(entry, storage: storage)
+        }
+        verificationTasks[entry.id] = (token, task)
+        let result = await task.value
+        if verificationTasks[entry.id]?.token == token {
+            verificationTasks.removeValue(forKey: entry.id)
+        }
+        return result
+    }
+
+    private func verifyExistingUncoalesced(_ entry: ModelCatalog.Entry,
+                                           storage: StorageManager) async -> URL? {
+        guard let existing = ModelCatalog.localURL(for: entry, storage: storage),
+              let expectedSHA256 = entry.expectedSHA256 else { return nil }
+        let isValid: Bool
+        do {
+            if let expectedBytes = entry.expectedSizeBytes {
+                isValid = try await DownloadIntegrity.verifyExisting(
+                    at: existing,
+                    expectedBytes: expectedBytes,
+                    expectedSHA256: expectedSHA256)
+            } else {
+                try Task.checkCancellation()
+                isValid = try await sha256Digest(existing).lowercased() == expectedSHA256
+            }
+        } catch {
+            guard !Task.isCancelled else { return nil }
+            errors[entry.id] = "Could not verify the existing model: \(error.localizedDescription)"
+            return nil
+        }
+        guard !Task.isCancelled else { return nil }
+        guard isValid else {
+            DownloadIntegrity.removeFileAndMarker(at: existing)
+            errors[entry.id] = "The existing model failed its SHA-256 integrity check."
+            objectWillChange.send()
+            return nil
+        }
+        errors[entry.id] = nil
+        return existing
     }
 
     /// Await the same single-flight download used by the Models UI. This keeps
@@ -83,9 +142,10 @@ final class ModelDownloadManager: ObservableObject {
     /// racing a second download and turns preparation failures into actionable
     /// pipeline errors instead of a generic "model missing" response.
     func ensureAvailable(_ entry: ModelCatalog.Entry, storage: StorageManager) async throws -> URL {
-        if let existing = ModelCatalog.localURL(for: entry, storage: storage) {
+        if let existing = await verifiedExistingURL(entry, storage: storage) {
             return existing
         }
+        try Task.checkCancellation()
 
         download(entry, storage: storage)
         while tasks[entry.id] != nil {
@@ -93,7 +153,7 @@ final class ModelDownloadManager: ObservableObject {
             try await Task.sleep(for: .milliseconds(200))
         }
 
-        if let downloaded = ModelCatalog.localURL(for: entry, storage: storage) {
+        if let downloaded = await verifiedExistingURL(entry, storage: storage) {
             return downloaded
         }
         throw PreparationError.failed(
@@ -108,6 +168,7 @@ final class ModelDownloadManager: ObservableObject {
                   expectedSizeGB: Double? = nil, expectedSHA256: String? = nil,
                   storage: StorageManager) {
         guard tasks[id] == nil, let rawURL = URL(string: urlString) else { return }
+        verificationTasks.removeValue(forKey: id)?.task.cancel()
         guard Self.isSafeFileName(fileName) else {
             errors[id] = "The model filename is unsafe. Choose the file again."
             return
@@ -198,6 +259,7 @@ final class ModelDownloadManager: ObservableObject {
 
     func cancel(id: String) {
         tasks[id]?.cancel()
+        verificationTasks.removeValue(forKey: id)?.task.cancel()
         tasks[id] = nil
         generations[id] = nil
         progress[id] = nil
@@ -205,7 +267,8 @@ final class ModelDownloadManager: ObservableObject {
     }
 
     func delete(_ entry: ModelCatalog.Entry, storage: StorageManager) {
-        try? FileManager.default.removeItem(
+        verificationTasks.removeValue(forKey: entry.id)?.task.cancel()
+        DownloadIntegrity.removeFileAndMarker(
             at: storage.rootURL.appendingPathComponent("models/\(entry.fileName)"))
         objectWillChange.send()
     }

--- a/LokalBot/Engines/ModelDownloadManager.swift
+++ b/LokalBot/Engines/ModelDownloadManager.swift
@@ -8,6 +8,15 @@ import Foundation
 @MainActor
 final class ModelDownloadManager: ObservableObject {
 
+    struct ProgressSink: Sendable {
+        let publish: @Sendable (ParallelRangeDownloader.Progress) -> Void
+    }
+
+    typealias StagedDownloader = @Sendable (
+        URL, URLSession, URL, ProgressSink
+    ) async throws -> URL
+    typealias SHA256Digest = @Sendable (URL) async throws -> String
+
     enum PreparationError: LocalizedError {
         case failed(String)
 
@@ -24,9 +33,34 @@ final class ModelDownloadManager: ObservableObject {
     @Published private(set) var errors: [String: String] = [:]
 
     private var tasks: [String: Task<Void, Never>] = [:]
+    private var generations: [String: UUID] = [:]
     private var lastProgressPublish: [String: (fraction: Double, time: TimeInterval)] = [:]
 
-    private let session = URLSession(configuration: {
+    private let session: URLSession
+    private let stagedDownloader: StagedDownloader
+    private let sha256Digest: SHA256Digest
+
+    init(
+        session: URLSession? = nil,
+        stagedDownloader: @escaping StagedDownloader = { url, session, stashDirectory, progress in
+            try await ParallelRangeDownloader.download(
+                from: url,
+                session: session,
+                stashDirectory: stashDirectory,
+                progress: progress.publish)
+        },
+        sha256Digest: @escaping SHA256Digest = { url in
+            try await Task.detached(priority: .utility) {
+                try SHA256Verifier.hexDigest(of: url)
+            }.value
+        }
+    ) {
+        self.session = session ?? Self.makeSession()
+        self.stagedDownloader = stagedDownloader
+        self.sha256Digest = sha256Digest
+    }
+
+    private static func makeSession() -> URLSession {
         let configuration = URLSessionConfiguration.default
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
         configuration.timeoutIntervalForRequest = 60
@@ -35,8 +69,8 @@ final class ModelDownloadManager: ObservableObject {
         configuration.httpMaximumConnectionsPerHost = ParallelRangeDownloader.defaultMaxConcurrentParts
         configuration.networkServiceType = .responsiveData
         configuration.httpShouldSetCookies = false
-        return configuration
-    }())
+        return URLSession(configuration: configuration)
+    }
 
     func download(_ entry: ModelCatalog.Entry, storage: StorageManager) {
         download(url: entry.url, fileName: entry.fileName, id: entry.id,
@@ -73,7 +107,23 @@ final class ModelDownloadManager: ObservableObject {
     func download(url urlString: String, fileName: String, id: String,
                   expectedSizeGB: Double? = nil, expectedSHA256: String? = nil,
                   storage: StorageManager) {
-        guard tasks[id] == nil, let url = URL(string: urlString) else { return }
+        guard tasks[id] == nil, let rawURL = URL(string: urlString) else { return }
+        guard Self.isSafeFileName(fileName) else {
+            errors[id] = "The model filename is unsafe. Choose the file again."
+            return
+        }
+        let embeddedSHA256 = Self.embeddedSHA256(in: rawURL)
+        let requiredSHA256 = expectedSHA256 ?? embeddedSHA256
+        guard let url = Self.networkURL(from: rawURL) else {
+            errors[id] = "The model download URL is invalid."
+            return
+        }
+        if Self.isHuggingFaceURL(url) {
+            guard Self.isPinnedHuggingFaceURL(url), requiredSHA256 != nil else {
+                errors[id] = "For safety, Hugging Face models must use an immutable revision and an advertised SHA-256 digest. Choose the model again from Browse Hugging Face."
+                return
+            }
+        }
         let folder = storage.rootURL.appendingPathComponent("models", isDirectory: true)
         try? FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
         let destination = folder.appendingPathComponent(fileName)
@@ -95,28 +145,51 @@ final class ModelDownloadManager: ObservableObject {
         }
         progress[id] = 0
         errors[id] = nil
+        let generation = UUID()
+        generations[id] = generation
         let session = session
+        let progressHandler: @Sendable (ParallelRangeDownloader.Progress) -> Void = { [weak self] update in
+            Task { @MainActor [weak self] in
+                self?.publishProgress(
+                    id: id, generation: generation,
+                    fraction: update.fractionCompleted)
+            }
+        }
+        let stagedDownloader = stagedDownloader
+        let sha256Digest = sha256Digest
         tasks[id] = Task(priority: .utility) { [weak self] in
+            var stagedURL: URL?
             do {
-                let stashed = try await ParallelRangeDownloader.download(
-                    from: url, session: session, stashDirectory: stashDirectory) { update in
-                    Task { @MainActor [weak self] in
-                        self?.publishProgress(id: id, fraction: update.fractionCompleted)
-                    }
-                }
-                if let expectedSHA256 {
-                    let digest = try await Task.detached(priority: .utility) {
-                        try SHA256Verifier.hexDigest(of: stashed)
-                    }.value
-                    guard digest.lowercased() == expectedSHA256.lowercased() else {
+                let stashed = try await stagedDownloader(
+                    url, session, stashDirectory,
+                    ProgressSink(publish: progressHandler))
+                stagedURL = stashed
+                try Task.checkCancellation()
+                if let requiredSHA256 {
+                    let digest = try await sha256Digest(stashed)
+                    try Task.checkCancellation()
+                    guard digest.lowercased() == requiredSHA256.lowercased() else {
                         DownloadFileRescuer.cleanup(stashed)
                         throw PreparationError.failed(
                             "The downloaded model failed its SHA-256 integrity check.")
                     }
                 }
-                self?.finish(id: id, destination: destination, stashed: stashed)
+                if let self {
+                    self.finish(
+                        id: id, generation: generation,
+                        destination: destination, stashed: stashed,
+                        expectedSHA256: requiredSHA256)
+                } else {
+                    DownloadFileRescuer.cleanup(stashed)
+                }
+                stagedURL = nil
             } catch {
-                self?.fail(id: id, error: error)
+                // ParallelRangeDownloader owns resumable partials until it
+                // returns. Once it hands back a complete staged file, that URL
+                // is non-resumable and this task owns removing it if SHA work
+                // is cancelled or the generation is superseded.
+                if let stagedURL { DownloadFileRescuer.cleanup(stagedURL) }
+                self?.fail(id: id, generation: generation, error: error)
             }
         }
     }
@@ -126,6 +199,7 @@ final class ModelDownloadManager: ObservableObject {
     func cancel(id: String) {
         tasks[id]?.cancel()
         tasks[id] = nil
+        generations[id] = nil
         progress[id] = nil
         lastProgressPublish[id] = nil
     }
@@ -136,9 +210,15 @@ final class ModelDownloadManager: ObservableObject {
         objectWillChange.send()
     }
 
-    private func finish(id: String, destination: URL, stashed: URL) {
+    private func finish(id: String, generation: UUID, destination: URL, stashed: URL,
+                        expectedSHA256: String?) {
+        guard generations[id] == generation else {
+            DownloadFileRescuer.cleanup(stashed)
+            return
+        }
         defer {
             tasks[id] = nil
+            generations[id] = nil
             progress[id] = nil
             lastProgressPublish[id] = nil
         }
@@ -154,22 +234,32 @@ final class ModelDownloadManager: ObservableObject {
 
         do {
             try DownloadFileRescuer.install(stashed: stashed, to: destination)
+            if let expectedSHA256 {
+                try expectedSHA256.lowercased().write(
+                    to: destination.appendingPathExtension("sha256"),
+                    atomically: true,
+                    encoding: .utf8)
+            }
         } catch {
             errors[id] = "Could not save model: \(error.localizedDescription)"
         }
     }
 
-    private func fail(id: String, error: Error) {
+    private func fail(id: String, generation: UUID, error: Error) {
+        guard generations[id] == generation else { return }
         let outcome = DownloadOutcomeClassifier.classify(
             httpStatus: nil, error: error, looksLikeGGUF: false)
         tasks[id] = nil
+        generations[id] = nil
         progress[id] = nil
         lastProgressPublish[id] = nil
         if case .cancelled = outcome { return }
         errors[id] = outcome.userMessage
     }
 
-    private func publishProgress(id: String, fraction: Double, force: Bool = false) {
+    private func publishProgress(id: String, generation: UUID,
+                                 fraction: Double, force: Bool = false) {
+        guard generations[id] == generation else { return }
         let clamped = min(1, max(0, fraction))
         let now = Date().timeIntervalSinceReferenceDate
         if !force, let last = lastProgressPublish[id],
@@ -180,5 +270,42 @@ final class ModelDownloadManager: ObservableObject {
         }
         progress[id] = clamped
         lastProgressPublish[id] = (clamped, now)
+    }
+
+    private static func embeddedSHA256(in url: URL) -> String? {
+        guard let fragment = URLComponents(url: url, resolvingAgainstBaseURL: false)?.fragment,
+              fragment.hasPrefix("sha256=") else { return nil }
+        let digest = String(fragment.dropFirst("sha256=".count)).lowercased()
+        guard digest.count == 64, digest.allSatisfy({ $0.isHexDigit }) else { return nil }
+        return digest
+    }
+
+    private static func networkURL(from url: URL) -> URL? {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        components.fragment = nil
+        return components.url
+    }
+
+    private static func isHuggingFaceURL(_ url: URL) -> Bool {
+        url.scheme?.lowercased() == "https" && url.host?.lowercased() == "huggingface.co"
+    }
+
+    private static func isPinnedHuggingFaceURL(_ url: URL) -> Bool {
+        let components = url.pathComponents
+        guard let resolveIndex = components.firstIndex(of: "resolve"),
+              components.indices.contains(resolveIndex + 1) else { return false }
+        let revision = components[resolveIndex + 1]
+        return revision.count == 40 && revision.allSatisfy({ $0.isHexDigit })
+    }
+
+    private static func isSafeFileName(_ fileName: String) -> Bool {
+        !fileName.isEmpty
+            && fileName.utf8.count <= 255
+            && fileName == (fileName as NSString).lastPathComponent
+            && fileName != "."
+            && fileName != ".."
+            && !fileName.contains("\0")
     }
 }

--- a/LokalBot/Engines/ModelResidency.swift
+++ b/LokalBot/Engines/ModelResidency.swift
@@ -31,6 +31,12 @@ final class ModelResidency: ObservableObject {
         var lastUsed: Date
     }
 
+    struct LoadReservation: Identifiable, Equatable, Sendable {
+        let id: UUID
+        let residencyID: String
+        let bytes: Int64
+    }
+
     @Published private(set) var residents: [Resident] = []
     /// Residency ids currently pinned by open inference leases (pushed by
     /// `InferenceBroker`). Pinned rows are never eviction victims; they still
@@ -45,6 +51,8 @@ final class ModelResidency: ObservableObject {
     /// finishing. Generations keep that stale task from unregistering the
     /// replacement model that now occupies the same logical residency id.
     private var registrationGenerations: [String: UUID] = [:]
+    private var loadReservations: [UUID: LoadReservation] = [:]
+    private var reservationExpiryTasks: [UUID: Task<Void, Never>] = [:]
 
     /// Weights budget: half of physical RAM by default, leaving the other
     /// half for the app, transcription engines, and everything else.
@@ -55,12 +63,16 @@ final class ModelResidency: ObservableObject {
     }
 
     var totalBytes: Int64 { residents.reduce(0) { $0 + $1.bytes } }
+    var pendingLoadBytes: Int64 {
+        loadReservations.values.reduce(0) { Self.saturatingAdd($0, $1.bytes) }
+    }
 
     func register(id: String, label: String, bytes: Int64,
                   processIdentifier: pid_t? = nil,
                   processStartTime: UInt64? = nil,
                   generation: UUID = UUID(),
                   unload: @escaping () async -> Void) {
+        finishReservations(for: id)
         unloaders[id] = unload
         registrationGenerations[id] = generation
         let entry = Resident(
@@ -105,10 +117,20 @@ final class ModelResidency: ObservableObject {
     /// Evict least-recently-used residents (never `id` itself — a model swap
     /// on the same runtime replaces in place) until `bytes` fits the budget.
     /// Call right before loading new weights.
-    func willLoad(id: String, bytes: Int64, reservedBytes: Int64 = 0) async {
+    @discardableResult
+    func willLoad(id: String, bytes: Int64, reservedBytes: Int64 = 0) async
+        -> LoadReservation {
+        let reservation = LoadReservation(
+            id: UUID(), residencyID: id, bytes: max(0, bytes))
+        loadReservations[reservation.id] = reservation
+        scheduleReservationExpiry(reservation.id)
+        let otherPendingBytes = loadReservations.values
+            .filter { $0.id != reservation.id }
+            .reduce(Int64(0)) { Self.saturatingAdd($0, $1.bytes) }
+        let allReservedBytes = Self.saturatingAdd(max(0, reservedBytes), otherPendingBytes)
         let victims = ModelResidencyPolicy.evictions(
             residents: residents.map { .init(id: $0.id, bytes: $0.bytes, lastUsed: $0.lastUsed) },
-            incomingID: id, incomingBytes: bytes, reservedBytes: reservedBytes,
+            incomingID: id, incomingBytes: bytes, reservedBytes: allReservedBytes,
             pinned: pinnedIDs,
             budgetBytes: budgetBytes)
         for victim in victims {
@@ -120,6 +142,39 @@ final class ModelResidency: ObservableObject {
             unregister(id: victim)
             await unload?()
         }
+        return reservation
+    }
+
+    func cancelLoad(_ reservation: LoadReservation) {
+        reservationExpiryTasks[reservation.id]?.cancel()
+        reservationExpiryTasks[reservation.id] = nil
+        loadReservations[reservation.id] = nil
+    }
+
+    private func finishReservations(for residencyID: String) {
+        let ids = loadReservations.values
+            .filter { $0.residencyID == residencyID }
+            .map(\.id)
+        for id in ids {
+            reservationExpiryTasks[id]?.cancel()
+            reservationExpiryTasks[id] = nil
+            loadReservations[id] = nil
+        }
+    }
+
+    private func scheduleReservationExpiry(_ id: UUID) {
+        reservationExpiryTasks[id]?.cancel()
+        reservationExpiryTasks[id] = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(300))
+            guard !Task.isCancelled else { return }
+            self?.loadReservations[id] = nil
+            self?.reservationExpiryTasks[id] = nil
+        }
+    }
+
+    private static func saturatingAdd(_ lhs: Int64, _ rhs: Int64) -> Int64 {
+        let result = lhs.addingReportingOverflow(rhs)
+        return result.overflow ? .max : result.partialValue
     }
 
     /// File size of the weights at `url` (0 if unreadable) — the bytes every

--- a/LokalBot/Engines/OnnxTranscriptionEngine.swift
+++ b/LokalBot/Engines/OnnxTranscriptionEngine.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Darwin
 import FluidAudio
 import Foundation
 
@@ -186,44 +187,60 @@ actor OnnxTranscriptionEngine: TranscriptionEngine {
 
         let binary = runtime.binary
         let libDir = runtime.libDir
-        let stdout = try await Task.detached(priority: .userInitiated) { () throws -> String in
+        let processController = ONNXProcessController()
+        let execution = Task.detached(priority: .userInitiated) { () throws -> String in
             let runtimeID = "transcription:onnx:\(model.modelType):\(UUID().uuidString)"
             let estimatedBytes = ModelRuntimeRegistry.fileBytes(at: modelFile)
             await ModelRuntimeRegistry.shared.reserve(
                 id: runtimeID, role: "Transcription", label: model.displayName,
                 estimatedBytes: estimatedBytes)
-            let process = Process()
-            process.executableURL = binary
-            process.arguments = args
-            var env = ProcessInfo.processInfo.environment
-            env["DYLD_LIBRARY_PATH"] = libDir.path
-            process.environment = env
-            let out = Pipe()
-            process.standardOutput = out
-            process.standardError = FileHandle.nullDevice   // verbose logging — discard
             do {
+                // Cancellation can arrive while the MainActor reservation call
+                // is suspended. Keep every subsequent exit inside this cleanup
+                // scope so a helper that never attaches cannot strand a row.
+                try Task.checkCancellation()
+                let process = Process()
+                process.executableURL = binary
+                process.arguments = args
+                var env = ProcessInfo.processInfo.environment
+                env["DYLD_LIBRARY_PATH"] = libDir.path
+                process.environment = env
+                let out = Pipe()
+                process.standardOutput = out
+                process.standardError = FileHandle.nullDevice   // verbose logging — discard
+                guard processController.attach(process) else { throw CancellationError() }
+                defer { processController.detach(process) }
                 try process.run()
+                processController.processDidStart(process)
+                let processUsage = SystemResourceSampler.processUsage(for: process.processIdentifier)
+                await ModelRuntimeRegistry.shared.register(
+                    id: runtimeID,
+                    role: "Transcription",
+                    label: model.displayName,
+                    estimatedBytes: estimatedBytes,
+                    processIdentifier: processUsage?.processIdentifier,
+                    processStartTime: processUsage?.startTime
+                )
+                let data = out.fileHandleForReading.readDataToEndOfFile()
+                process.waitUntilExit()
+                try Task.checkCancellation()
+                if processController.wasCancelled { throw CancellationError() }
+                guard process.terminationStatus == 0 else {
+                    throw EngineError.transcriptionFailed(Int(process.terminationStatus))
+                }
+                await ModelRuntimeRegistry.shared.unregister(id: runtimeID)
+                return String(decoding: data, as: UTF8.self)
             } catch {
                 await ModelRuntimeRegistry.shared.unregister(id: runtimeID)
                 throw error
             }
-            let processUsage = SystemResourceSampler.processUsage(for: process.processIdentifier)
-            await ModelRuntimeRegistry.shared.register(
-                id: runtimeID,
-                role: "Transcription",
-                label: model.displayName,
-                estimatedBytes: estimatedBytes,
-                processIdentifier: processUsage?.processIdentifier,
-                processStartTime: processUsage?.startTime
-            )
-            let data = out.fileHandleForReading.readDataToEndOfFile()
-            process.waitUntilExit()
-            await ModelRuntimeRegistry.shared.unregister(id: runtimeID)
-            guard process.terminationStatus == 0 else {
-                throw EngineError.transcriptionFailed(Int(process.terminationStatus))
-            }
-            return String(decoding: data, as: UTF8.self)
-        }.value
+        }
+        let stdout = try await withTaskCancellationHandler {
+            try await execution.value
+        } onCancel: {
+            execution.cancel()
+            processController.cancel()
+        }
         return Self.parseTexts(stdout)
     }
 
@@ -286,5 +303,79 @@ actor OnnxTranscriptionEngine: TranscriptionEngine {
             case .transcriptionFailed(let code): "sherpa-onnx-offline exited with code \(code)."
             }
         }
+    }
+}
+
+/// Bridges structured Swift cancellation to the blocking sherpa subprocess.
+/// Cancellation sends SIGTERM immediately and escalates to SIGKILL only if the
+/// helper ignores it, guaranteeing that `readDataToEndOfFile` eventually
+/// unblocks and model memory is released.
+private final class ONNXProcessController: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+    private var cancelled = false
+
+    var wasCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func attach(_ process: Process) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !cancelled else { return false }
+        self.process = process
+        return true
+    }
+
+    func processDidStart(_ process: Process) {
+        lock.lock()
+        let shouldTerminate = cancelled && self.process === process
+        lock.unlock()
+        if shouldTerminate, process.isRunning { terminate(process) }
+    }
+
+    func detach(_ process: Process) {
+        lock.lock()
+        if self.process === process { self.process = nil }
+        lock.unlock()
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        let process = self.process
+        lock.unlock()
+        guard let process, process.isRunning else { return }
+        terminate(process)
+    }
+
+    private func terminate(_ process: Process) {
+        let pid = process.processIdentifier
+        let processStartTime = SystemResourceSampler.processUsage(for: pid)?.startTime
+        process.terminate()
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 2) { [weak self, weak process] in
+            guard let self, let process else { return }
+            self.killIfStillAttached(
+                process, pid: pid, expectedStartTime: processStartTime)
+        }
+    }
+
+    private func killIfStillAttached(
+        _ process: Process,
+        pid: pid_t,
+        expectedStartTime: UInt64?
+    ) {
+        lock.lock()
+        let isSameCancelledProcess = cancelled && self.process === process
+        lock.unlock()
+        guard isSameCancelledProcess,
+              process.isRunning,
+              process.processIdentifier == pid,
+              let expectedStartTime,
+              SystemResourceSampler.processUsage(for: pid)?.startTime == expectedStartTime
+        else { return }
+        kill(pid, SIGKILL)
     }
 }

--- a/LokalBot/Engines/ParallelRangeDownloader.swift
+++ b/LokalBot/Engines/ParallelRangeDownloader.swift
@@ -28,7 +28,17 @@ enum ParallelRangeDownloader {
         let url: String
         let totalBytes: Int64
         let partSize: Int64
+        let validator: String?
         var completedParts: [Int]
+
+        init(url: String, totalBytes: Int64, partSize: Int64,
+             validator: String? = nil, completedParts: [Int]) {
+            self.url = url
+            self.totalBytes = totalBytes
+            self.partSize = partSize
+            self.validator = validator
+            self.completedParts = completedParts
+        }
     }
     struct Progress: Sendable {
         let bytesWritten: Int64
@@ -180,6 +190,8 @@ enum ParallelRangeDownloader {
            state.url == url.absoluteString,
            state.totalBytes == probe.totalBytes,
            state.partSize == partSize,
+           probe.validator != nil,
+           state.validator == probe.validator,
            fileManager.fileExists(atPath: assembled.path) {
             completed = Set(state.completedParts).intersection(byteRanges.map(\.index))
         } else {
@@ -193,7 +205,8 @@ enum ParallelRangeDownloader {
         defer { try? output.close() }
 
         var state = ResumeState(url: url.absoluteString, totalBytes: probe.totalBytes,
-                                partSize: partSize, completedParts: completed.sorted())
+                                partSize: partSize, validator: probe.validator,
+                                completedParts: completed.sorted())
         try await downloadParts(
             byteRanges,
             skipping: completed,
@@ -225,10 +238,9 @@ enum ParallelRangeDownloader {
         return assembled
     }
 
-    /// Single streamed GET for servers without byte-range support (or files
-    /// below the acceleration threshold). Still reports progress — unlike a
-    /// bare `URLSession.download(from:)` — so a 1.5 GB fallback download never
-    /// looks frozen in the UI.
+    /// Single download-task GET for servers without byte-range support (or
+    /// files below the acceleration threshold). URLSession streams directly
+    /// to disk instead of iterating every byte in Swift.
     private static func downloadWhole(
         from url: URL,
         session: URLSession,
@@ -240,52 +252,35 @@ enum ParallelRangeDownloader {
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.setValue(AppIdentifiers.bundleID, forHTTPHeaderField: "User-Agent")
 
-        let (bytes, response) = try await session.bytes(for: request)
+        progress(.init(bytesWritten: 0, totalBytes: -1))
+        let (temporary, response) = try await session.download(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw DownloadError.invalidResponse
         }
         guard (200..<300).contains(http.statusCode) else {
             throw DownloadError.httpStatus(http.statusCode)
         }
-        let totalBytes = parseContentLength(http)
+        let expectedBytes = parseContentLength(http)
+        let actualBytes = fileSize(temporary)
+        if expectedBytes > 0, actualBytes != expectedBytes {
+            try? FileManager.default.removeItem(at: temporary)
+            throw DownloadError.assemblySizeMismatch(
+                expected: expectedBytes, actual: actualBytes)
+        }
 
         let fileManager = FileManager.default
         let destination = fileManager.temporaryDirectory
             .appendingPathComponent("LokalBot-download-\(UUID().uuidString)", isDirectory: false)
-        _ = fileManager.createFile(atPath: destination.path, contents: nil)
-        let output = try FileHandle(forWritingTo: destination)
-
-        var success = false
-        defer {
-            try? output.close()
-            if !success { try? fileManager.removeItem(at: destination) }
-        }
-
-        var written: Int64 = 0
-        var buffer = Data()
-        buffer.reserveCapacity(8 * 1024 * 1024)
-        progress(.init(bytesWritten: 0, totalBytes: totalBytes))
-        for try await byte in bytes {
-            buffer.append(byte)
-            if buffer.count >= 8 * 1024 * 1024 {
-                try output.write(contentsOf: buffer)
-                written += Int64(buffer.count)
-                buffer.removeAll(keepingCapacity: true)
-                progress(.init(bytesWritten: written, totalBytes: totalBytes))
-            }
-        }
-        if !buffer.isEmpty {
-            try output.write(contentsOf: buffer)
-            written += Int64(buffer.count)
-        }
-        progress(.init(bytesWritten: written, totalBytes: max(totalBytes, written)))
-        success = true
+        try? fileManager.removeItem(at: destination)
+        try fileManager.moveItem(at: temporary, to: destination)
+        progress(.init(bytesWritten: actualBytes, totalBytes: max(expectedBytes, actualBytes)))
         return destination
     }
 
     private struct Probe: Sendable {
         let totalBytes: Int64
         let supportsByteRanges: Bool
+        let validator: String?
     }
 
     private struct PartResult: Sendable {
@@ -315,7 +310,14 @@ enum ParallelRangeDownloader {
         guard totalBytes > 0 else { throw FallbackRequired.unsupported }
         let supportsByteRanges = http.value(forHTTPHeaderField: "Accept-Ranges")?
             .localizedCaseInsensitiveContains("bytes") == true
-        return Probe(totalBytes: totalBytes, supportsByteRanges: supportsByteRanges)
+        let validator = http.value(forHTTPHeaderField: "X-Linked-Etag")
+            ?? http.value(forHTTPHeaderField: "ETag")
+            ?? http.value(forHTTPHeaderField: "X-Repo-Commit")
+            ?? http.value(forHTTPHeaderField: "Last-Modified")
+        return Probe(
+            totalBytes: totalBytes,
+            supportsByteRanges: supportsByteRanges,
+            validator: validator)
     }
 
     private static func parseContentLength(_ response: HTTPURLResponse) -> Int64 {
@@ -359,7 +361,9 @@ enum ParallelRangeDownloader {
                 guard let range = iterator.next() else { return }
                 active += 1
                 group.addTask {
-                    try await downloadPart(range, from: url, into: workDir, session: session)
+                    try await downloadPart(
+                        range, totalBytes: totalBytes,
+                        from: url, into: workDir, session: session)
                 }
             }
 
@@ -389,6 +393,7 @@ enum ParallelRangeDownloader {
 
     private static func downloadPart(
         _ range: ByteRange,
+        totalBytes: Int64,
         from url: URL,
         into workDir: URL,
         session: URLSession
@@ -408,6 +413,13 @@ enum ParallelRangeDownloader {
         guard http.statusCode == 206 else {
             throw DownloadError.unexpectedRangeStatus(http.statusCode)
         }
+        guard contentRangeMatches(
+            http.value(forHTTPHeaderField: "Content-Range"),
+            range: range,
+            totalBytes: totalBytes) else {
+            try? FileManager.default.removeItem(at: temporary)
+            throw DownloadError.invalidResponse
+        }
 
         let size = fileSize(temporary)
         guard size == range.length else {
@@ -419,6 +431,13 @@ enum ParallelRangeDownloader {
         try? FileManager.default.removeItem(at: destination)
         try FileManager.default.moveItem(at: temporary, to: destination)
         return .init(range: range, url: destination)
+    }
+
+    private static func contentRangeMatches(
+        _ header: String?, range: ByteRange, totalBytes: Int64
+    ) -> Bool {
+        guard let header else { return false }
+        return header.lowercased() == "bytes \(range.start)-\(range.end)/\(totalBytes)"
     }
 
     private static func copyFile(_ inputURL: URL, to output: FileHandle, atOffset offset: Int64) throws {

--- a/LokalBot/HeadlessCommands.swift
+++ b/LokalBot/HeadlessCommands.swift
@@ -193,7 +193,8 @@ struct HeadlessCommandRunner {
     }
 
     /// `LokalBot --agent "<prompt>"`: one Agent Mode turn against the real
-    /// runtime + Main LLM engine, auto-approved, printing each transcript
+    /// runtime + Main LLM engine, auto-approving file changes and declining
+    /// privacy-sensitive shell/external-read requests, then printing each transcript
     /// item. Exit 0 ok / 3 skip (runtime not installed) / 1 fail. Test hook
     /// for Agent Mode, same spirit as --chat.
     private func runAgent(prompt: String) {
@@ -216,9 +217,11 @@ struct HeadlessCommandRunner {
             // THEN wait for it to leave .running. Otherwise the settle loop
             // exits before any work happened.
             for _ in 0..<100 where controller.state != .running {   // 10s to start
+                await controller.denyAllPendingApprovals()
                 try? await Task.sleep(for: .milliseconds(100))
             }
             for _ in 0..<600 where controller.state == .running {   // 60s to settle
+                await controller.denyAllPendingApprovals()
                 try? await Task.sleep(for: .milliseconds(100))
             }
             for item in controller.items {
@@ -226,7 +229,7 @@ struct HeadlessCommandRunner {
                 case .user(_, let text): print("LokalBot --agent: > \(text)")
                 case .assistant(_, let text, _): print("LokalBot --agent: \(text)")
                 case .tool(_, let name, _, _, let status): print("LokalBot --agent: tool \(name) [\(status)]")
-                case .approval: break   // auto-approve means none surface
+                case .approval: break   // handled by the unattended-run policy above
                 case .notice(_, let text, let isError): print("LokalBot --agent: \(isError ? "ERROR" : "note") \(text)")
                 }
             }

--- a/LokalBot/Info.plist
+++ b/LokalBot/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.0</string>
+	<string>0.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/LokalBot/LokalBotApp.swift
+++ b/LokalBot/LokalBotApp.swift
@@ -105,6 +105,103 @@ struct LokalBotApp: App {
     }
 }
 
+/// One long-lived utility worker owns the background FTS connection. A
+/// dictionary keeps only the latest pending snapshot for each meeting, while
+/// the actor serializes SQLite writes across the entire queue.
+actor SearchIndexWorkQueue {
+    private let databaseURL: URL
+    private let rootURL: URL
+    private var index: SearchIndex?
+    private var storage: StorageManager?
+    private var pending: [Meeting.ID: Meeting] = [:]
+    private var deleted: Set<Meeting.ID> = []
+    private var drainTask: Task<Void, Never>?
+    private var stopped = false
+
+    init(databaseURL: URL, rootURL: URL) {
+        self.databaseURL = databaseURL
+        self.rootURL = rootURL
+    }
+
+    func enqueue(_ meeting: Meeting) {
+        enqueue([meeting])
+    }
+
+    func enqueue(_ meetings: [Meeting]) {
+        guard !stopped else { return }
+        for meeting in meetings where !deleted.contains(meeting.id) {
+            pending[meeting.id] = meeting
+        }
+        startDrainIfNeeded()
+    }
+
+    @discardableResult
+    func remove(_ meetingID: Meeting.ID) -> (search: Bool, embedding: Bool) {
+        deleted.insert(meetingID)
+        pending.removeValue(forKey: meetingID)
+        let searchClean = searchIndex.remove(meetingID)
+        let embeddingClean = EmbeddingIndex.remove(
+            meetingID, databaseURL: databaseURL)
+        return (searchClean, embeddingClean)
+    }
+
+    @discardableResult
+    func reconcileDeletedMeetings() -> (search: Bool, embedding: Bool) {
+        let searchClean = searchIndex.reconcileDeletedMeetings()
+        let embeddingClean = EmbeddingIndex.reconcileDeletedMeetings(
+            databaseURL: databaseURL)
+        return (searchClean, embeddingClean)
+    }
+
+    func stop() {
+        stopped = true
+        pending.removeAll()
+        drainTask?.cancel()
+        drainTask = nil
+    }
+
+    /// Test/diagnostic seam: wait for the currently scheduled drain and any
+    /// follow-up work that arrived while it yielded between meetings.
+    func waitUntilIdle() async {
+        while let drainTask {
+            await drainTask.value
+        }
+    }
+
+    private var searchIndex: SearchIndex {
+        if let index { return index }
+        let created = SearchIndex(databaseURL: databaseURL)
+        index = created
+        return created
+    }
+
+    private var workerStorage: StorageManager {
+        if let storage { return storage }
+        let created = StorageManager(rootURL: rootURL)
+        storage = created
+        return created
+    }
+
+    private func startDrainIfNeeded() {
+        guard drainTask == nil, !pending.isEmpty, !stopped else { return }
+        drainTask = Task(priority: .utility) { [weak self] in
+            await self?.drain()
+        }
+    }
+
+    private func drain() async {
+        while !Task.isCancelled, !stopped, let (meetingID, meeting) = pending.first {
+            pending.removeValue(forKey: meetingID)
+            searchIndex.reindex(meeting, storage: workerStorage)
+            // Let enqueues, deletions, and shutdown coalesce or cancel work
+            // between meetings without allowing concurrent SQLite writers.
+            await Task.yield()
+        }
+        drainTask = nil
+        startDrainIfNeeded()
+    }
+}
+
 /// Central app state (the "coordinator" from the design doc §6): dependency
 /// wiring, the meeting library, navigation, and the detection→recording glue.
 /// The recording lifecycle itself lives in `RecordingController`; headless
@@ -176,6 +273,10 @@ final class AppState: ObservableObject {
     /// Sparkle, periodic screenshots) so the UI renders against synthetic
     /// data without touching real audio, TCC, or the network.
     nonisolated static var isUITesting: Bool { UITestRuntime.isEnabled }
+    /// Hosted XCTest executes the real app entry point. It needs neither UI
+    /// fixtures nor any interactive service, so return before touching the
+    /// meeting library, indexes, permissions, audio, Sparkle, or the network.
+    nonisolated static var isUnitTesting: Bool { UITestRuntime.isUnitTesting }
 
     /// UserDefaults flag: the permission onboarding has been shown once. Also
     /// read by `AppDelegate` to keep the first run windowed.
@@ -192,16 +293,47 @@ final class AppState: ObservableObject {
     /// subsystems that apply settings live.
     @Published var settings: AppSettings {
         didSet {
+            guard settings != oldValue else { return }
             settingsStore.current = settings
-            detector.stopDebounce = settings.stopDebounceSeconds
-            detector.calendarEnabled = settings.calendarDetectionEnabled
-            detector.requireCalendarForBrowser = settings.requireCalendarForBrowser
+            if settings.stopDebounceSeconds != oldValue.stopDebounceSeconds {
+                detector.stopDebounce = settings.stopDebounceSeconds
+            }
+            if settings.calendarDetectionEnabled != oldValue.calendarDetectionEnabled {
+                detector.calendarEnabled = settings.calendarDetectionEnabled
+            }
+            if settings.requireCalendarForBrowser != oldValue.requireCalendarForBrowser {
+                detector.requireCalendarForBrowser = settings.requireCalendarForBrowser
+            }
             if interactive {
-                dictation.applySettings()
-                cotyping.applySettings()
-                if settings.cotypingEnabled { Task { await cotypingEngine.prewarm() } }
+                if Self.dictationLifecycleChanged(from: oldValue, to: settings) {
+                    dictation.applySettings()
+                }
+                if settings.cotypingEnabled != oldValue.cotypingEnabled {
+                    cotyping.applySettings()
+                    if !settings.cotypingEnabled {
+                        cotypingPrewarmTask?.cancel()
+                        cotypingPrewarmTask = nil
+                    }
+                }
+                if Self.cotypingRuntimeChanged(from: oldValue, to: settings) {
+                    scheduleCotypingPrewarm()
+                }
             }
         }
+    }
+
+    private static func dictationLifecycleChanged(from old: AppSettings, to new: AppSettings) -> Bool {
+        old.dictationEnabled != new.dictationEnabled
+            || old.dictationShowOverlay != new.dictationShowOverlay
+            || old.dictationLivePreview != new.dictationLivePreview
+    }
+
+    private static func cotypingRuntimeChanged(from old: AppSettings, to new: AppSettings) -> Bool {
+        guard new.cotypingEnabled else { return false }
+        return !old.cotypingEnabled
+            || old.cotypingBuiltInModelID != new.cotypingBuiltInModelID
+            || old.cotypingInProcessRuntime != new.cotypingInProcessRuntime
+            || old.customBuiltInModels != new.customBuiltInModels
     }
 
     // Navigation (main window): sidebar section, selected meeting, and a
@@ -270,14 +402,28 @@ final class AppState: ObservableObject {
     /// recordings. Concrete type so the settings UI observes its permission
     /// state; handed to the detector as the `CalendarEventProviding` seam.
     let calendar = EventKitCalendarEventProvider()
-    private(set) lazy var searchIndex = SearchIndex(
-        databaseURL: storage.rootURL.appendingPathComponent("lokalbotv3.sqlite"))
+    private var cachedSearchIndex: SearchIndex?
+    var searchIndex: SearchIndex {
+        if let cachedSearchIndex { return cachedSearchIndex }
+        let created = SearchIndex(
+            databaseURL: storage.rootURL.appendingPathComponent("lokalbotv3.sqlite"))
+        for meetingID in deletedMeetingIDs { created.noteDeletion(meetingID) }
+        cachedSearchIndex = created
+        return created
+    }
     private(set) lazy var activityStore = ActivityStore(
         databaseURL: storage.rootURL.appendingPathComponent("lokalbotv3.sqlite"))
     private(set) lazy var sampler = ActivitySampler(store: activityStore)
-    private(set) lazy var embeddingIndex = EmbeddingIndex(
-        databaseURL: storage.rootURL.appendingPathComponent("lokalbotv3.sqlite"),
-        storage: storage)
+    private var cachedEmbeddingIndex: EmbeddingIndex?
+    var embeddingIndex: EmbeddingIndex {
+        if let cachedEmbeddingIndex { return cachedEmbeddingIndex }
+        let created = EmbeddingIndex(
+            databaseURL: storage.rootURL.appendingPathComponent("lokalbotv3.sqlite"),
+            storage: storage)
+        for meetingID in deletedMeetingIDs { created.noteDeletion(meetingID) }
+        cachedEmbeddingIndex = created
+        return created
+    }
     private(set) lazy var screenshots = ScreenshotService(
         store: activityStore, storage: storage, sampler: sampler,
         isMeetingRecordingActive: { [weak self] in
@@ -392,6 +538,16 @@ final class AppState: ObservableObject {
     /// gates recording notifications and first-run onboarding.
     private var interactive = false
     private var terminationCleanupTask: Task<Void, Never>?
+    private var cotypingPrewarmTask: Task<Void, Never>?
+    private var libraryLoadTask: Task<Void, Never>?
+    private var embeddingIndexTasks: [Meeting.ID: (token: UUID, task: Task<Void, Never>)] = [:]
+    private var indexCleanupTasks: [Meeting.ID: (token: UUID, task: Task<Void, Never>)] = [:]
+    private var deletedMeetingIDs: Set<Meeting.ID> = []
+    private var libraryReady = false
+    private var pendingRecordingStart: (context: MeetingDetectionContext?, source: String)?
+    private lazy var searchIndexWorkQueue = SearchIndexWorkQueue(
+        databaseURL: storage.rootURL.appendingPathComponent("lokalbotv3.sqlite"),
+        rootURL: storage.rootURL)
 
     // Recording facades — views observe AppState only.
     var isRecording: Bool { recording.isRecording }
@@ -400,10 +556,19 @@ final class AppState: ObservableObject {
     var menuBarTimer: String { recording.menuBarTimer }
 
     func startRecording(context: MeetingDetectionContext? = nil, source: String = "ui") {
+        guard libraryReady else {
+            pendingRecordingStart = (context, source)
+            lastError = "Preparing your meeting library; recording will start when it is ready."
+            return
+        }
         recording.start(context: context, source: source)
     }
 
     func stopRecording(process: Bool = true) {
+        if !libraryReady {
+            pendingRecordingStart = nil
+            return
+        }
         recording.stop(process: process)
     }
 
@@ -434,18 +599,13 @@ final class AppState: ObservableObject {
     init() {
         AppLog.bootstrap()
         settings = settingsStore.current
-        var loaded = storage.loadMeetings()
-        // One-time backfill: meetings recorded before `recordedDuration` existed
-        // would otherwise show the wall-clock span (which can exceed the captured
-        // audio). Measure the actual playable length once and persist it.
-        for i in loaded.indices where loaded[i].recordedDuration == nil && loaded[i].endedAt != nil {
-            let folder = loaded[i].folderURL(in: storage)
-            if let recorded = MeetingAudioFiles.longestDuration(in: folder) {
-                loaded[i].recordedDuration = recorded
-                try? storage.saveMeta(loaded[i])
-            }
+        if Self.isUnitTesting { return }
+        let headlessCommand = HeadlessCommand.requested
+        let needsSynchronousLibrary = headlessCommand != nil || Self.isUITesting
+        if needsSynchronousLibrary {
+            meetings = storage.loadMeetings()
+            libraryReady = true
         }
-        meetings = loaded
         LiveMeetingTranscriber.sweepOrphanedSnapshots(storageRoot: storage.rootURL)
         // Views observe AppState only; forward pipeline / recording /
         // audio-monitor / calendar change notifications so MainWindowView
@@ -483,13 +643,15 @@ final class AppState: ObservableObject {
         }
         pipeline.onArtifactsWritten = { [weak self] meeting in
             guard let self else { return }
-            self.searchIndex.reindex(meeting, storage: self.storage)
+            self.reindexSearchInBackground(meeting)
             if self.settings.semanticSearchEnabled {
-                Task { try? await self.embeddingIndex.index(meeting) }
+                self.reindexEmbeddingInBackground(meeting)
             }
         }
-        searchIndex.reindexAll(meetings, storage: storage)
-        if let command = HeadlessCommand.requested {
+        if needsSynchronousLibrary {
+            searchIndex.reindexAll(meetings, storage: storage)
+        }
+        if let command = headlessCommand {
             HeadlessCommandRunner(app: self).run(command)
             return
         }
@@ -502,7 +664,6 @@ final class AppState: ObservableObject {
         applyTrackingSetting()
         // Crash recovery: re-enqueue any meeting whose processing never
         // finished — a quit or crash mid-transcription used to lose the job.
-        pipeline.resumePending(meetings: meetings)
         detector.onMeetingStarted = { [weak self] context in
             guard let self else { return }
             switch self.settings.autoRecordMode {
@@ -550,7 +711,114 @@ final class AppState: ObservableObject {
         // and the grants are in place; otherwise it parks itself.
         dictation.applySettings()
         cotyping.applySettings()
-        if settings.cotypingEnabled { Task { await cotypingEngine.prewarm() } }
+        if settings.cotypingEnabled { scheduleCotypingPrewarm() }
+        loadLibraryInBackground()
+    }
+
+    /// Large meeting libraries can take seconds to enumerate, repair, duration-
+    /// probe, and FTS-index. Do that work on a utility executor and publish one
+    /// sorted snapshot when ready instead of blocking the first app window.
+    private func loadLibraryInBackground() {
+        libraryLoadTask?.cancel()
+        let rootURL = storage.rootURL
+        libraryLoadTask = Task { @MainActor [weak self] in
+            let worker = Task.detached(priority: .utility) {
+                guard !Task.isCancelled else { return [Meeting]() }
+                let workerStorage = StorageManager(rootURL: rootURL)
+                return workerStorage.loadMeetings()
+            }
+            let loaded = await withTaskCancellationHandler {
+                await worker.value
+            } onCancel: {
+                worker.cancel()
+            }
+            guard let self, !Task.isCancelled else { return }
+
+            var byID = Dictionary(uniqueKeysWithValues: loaded.map { ($0.id, $0) })
+            // Preserve meetings created while the background scan was running.
+            for meeting in self.meetings { byID[meeting.id] = meeting }
+            let merged = byID.values.sorted { $0.startedAt > $1.startedAt }
+            self.meetings = merged
+            self.libraryReady = true
+            self.pipeline.resumePending(meetings: merged)
+            self.reindexLibraryInBackground(merged)
+            self.libraryLoadTask = nil
+            if let pending = self.pendingRecordingStart {
+                self.pendingRecordingStart = nil
+                self.lastError = nil
+                self.recording.start(context: pending.context, source: pending.source)
+            }
+        }
+    }
+
+    private func reindexLibraryInBackground(_ meetings: [Meeting]) {
+        let worker = searchIndexWorkQueue
+        Task { await worker.enqueue(meetings) }
+    }
+
+    private func reindexSearchInBackground(_ meeting: Meeting) {
+        let worker = searchIndexWorkQueue
+        Task { await worker.enqueue(meeting) }
+    }
+
+    private func reindexEmbeddingInBackground(_ meeting: Meeting) {
+        embeddingIndexTasks.removeValue(forKey: meeting.id)?.task.cancel()
+        let token = UUID()
+        let task = Task { @MainActor [weak self] in
+            guard let self, !Task.isCancelled else { return }
+            try? await self.embeddingIndex.index(meeting)
+            guard self.embeddingIndexTasks[meeting.id]?.token == token else { return }
+            self.embeddingIndexTasks.removeValue(forKey: meeting.id)
+        }
+        embeddingIndexTasks[meeting.id] = (token, task)
+    }
+
+    /// Index rows are reconstructible, but a failed SQLite cleanup must not
+    /// become permanent once the meeting folder disappears. Retry both stores
+    /// with bounded backoff for the rest of the session; durable tombstones and
+    /// each index's startup reconciliation cover interruption or app exit.
+    private func scheduleIndexCleanup(_ meetingID: Meeting.ID) {
+        indexCleanupTasks.removeValue(forKey: meetingID)?.task.cancel()
+        let token = UUID()
+        let worker = searchIndexWorkQueue
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            var embeddingClean = false
+            var searchClean = false
+            var attempt = 0
+
+            while !Task.isCancelled {
+                let result = await worker.remove(meetingID)
+                embeddingClean = embeddingClean || result.embedding
+                searchClean = searchClean || result.search
+                guard !Task.isCancelled,
+                      self.indexCleanupTasks[meetingID]?.token == token else { return }
+                if embeddingClean && searchClean {
+                    self.indexCleanupTasks.removeValue(forKey: meetingID)
+                    return
+                }
+
+                attempt += 1
+                if attempt.isMultiple(of: 4) {
+                    let reconciled = await worker.reconcileDeletedMeetings()
+                    embeddingClean = embeddingClean || reconciled.embedding
+                    searchClean = searchClean || reconciled.search
+                }
+                let delayMilliseconds = min(30_000, 250 * (1 << min(attempt, 7)))
+                try? await Task.sleep(for: .milliseconds(delayMilliseconds))
+            }
+        }
+        indexCleanupTasks[meetingID] = (token, task)
+    }
+
+    private func scheduleCotypingPrewarm() {
+        cotypingPrewarmTask?.cancel()
+        cotypingPrewarmTask = Task { @MainActor [weak self] in
+            guard let self, !Task.isCancelled, self.settings.cotypingEnabled else { return }
+            await self.cotypingEngine.prewarm()
+            guard !Task.isCancelled else { return }
+            self.cotypingPrewarmTask = nil
+        }
     }
 
     func prepareForTermination() async {
@@ -560,6 +828,17 @@ final class AppState: ObservableObject {
         }
         let task = Task { @MainActor in
             interactive = false
+            settingsStore.flush()
+            cotypingPrewarmTask?.cancel()
+            cotypingPrewarmTask = nil
+            libraryLoadTask?.cancel()
+            libraryLoadTask = nil
+            for entry in embeddingIndexTasks.values { entry.task.cancel() }
+            embeddingIndexTasks.removeAll()
+            for entry in indexCleanupTasks.values { entry.task.cancel() }
+            indexCleanupTasks.removeAll()
+            await searchIndexWorkQueue.stop()
+            pendingRecordingStart = nil
             recording.prepareForTermination()
             detector.stop()
             audioMonitor.stop()
@@ -639,10 +918,15 @@ final class AppState: ObservableObject {
     }
 
     private func notifyMeetingDetected(_ context: MeetingDetectionContext) {
-        // M1: simple user notification via the menu bar (badge). A richer
-        // UNUserNotification with a "Record" action button is a fast follow.
         lastError = nil
-        NSSound.beep()
+        let title = MeetingMatcher.recordingTitle(
+            calendarTitle: context.calendarEvent?.title,
+            useCalendarTitles: settings.useCalendarTitles,
+            appName: context.detectedApp?.name)
+        RecordingNotifier.shared.meetingDetected(title: title) { [weak self] in
+            guard let self, !self.recording.isRecording, !self.recording.isStarting else { return }
+            self.startRecording(context: context, source: "notification")
+        }
     }
 
     // MARK: - Library operations
@@ -653,9 +937,9 @@ final class AppState: ObservableObject {
 
     func saveTranscript(_ transcript: Transcript, for meeting: Meeting) throws {
         try pipeline.saveTranscript(transcript, for: meeting)
-        searchIndex.reindex(meeting, storage: storage)
+        reindexSearchInBackground(meeting)
         if settings.semanticSearchEnabled {
-            Task { try? await embeddingIndex.index(meeting) }
+            reindexEmbeddingInBackground(meeting)
         }
         objectWillChange.send()
     }
@@ -696,12 +980,21 @@ final class AppState: ObservableObject {
 
     /// Permanently removes meetings: audio folder, list entry, both indexes.
     func deleteMeetings(_ ids: Set<Meeting.ID>) {
+        var deletedIDs: Set<Meeting.ID> = []
         for meeting in meetings where ids.contains(meeting.id) {
-            storage.deleteMeeting(meeting)
-            searchIndex.remove(meeting.id)
-            embeddingIndex.remove(meeting.id)
+            do {
+                try storage.deleteMeeting(meeting)
+                embeddingIndexTasks.removeValue(forKey: meeting.id)?.task.cancel()
+                deletedMeetingIDs.insert(meeting.id)
+                cachedSearchIndex?.noteDeletion(meeting.id)
+                cachedEmbeddingIndex?.noteDeletion(meeting.id)
+                scheduleIndexCleanup(meeting.id)
+                deletedIDs.insert(meeting.id)
+            } catch {
+                lastError = "Could not delete \(meeting.title): \(error.localizedDescription)"
+            }
         }
-        meetings.removeAll { ids.contains($0.id) }
-        selectedMeetingIDs.subtract(ids)
+        meetings.removeAll { deletedIDs.contains($0.id) }
+        selectedMeetingIDs.subtract(deletedIDs)
     }
 }

--- a/LokalBot/LokalBotApp.swift
+++ b/LokalBot/LokalBotApp.swift
@@ -556,6 +556,7 @@ final class AppState: ObservableObject {
     var menuBarTimer: String { recording.menuBarTimer }
 
     func startRecording(context: MeetingDetectionContext? = nil, source: String = "ui") {
+        RecordingNotifier.shared.invalidateMeetingDetections()
         guard libraryReady else {
             pendingRecordingStart = (context, source)
             lastError = "Preparing your meeting library; recording will start when it is ready."
@@ -669,14 +670,27 @@ final class AppState: ObservableObject {
             switch self.settings.autoRecordMode {
             case .automatic: self.startRecording(context: context, source: "detector")
             case .ask: self.notifyMeetingDetected(context)
-            case .manual: break
+            case .manual: RecordingNotifier.shared.invalidateMeetingDetections()
             }
         }
         detector.onMeetingSwitched = { [weak self] context in
-            guard let self, self.settings.autoRecordMode == .automatic else { return }
-            self.recording.splitForCalendarHandoff(context)
+            guard let self else { return }
+            switch self.settings.autoRecordMode {
+            case .automatic:
+                RecordingNotifier.shared.invalidateMeetingDetections()
+                self.recording.splitForCalendarHandoff(context)
+            case .ask:
+                if self.recording.isRecording || self.recording.isStarting {
+                    RecordingNotifier.shared.invalidateMeetingDetections()
+                } else {
+                    self.notifyMeetingDetected(context)
+                }
+            case .manual:
+                RecordingNotifier.shared.invalidateMeetingDetections()
+            }
         }
         detector.onMeetingEnded = { [weak self] in
+            RecordingNotifier.shared.invalidateMeetingDetections()
             self?.stopRecording()
         }
         detector.stopDebounce = settings.stopDebounceSeconds
@@ -924,7 +938,10 @@ final class AppState: ObservableObject {
             useCalendarTitles: settings.useCalendarTitles,
             appName: context.detectedApp?.name)
         RecordingNotifier.shared.meetingDetected(title: title) { [weak self] in
-            guard let self, !self.recording.isRecording, !self.recording.isStarting else { return }
+            guard let self,
+                  self.settings.autoRecordMode == .ask,
+                  !self.recording.isRecording,
+                  !self.recording.isStarting else { return }
             self.startRecording(context: context, source: "notification")
         }
     }

--- a/LokalBot/Models/AppIdentifiers.swift
+++ b/LokalBot/Models/AppIdentifiers.swift
@@ -21,6 +21,14 @@ enum UITestRuntime {
     private static let storageRootArgument = "--lokalbot-storage-root"
     private static let defaultsSuiteArgument = "--lokalbot-defaults-suite"
 
+    /// XCTest loads the production app as its host, so `LokalBotMain.main()` and
+    /// `AppState` still run before the first test method. Keep that launch
+    /// hermetic even when the caller did not provide the UI-test overrides.
+    static var isUnitTesting: Bool {
+        !isEnabled
+            && ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
     static var isEnabled: Bool {
 #if LOKALBOT_UI_TEST_HOST
         true
@@ -35,12 +43,27 @@ enum UITestRuntime {
         nonEmpty(ProcessInfo.processInfo.environment["LOKALBOT_STORAGE_ROOT"])
             ?? argumentValue(after: storageRootArgument)
             ?? nonEmpty(UserDefaults.standard.string(forKey: storageRootKey))
+            ?? unitTestStorageRoot
     }
 
     static var defaultsSuiteName: String? {
         nonEmpty(ProcessInfo.processInfo.environment["LOKALBOT_DEFAULTS_SUITE"])
             ?? argumentValue(after: defaultsSuiteArgument)
             ?? nonEmpty(UserDefaults.standard.string(forKey: defaultsSuiteKey))
+            ?? unitTestDefaultsSuite
+    }
+
+    private static var unitTestStorageRoot: String? {
+        guard isUnitTesting else { return nil }
+        return FileManager.default.temporaryDirectory
+            .appendingPathComponent("lokalbot-unit-tests-\(ProcessInfo.processInfo.processIdentifier)",
+                                    isDirectory: true)
+            .path
+    }
+
+    private static var unitTestDefaultsSuite: String? {
+        guard isUnitTesting else { return nil }
+        return "me.dotenv.LokalBot.unit-tests.\(ProcessInfo.processInfo.processIdentifier)"
     }
 
     private static func argumentValue(after option: String) -> String? {

--- a/LokalBot/Models/AppSettings.swift
+++ b/LokalBot/Models/AppSettings.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct AppSettings: Codable {
+struct AppSettings: Codable, Equatable {
     enum AutoRecordMode: String, Codable, CaseIterable, Identifiable {
         case automatic = "Record automatically"
         case ask = "Ask via notification"

--- a/LokalBot/Models/InferenceEndpointPolicy.swift
+++ b/LokalBot/Models/InferenceEndpointPolicy.swift
@@ -7,12 +7,15 @@ enum InferenceEndpointPolicy {
 
     enum PolicyError: LocalizedError, Equatable {
         case unsupportedURL
+        case insecureRemoteEndpoint(String)
         case remoteApprovalRequired(String)
 
         var errorDescription: String? {
             switch self {
             case .unsupportedURL:
                 "Use an http or https inference-server URL."
+            case .insecureRemoteEndpoint(let origin):
+                "Remote inference server \(origin) is not encrypted. Use HTTPS, or run the server on this Mac."
             case .remoteApprovalRequired(let origin):
                 "Approve the remote inference server \(origin) under Settings → Models before sending meeting or workday text to it."
             }
@@ -39,8 +42,7 @@ enum InferenceEndpointPolicy {
             || host == "::1"
             || host == "0:0:0:0:0:0:0:1"
             || host == "0.0.0.0"
-            || host == "127.0.0.1"
-            || host.hasPrefix("127.")
+            || isIPv4Loopback(host)
     }
 
     static func requiresApproval(_ url: URL) -> Bool {
@@ -49,13 +51,34 @@ enum InferenceEndpointPolicy {
 
     static func isAllowed(_ url: URL, approvedOrigins: [String]) -> Bool {
         guard let origin = origin(for: url) else { return false }
-        return isLoopback(url) || approvedOrigins.contains(origin)
+        if isLoopback(url) { return true }
+        return url.scheme?.lowercased() == "https" && approvedOrigins.contains(origin)
     }
 
     static func validate(_ url: URL, approvedOrigins: [String]) throws {
         guard let origin = origin(for: url) else { throw PolicyError.unsupportedURL }
-        guard isLoopback(url) || approvedOrigins.contains(origin) else {
+        if isLoopback(url) { return }
+        guard url.scheme?.lowercased() == "https" else {
+            throw PolicyError.insecureRemoteEndpoint(origin)
+        }
+        guard approvedOrigins.contains(origin) else {
             throw PolicyError.remoteApprovalRequired(origin)
         }
+    }
+
+    private static func isIPv4Loopback(_ host: String) -> Bool {
+        let octets = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard octets.count == 4 else { return false }
+        var values: [Int] = []
+        values.reserveCapacity(4)
+        for octet in octets {
+            guard !octet.isEmpty,
+                  octet.allSatisfy(\.isNumber),
+                  let value = Int(octet), (0...255).contains(value) else {
+                return false
+            }
+            values.append(value)
+        }
+        return values[0] == 127
     }
 }

--- a/LokalBot/Models/Meeting.swift
+++ b/LokalBot/Models/Meeting.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// One recorded meeting. Persisted as `meta.json` inside its own folder:
 /// `meetings/YYYY/MM/dd-slug/{mic.m4a, system.m4a, meta.json}`.
-struct Meeting: Identifiable, Codable, Equatable {
+struct Meeting: Identifiable, Codable, Equatable, Sendable {
     let id: UUID
     var title: String
     var appName: String

--- a/LokalBot/Resources/pi/lokalbot-extension/index.ts
+++ b/LokalBot/Resources/pi/lokalbot-extension/index.ts
@@ -6,10 +6,12 @@
 // extension_ui_request on stdout, answered over stdin.
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { resolve } from "node:path";
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { homedir } from "node:os";
 
-const GATED_TOOLS = new Set(["write", "edit", "bash"]);
+const MUTATING_TOOLS = new Set(["write", "edit", "bash"]);
+const MAX_APPROVAL_TEXT = 64 * 1024;
 
 export default function lokalbotExtension(pi: ExtensionAPI) {
   const baseUrl = process.env.LOKALBOT_LLM_BASE_URL;
@@ -19,7 +21,21 @@ export default function lokalbotExtension(pi: ExtensionAPI) {
       "LOKALBOT_LLM_BASE_URL and LOKALBOT_LLM_MODEL must be set (launched outside LokalBot?)",
     );
   }
-  const contextWindow = Number(process.env.LOKALBOT_LLM_CTX ?? "16384");
+  const parsedContextWindow = Number(process.env.LOKALBOT_LLM_CTX ?? "16384");
+  const contextWindow = Number.isSafeInteger(parsedContextWindow)
+    && parsedContextWindow >= 1024
+    && parsedContextWindow <= 1_048_576
+    ? parsedContextWindow
+    : 16384;
+  const endpoint = new URL(baseUrl);
+  const loopback = endpoint.hostname === "localhost"
+    || endpoint.hostname.endsWith(".localhost")
+    || isIPv4Loopback(endpoint.hostname)
+    || endpoint.hostname === "[::1]"
+    || endpoint.hostname === "::1";
+  if (!loopback && endpoint.protocol !== "https:") {
+    throw new Error("Remote LokalBot LLM endpoints must use HTTPS");
+  }
 
   pi.registerProvider("lokalbot", {
     baseUrl,
@@ -41,7 +57,7 @@ export default function lokalbotExtension(pi: ExtensionAPI) {
   });
 
   pi.on("tool_call", async (event, ctx) => {
-    if (!GATED_TOOLS.has(event.toolName)) return undefined; // reads auto-allowed
+    if (!requiresApproval(event.toolName, event.input)) return undefined;
 
     // Machine-parseable payload: the host renders exact commands and file
     // changes, rather than relying on a model-authored summary.
@@ -60,12 +76,64 @@ export default function lokalbotExtension(pi: ExtensionAPI) {
   });
 }
 
-function resolvedPath(value: unknown): string | undefined {
+function isIPv4Loopback(hostname: string): boolean {
+  const octets = hostname.split(".");
+  return octets.length === 4
+    && octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255)
+    && Number(octets[0]) === 127;
+}
+
+function requestedPath(value: unknown): string | undefined {
   const path = String(value ?? "");
   if (!path) return undefined;
   if (path === "~") return homedir();
   if (path.startsWith("~/")) return resolve(homedir(), path.slice(2));
   return resolve(process.cwd(), path);
+}
+
+function canonicalPath(value: unknown): string | undefined {
+  const requested = requestedPath(value);
+  if (!requested) return undefined;
+  try {
+    return realpathSync(requested);
+  } catch {
+    // Canonicalize the nearest existing ancestor so a path through a symlink
+    // cannot escape merely because its final component does not exist yet.
+    let ancestor = requested;
+    const suffix: string[] = [];
+    while (!existsSync(ancestor)) {
+      const parent = dirname(ancestor);
+      if (parent === ancestor) return undefined;
+      suffix.unshift(ancestor.slice(parent.length).replace(/^\//, ""));
+      ancestor = parent;
+    }
+    try {
+      return resolve(realpathSync(ancestor), ...suffix);
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+function isInsideWorkspace(path: string): boolean {
+  const workspace = realpathSync(process.cwd());
+  const child = relative(workspace, path);
+  return child === "" || (!child.startsWith("..") && !isAbsolute(child));
+}
+
+function requiresApproval(toolName: string, input: unknown): boolean {
+  if (MUTATING_TOOLS.has(toolName)) return true;
+  if (toolName !== "read") return false;
+  const args = (input ?? {}) as Record<string, unknown>;
+  const path = canonicalPath(args.path ?? args.file_path);
+  // Missing/unresolvable paths are never silently treated as in-workspace.
+  return !path || !isInsideWorkspace(path);
+}
+
+function boundedText(value: unknown): { text: string; truncated: boolean } {
+  const text = String(value ?? "");
+  if (text.length <= MAX_APPROVAL_TEXT) return { text, truncated: false };
+  return { text: text.slice(0, MAX_APPROVAL_TEXT), truncated: true };
 }
 
 function approvalPayload(toolName: string, input: unknown): Record<string, unknown> {
@@ -78,26 +146,39 @@ function approvalPayload(toolName: string, input: unknown): Record<string, unkno
 
   switch (toolName) {
     case "bash": {
-      payload.command = String(args.command ?? args.cmd ?? JSON.stringify(args));
+      const bounded = boundedText(args.command ?? args.cmd ?? JSON.stringify(args));
+      payload.command = bounded.text;
+      payload.truncated = bounded.truncated;
       break;
     }
     case "write": {
-      payload.path = resolvedPath(args.path ?? args.file_path);
-      payload.content = String(args.content ?? "");
+      payload.path = canonicalPath(args.path ?? args.file_path) ?? requestedPath(args.path ?? args.file_path);
+      const bounded = boundedText(args.content);
+      payload.content = bounded.text;
+      payload.truncated = bounded.truncated;
       break;
     }
     case "edit": {
+      let wasTruncated = false;
       const edits = Array.isArray(args.edits)
         ? args.edits.map((value) => {
             const edit = (value ?? {}) as Record<string, unknown>;
+            const oldText = boundedText(edit.oldText ?? edit.old_text);
+            const newText = boundedText(edit.newText ?? edit.new_text);
+            wasTruncated ||= oldText.truncated || newText.truncated;
             return {
-              oldText: String(edit.oldText ?? edit.old_text ?? ""),
-              newText: String(edit.newText ?? edit.new_text ?? ""),
+              oldText: oldText.text,
+              newText: newText.text,
             };
           })
         : [];
-      payload.path = resolvedPath(args.path ?? args.file_path);
-      payload.edits = edits;
+      payload.path = canonicalPath(args.path ?? args.file_path) ?? requestedPath(args.path ?? args.file_path);
+      payload.edits = edits.slice(0, 100);
+      payload.truncated = wasTruncated || edits.length > 100;
+      break;
+    }
+    case "read": {
+      payload.path = canonicalPath(args.path ?? args.file_path) ?? requestedPath(args.path ?? args.file_path);
       break;
     }
   }

--- a/LokalBot/Services/ActivityTracker.swift
+++ b/LokalBot/Services/ActivityTracker.swift
@@ -20,35 +20,45 @@ struct ActivityBlock: Identifiable {
 @MainActor
 final class ActivityStore {
     private let database: SQLiteDatabase?
+    private let databaseURL: URL
 
     init(databaseURL: URL) {
+        self.databaseURL = databaseURL
         database = SQLiteDatabase(url: databaseURL)
-        database?.exec("""
-            CREATE TABLE IF NOT EXISTS activity_blocks (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                app TEXT NOT NULL, title TEXT NOT NULL,
-                start REAL NOT NULL, end REAL NOT NULL);
-            CREATE INDEX IF NOT EXISTS idx_activity_start ON activity_blocks(start);
-            CREATE TABLE IF NOT EXISTS screenshots (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                ts REAL NOT NULL, path TEXT NOT NULL, app TEXT NOT NULL,
-                window_title TEXT NOT NULL DEFAULT '',
-                capture_trigger TEXT NOT NULL DEFAULT 'interval');
-            """)
-        migrateScreenshotColumns()
-        migrateOCRTable()
+        guard let database else { return }
+        do {
+            try database.execute("""
+                CREATE TABLE IF NOT EXISTS activity_blocks (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    app TEXT NOT NULL, title TEXT NOT NULL,
+                    start REAL NOT NULL, end REAL NOT NULL);
+                CREATE INDEX IF NOT EXISTS idx_activity_start ON activity_blocks(start);
+                CREATE TABLE IF NOT EXISTS screenshots (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ts REAL NOT NULL, path TEXT NOT NULL, app TEXT NOT NULL,
+                    window_title TEXT NOT NULL DEFAULT '',
+                    capture_trigger TEXT NOT NULL DEFAULT 'interval');
+                """)
+            try migrateScreenshotColumns()
+            try migrateOCRTable()
+        } catch {
+            lokalbotLog("activity store initialization failed: \(error.localizedDescription)")
+        }
     }
 
     /// Screenshots taken by builds before event-driven capture lack the
     /// `window_title` / `capture_trigger` columns. ALTER is cheap and keeps
     /// existing rows; fresh databases already have the full shape.
-    private func migrateScreenshotColumns() {
-        let columns = columnNames(of: "screenshots")
+    private func migrateScreenshotColumns() throws {
+        let database = try requiredDatabase()
+        let columns = try columnNames(of: "screenshots")
         if !columns.contains("window_title") {
-            database?.exec("ALTER TABLE screenshots ADD COLUMN window_title TEXT NOT NULL DEFAULT ''")
+            try database.execute(
+                "ALTER TABLE screenshots ADD COLUMN window_title TEXT NOT NULL DEFAULT ''")
         }
         if !columns.contains("capture_trigger") {
-            database?.exec("ALTER TABLE screenshots ADD COLUMN capture_trigger TEXT NOT NULL DEFAULT 'interval'")
+            try database.execute(
+                "ALTER TABLE screenshots ADD COLUMN capture_trigger TEXT NOT NULL DEFAULT 'interval'")
         }
     }
 
@@ -57,20 +67,23 @@ final class ActivityStore {
     /// indexed (searchable) plus `text_source` / `snapshot_id` metadata.
     /// `text_source` is always "ocr" today; it exists so Accessibility-first
     /// capture can land later as a data-only change.
-    private func migrateOCRTable() {
-        let existing = columnNames(of: "ocr_fts")
+    private func migrateOCRTable() throws {
+        let database = try requiredDatabase()
+        let existing = try columnNames(of: "ocr_fts")
         if existing.isEmpty {
-            database?.exec(Self.createOCRTableSQL(named: "ocr_fts"))
+            try database.execute(Self.createOCRTableSQL(named: "ocr_fts"))
             return
         }
         guard !existing.contains("snapshot_id") else { return }
-        database?.exec(Self.createOCRTableSQL(named: "ocr_fts_v2"))
-        database?.exec("""
-            INSERT INTO ocr_fts_v2 (text, window_title, ts, app, text_source, snapshot_id)
-                SELECT text, '', ts, app, 'ocr', 0 FROM ocr_fts;
-            DROP TABLE ocr_fts;
-            ALTER TABLE ocr_fts_v2 RENAME TO ocr_fts;
-            """)
+        try database.withTransaction {
+            try database.execute(Self.createOCRTableSQL(named: "ocr_fts_v2"))
+            try database.execute("""
+                INSERT INTO ocr_fts_v2 (text, window_title, ts, app, text_source, snapshot_id)
+                    SELECT text, '', ts, app, 'ocr', 0 FROM ocr_fts;
+                DROP TABLE ocr_fts;
+                ALTER TABLE ocr_fts_v2 RENAME TO ocr_fts;
+                """)
+        }
     }
 
     private static func createOCRTableSQL(named name: String) -> String {
@@ -82,10 +95,18 @@ final class ActivityStore {
         """
     }
 
-    private func columnNames(of table: String) -> Set<String> {
-        Set(database?.query("PRAGMA table_info(\(table))") { statement in
+    private func columnNames(of table: String) throws -> Set<String> {
+        let database = try requiredDatabase()
+        return Set(try database.queryChecked("PRAGMA table_info(\(table))") { statement in
             String(cString: sqlite3_column_text(statement, 1))
-        } ?? [])
+        })
+    }
+
+    private func requiredDatabase() throws -> SQLiteDatabase {
+        guard let database else {
+            throw SQLiteDatabase.DatabaseError.unavailable(path: databaseURL.path)
+        }
+        return database
     }
 
     nonisolated static func dayInterval(containing day: Date, calendar: Calendar = .current) -> DateInterval {
@@ -93,10 +114,18 @@ final class ActivityStore {
             ?? DateInterval(start: calendar.startOfDay(for: day), duration: 86_400)
     }
 
-    func insert(_ block: ActivityBlock) {
-        database?.run(
-            "INSERT INTO activity_blocks (app, title, start, end) VALUES (?1, ?2, ?3, ?4)",
-            bind: [block.app, block.title, block.start.timeIntervalSince1970, block.end.timeIntervalSince1970])
+    @discardableResult
+    func insert(_ block: ActivityBlock) -> Bool {
+        do {
+            try requiredDatabase().runChecked(
+                "INSERT INTO activity_blocks (app, title, start, end) VALUES (?1, ?2, ?3, ?4)",
+                bind: [block.app, block.title, block.start.timeIntervalSince1970,
+                       block.end.timeIntervalSince1970])
+            return true
+        } catch {
+            lokalbotLog("activity block persistence failed: \(error.localizedDescription)")
+            return false
+        }
     }
 
     // MARK: Screenshots / OCR (M5)
@@ -123,34 +152,49 @@ final class ActivityStore {
     @discardableResult
     func insertScreenshot(ts: Date, path: String, app: String,
                           windowTitle: String = "", trigger: String = "interval",
-                          textSource: String = "ocr", ocr: String) -> Int64 {
-        database?.run("""
-            INSERT INTO screenshots (ts, path, app, window_title, capture_trigger)
-            VALUES (?1, ?2, ?3, ?4, ?5)
-            """, bind: [ts.timeIntervalSince1970, path, app, windowTitle, trigger])
-        let snapshotID = database?.lastInsertRowID() ?? 0
-        if !ocr.isEmpty {
-            database?.run("""
-                INSERT INTO ocr_fts (text, window_title, ts, app, text_source, snapshot_id)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-                """, bind: [ocr, windowTitle, ts.timeIntervalSince1970, app, textSource, snapshotID])
+                          textSource: String = "ocr", ocr: String) throws -> Int64 {
+        let database = try requiredDatabase()
+        return try database.withTransaction {
+            try database.runChecked("""
+                INSERT INTO screenshots (ts, path, app, window_title, capture_trigger)
+                VALUES (?1, ?2, ?3, ?4, ?5)
+                """, bind: [ts.timeIntervalSince1970, path, app, windowTitle, trigger])
+            let snapshotID = database.lastInsertRowID()
+            guard snapshotID > 0 else {
+                throw SQLiteDatabase.DatabaseError.step(
+                    sql: nil, code: SQLITE_CORRUPT,
+                    message: "screenshot insert did not produce a row id")
+            }
+            if !ocr.isEmpty {
+                try database.runChecked("""
+                    INSERT INTO ocr_fts (text, window_title, ts, app, text_source, snapshot_id)
+                    VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                    """, bind: [ocr, windowTitle, ts.timeIntervalSince1970, app,
+                                 textSource, snapshotID])
+            }
+            return snapshotID
         }
-        return snapshotID
     }
 
     func screenshots(on day: Date) -> [Screenshot] {
         let interval = Self.dayInterval(containing: day)
-        return database?.query("""
-            SELECT id, ts, path, app, window_title, capture_trigger FROM screenshots
-            WHERE ts >= ?1 AND ts < ?2 AND path != '' ORDER BY ts
-            """, bind: [interval.start.timeIntervalSince1970, interval.end.timeIntervalSince1970]) { statement in
-            Screenshot(id: sqlite3_column_int64(statement, 0),
-                       ts: Date(timeIntervalSince1970: sqlite3_column_double(statement, 1)),
-                       path: String(cString: sqlite3_column_text(statement, 2)),
-                       app: String(cString: sqlite3_column_text(statement, 3)),
-                       windowTitle: String(cString: sqlite3_column_text(statement, 4)),
-                       trigger: String(cString: sqlite3_column_text(statement, 5)))
-        } ?? []
+        do {
+            return try requiredDatabase().queryChecked("""
+                SELECT id, ts, path, app, window_title, capture_trigger FROM screenshots
+                WHERE ts >= ?1 AND ts < ?2 AND path != '' ORDER BY ts
+                """, bind: [interval.start.timeIntervalSince1970,
+                             interval.end.timeIntervalSince1970]) { statement in
+                Screenshot(id: sqlite3_column_int64(statement, 0),
+                           ts: Date(timeIntervalSince1970: sqlite3_column_double(statement, 1)),
+                           path: String(cString: sqlite3_column_text(statement, 2)),
+                           app: String(cString: sqlite3_column_text(statement, 3)),
+                           windowTitle: String(cString: sqlite3_column_text(statement, 4)),
+                           trigger: String(cString: sqlite3_column_text(statement, 5)))
+            }
+        } catch {
+            lokalbotLog("screenshot query failed: \(error.localizedDescription)")
+            return []
+        }
     }
 
     /// FTS search over screen text (and window titles). `matchAll: false`
@@ -160,15 +204,20 @@ final class ActivityStore {
                    matchAll: Bool = true, dropStopWords: Bool = false) -> [OCRHit] {
         guard let match = SearchIndex.ftsQuery(from: query, matchAll: matchAll,
                                                dropStopWords: dropStopWords) else { return [] }
-        return database?.query("""
-            SELECT ts, app, window_title, snippet(ocr_fts, 0, '«', '»', '…', 14)
-            FROM ocr_fts WHERE ocr_fts MATCH ?1 ORDER BY rank LIMIT \(limit)
-            """, bind: [match]) { statement in
-            OCRHit(ts: Date(timeIntervalSince1970: sqlite3_column_double(statement, 0)),
-                   app: String(cString: sqlite3_column_text(statement, 1)),
-                   windowTitle: String(cString: sqlite3_column_text(statement, 2)),
-                   snippet: String(cString: sqlite3_column_text(statement, 3)))
-        } ?? []
+        do {
+            return try requiredDatabase().queryChecked("""
+                SELECT ts, app, window_title, snippet(ocr_fts, 0, '«', '»', '…', 14)
+                FROM ocr_fts WHERE ocr_fts MATCH ?1 ORDER BY rank LIMIT \(limit)
+                """, bind: [match]) { statement in
+                OCRHit(ts: Date(timeIntervalSince1970: sqlite3_column_double(statement, 0)),
+                       app: String(cString: sqlite3_column_text(statement, 1)),
+                       windowTitle: String(cString: sqlite3_column_text(statement, 2)),
+                       snippet: String(cString: sqlite3_column_text(statement, 3)))
+            }
+        } catch {
+            lokalbotLog("OCR search failed: \(error.localizedDescription)")
+            return []
+        }
     }
 
     /// OCR text for a day, for the "ask your day" LLM context.
@@ -181,54 +230,210 @@ final class ActivityStore {
     /// hints, where the current day's whole screen history would be too broad.
     func ocrText(from start: Date, to end: Date, maxChars: Int = 9_000,
                  includeAppNames: Bool = false) -> String {
-        return database?.withStatement("""
-            SELECT app, text FROM ocr_fts WHERE ts >= ?1 AND ts < ?2 ORDER BY ts
-            """, bind: [start.timeIntervalSince1970, end.timeIntervalSince1970]) { statement in
+        guard maxChars > 0 else { return "" }
+        do {
             var out = ""
-            while sqlite3_step(statement) == SQLITE_ROW, out.count < maxChars {
+            try requiredDatabase().forEachRowChecked("""
+                SELECT app, text FROM ocr_fts WHERE ts >= ?1 AND ts < ?2 ORDER BY ts
+                """, bind: [start.timeIntervalSince1970, end.timeIntervalSince1970]) { statement in
                 let app = String(cString: sqlite3_column_text(statement, 0))
                 let text = String(cString: sqlite3_column_text(statement, 1))
-                if includeAppNames {
-                    out += "[\(app)] \(text.prefix(600))\n"
-                } else {
-                    out += "\(text.prefix(600))\n"
-                }
+                let line = includeAppNames
+                    ? "[\(app)] \(text.prefix(600))\n"
+                    : "\(text.prefix(600))\n"
+                out += line.prefix(maxChars - out.count)
+                return out.count < maxChars
             }
             return out
-        } ?? ""
+        } catch {
+            lokalbotLog("OCR context query failed: \(error.localizedDescription)")
+            return ""
+        }
     }
 
     func screenshotPaths(olderThan cutoff: Date) -> [String] {
-        database?.query("SELECT path FROM screenshots WHERE ts < ?1 AND path != ''",
-                        bind: [cutoff.timeIntervalSince1970]) { statement in
-            String(cString: sqlite3_column_text(statement, 0))
-        } ?? []
+        do {
+            return try requiredDatabase().queryChecked(
+                "SELECT path FROM screenshots WHERE ts < ?1 AND path != ''",
+                bind: [cutoff.timeIntervalSince1970]) { statement in
+                String(cString: sqlite3_column_text(statement, 0))
+            }
+        } catch {
+            lokalbotLog("screenshot retention query failed: \(error.localizedDescription)")
+            return []
+        }
     }
 
-    func clearScreenshotPaths(olderThan cutoff: Date) {
-        database?.run("UPDATE screenshots SET path = '' WHERE ts < ?1",
-                      bind: [cutoff.timeIntervalSince1970])
+    /// Clear only the row whose file was successfully removed. This avoids
+    /// losing the sole reference to an encrypted file when filesystem cleanup
+    /// fails (permissions, transient volume error, and so on).
+    func clearScreenshotPath(_ path: String) throws {
+        try requiredDatabase().runChecked(
+            "UPDATE screenshots SET path = '' WHERE path = ?1", bind: [path])
     }
 
-    func clearOCRText(olderThan cutoff: Date) {
-        database?.run("DELETE FROM ocr_fts WHERE ts < ?1",
-                      bind: [cutoff.timeIntervalSince1970])
+    @discardableResult
+    func clearOCRText(olderThan cutoff: Date) -> Bool {
+        do {
+            try requiredDatabase().runChecked(
+                "DELETE FROM ocr_fts WHERE ts < ?1", bind: [cutoff.timeIntervalSince1970])
+            return true
+        } catch {
+            lokalbotLog("OCR retention cleanup failed: \(error.localizedDescription)")
+            return false
+        }
     }
 
     /// All blocks overlapping the given day, oldest first.
     func blocks(on day: Date) -> [ActivityBlock] {
         let interval = Self.dayInterval(containing: day)
-        return database?.query("""
-            SELECT id, app, title, start, end FROM activity_blocks
-            WHERE end > ?1 AND start < ?2 ORDER BY start
-            """, bind: [interval.start.timeIntervalSince1970, interval.end.timeIntervalSince1970]) { statement in
-            ActivityBlock(
-                id: sqlite3_column_int64(statement, 0),
-                app: String(cString: sqlite3_column_text(statement, 1)),
-                title: String(cString: sqlite3_column_text(statement, 2)),
-                start: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
-                end: Date(timeIntervalSince1970: sqlite3_column_double(statement, 4)))
-        } ?? []
+        do {
+            return try requiredDatabase().queryChecked("""
+                SELECT id, app, title, start, end FROM activity_blocks
+                WHERE end > ?1 AND start < ?2 ORDER BY start
+                """, bind: [interval.start.timeIntervalSince1970,
+                             interval.end.timeIntervalSince1970]) { statement in
+                ActivityBlock(
+                    id: sqlite3_column_int64(statement, 0),
+                    app: String(cString: sqlite3_column_text(statement, 1)),
+                    title: String(cString: sqlite3_column_text(statement, 2)),
+                    start: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
+                    end: Date(timeIntervalSince1970: sqlite3_column_double(statement, 4)))
+            }
+        } catch {
+            lokalbotLog("activity block query failed: \(error.localizedDescription)")
+            return []
+        }
+    }
+}
+
+struct FocusedWindowTitleLookupResult: Equatable, Sendable {
+    let title: String?
+    let timedOut: Bool
+
+    static let timeout = Self(title: nil, timedOut: true)
+}
+
+/// Keeps cross-process Accessibility title reads off the main actor and bounds
+/// both queue growth and caller latency. One resolver may be active at a time;
+/// same-PID callers share it, while a different PID fails closed instead of
+/// accumulating behind a wedged target process.
+final class FocusedWindowTitleLookup: @unchecked Sendable {
+    typealias Resolver = @Sendable (pid_t) -> String?
+
+    static let shared = FocusedWindowTitleLookup()
+    static let defaultDeadlineMilliseconds = 120
+    static let perElementMessagingTimeout: Float = 0.04
+
+    private struct Waiter {
+        let id: UInt64
+        let continuation: CheckedContinuation<FocusedWindowTitleLookupResult, Never>
+    }
+
+    private struct Work {
+        let id: UInt64
+        let processID: pid_t
+        var waiters: [UInt64: Waiter]
+    }
+
+    private let stateQueue = DispatchQueue(label: "me.dotenv.LokalBot.ax-window-title-state")
+    private let workerQueue = DispatchQueue(
+        label: "me.dotenv.LokalBot.ax-window-title-worker",
+        qos: .utility)
+    private let deadlineMilliseconds: Int
+    private let resolver: Resolver
+    private var nextIdentifier: UInt64 = 0
+    private var active: Work?
+
+    init(
+        deadlineMilliseconds: Int = defaultDeadlineMilliseconds,
+        resolver: @escaping Resolver = { processID in
+            FocusedWindowTitleLookup.resolveTitle(processID: processID)
+        }
+    ) {
+        self.deadlineMilliseconds = max(1, deadlineMilliseconds)
+        self.resolver = resolver
+    }
+
+    func title(for processID: pid_t) async -> FocusedWindowTitleLookupResult {
+        guard processID > 0 else { return .init(title: nil, timedOut: false) }
+        return await withCheckedContinuation { continuation in
+            stateQueue.async { [self] in
+                nextIdentifier &+= 1
+                let waiter = Waiter(id: nextIdentifier, continuation: continuation)
+                enqueue(waiter: waiter, processID: processID)
+            }
+        }
+    }
+
+    private func enqueue(waiter: Waiter, processID: pid_t) {
+        if var active {
+            guard active.processID == processID else {
+                waiter.continuation.resume(returning: .timeout)
+                return
+            }
+            active.waiters[waiter.id] = waiter
+            self.active = active
+            scheduleExpiration(for: waiter.id)
+            return
+        }
+
+        nextIdentifier &+= 1
+        let work = Work(
+            id: nextIdentifier,
+            processID: processID,
+            waiters: [waiter.id: waiter])
+        active = work
+        scheduleExpiration(for: waiter.id)
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            let title = resolver(processID)
+            stateQueue.async { [weak self] in
+                self?.finish(workID: work.id, title: title)
+            }
+        }
+    }
+
+    private func scheduleExpiration(for waiterID: UInt64) {
+        stateQueue.asyncAfter(deadline: .now() + .milliseconds(deadlineMilliseconds)) { [weak self] in
+            self?.expire(waiterID: waiterID)
+        }
+    }
+
+    private func expire(waiterID: UInt64) {
+        guard var active, let waiter = active.waiters.removeValue(forKey: waiterID) else { return }
+        self.active = active
+        waiter.continuation.resume(returning: .timeout)
+    }
+
+    private func finish(workID: UInt64, title: String?) {
+        guard let completed = active, completed.id == workID else { return }
+        active = nil
+        let result = FocusedWindowTitleLookupResult(title: title, timedOut: false)
+        for waiter in completed.waiters.values {
+            waiter.continuation.resume(returning: result)
+        }
+    }
+
+    static func resolveTitle(processID: pid_t) -> String? {
+        guard AXIsProcessTrusted(), processID > 0 else { return nil }
+        let appElement = AXUIElementCreateApplication(processID)
+        AXUIElementSetMessagingTimeout(appElement, perElementMessagingTimeout)
+        var rawWindow: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            appElement,
+            kAXFocusedWindowAttribute as CFString,
+            &rawWindow) == .success,
+              let rawWindow,
+              CFGetTypeID(rawWindow) == AXUIElementGetTypeID() else { return nil }
+        let window = rawWindow as! AXUIElement
+        AXUIElementSetMessagingTimeout(window, perElementMessagingTimeout)
+        var rawTitle: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            window,
+            kAXTitleAttribute as CFString,
+            &rawTitle) == .success else { return nil }
+        return rawTitle as? String
     }
 }
 
@@ -243,6 +448,7 @@ final class ActivitySampler: ObservableObject {
     @Published private(set) var currentApp: String?
 
     private let store: ActivityStore
+    private let windowTitleLookup: FocusedWindowTitleLookup
     /// Injected by AppState; apps matching these are logged as "Private".
     var excludedApps: () -> [String] = { [] }
     /// Event-driven capture hook: fired when the sampled (app, title) pair
@@ -251,22 +457,32 @@ final class ActivitySampler: ObservableObject {
     /// inside the same app. Excluded apps arrive as ("Private", "").
     var onActivityBoundary: ((_ app: String, _ title: String, _ appChanged: Bool) -> Void)?
     private var timer: Timer?
+    private let notificationCenter: NotificationCenter
+    private var terminationObserver: NSObjectProtocol?
     private var current: (app: String, title: String, start: Date)?
     private var lastSeen = Date()
     private static let idleLimit: TimeInterval = 180
     private static let minBlock: TimeInterval = 5
 
-    init(store: ActivityStore) {
+    init(
+        store: ActivityStore,
+        notificationCenter: NotificationCenter = .default,
+        windowTitleLookup: FocusedWindowTitleLookup = .shared
+    ) {
         self.store = store
+        self.notificationCenter = notificationCenter
+        self.windowTitleLookup = windowTitleLookup
     }
+
+    var hasTerminationObserver: Bool { terminationObserver != nil }
 
     func start() {
         guard timer == nil else { return }
         lokalbotLog("sampler start — AX trusted: \(Self.hasAccessibility ? "yes" : "no")")
         timer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { [weak self] _ in
-            Task { @MainActor in self?.sample() }
+            Task { @MainActor in await self?.sample() }
         }
-        NotificationCenter.default.addObserver(
+        terminationObserver = notificationCenter.addObserver(
             forName: NSApplication.willTerminateNotification, object: nil, queue: .main) { _ in
             Task { @MainActor [weak self] in self?.closeCurrentBlock() }
         }
@@ -275,7 +491,17 @@ final class ActivitySampler: ObservableObject {
     func stop() {
         timer?.invalidate()
         timer = nil
+        if let terminationObserver {
+            notificationCenter.removeObserver(terminationObserver)
+            self.terminationObserver = nil
+        }
         closeCurrentBlock()
+    }
+
+    deinit {
+        if let terminationObserver {
+            notificationCenter.removeObserver(terminationObserver)
+        }
     }
 
     /// Window titles need Accessibility; we degrade to app-name-only.
@@ -285,7 +511,7 @@ final class ActivitySampler: ObservableObject {
         AXIsProcessTrustedWithOptions(options)
     }
 
-    private func sample() {
+    private func sample() async {
         guard !isPaused else { return }
 
         // Idle: any input event type, session-wide.
@@ -299,10 +525,18 @@ final class ActivitySampler: ObservableObject {
 
         guard let frontmost = NSWorkspace.shared.frontmostApplication,
               var appName = frontmost.localizedName else { return }
+        let processID = frontmost.processIdentifier
+        let isExcluded = ScreenshotCaptureLayout.isExcluded(
+            appName: appName, excludedApps: excludedApps())
+        let titleResult = isExcluded
+            ? FocusedWindowTitleLookupResult(title: nil, timedOut: false)
+            : await windowTitleLookup.title(for: processID)
+        guard !titleResult.timedOut,
+              NSWorkspace.shared.frontmostApplication?.processIdentifier == processID else { return }
         currentApp = appName
-        var title = Self.focusedWindowTitle(pid: frontmost.processIdentifier) ?? ""
+        var title = titleResult.title ?? ""
         // Exclusion list (design §3.4): time still counts, content doesn't.
-        if excludedApps().contains(where: { appName.localizedCaseInsensitiveContains($0) }) {
+        if isExcluded {
             appName = "Private"
             title = ""
         }
@@ -325,15 +559,6 @@ final class ActivitySampler: ObservableObject {
     }
 
     nonisolated static func focusedWindowTitle(pid: pid_t) -> String? {
-        guard hasAccessibility else { return nil }
-        let appElement = AXUIElementCreateApplication(pid)
-        var window: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(appElement,
-            kAXFocusedWindowAttribute as CFString, &window) == .success,
-              let window else { return nil }
-        var title: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(window as! AXUIElement,
-            kAXTitleAttribute as CFString, &title) == .success else { return nil }
-        return title as? String
+        FocusedWindowTitleLookup.resolveTitle(processID: pid)
     }
 }

--- a/LokalBot/Services/AgentAccessManager.swift
+++ b/LokalBot/Services/AgentAccessManager.swift
@@ -121,14 +121,17 @@ final class AgentAccessManager: ObservableObject {
     static func resolveBuiltInModelURL(
         settings: AppSettings,
         storage: StorageManager
-    ) -> ResolvedBuiltInModel {
+    ) async -> ResolvedBuiltInModel {
         switch AgentLLMEndpointResolver.resolve(settings: settings) {
         case .builtIn(let modelID):
             guard let entry = ModelCatalog.entry(
                 id: modelID,
                 custom: settings.customBuiltInModels)
-                ?? ModelCatalog.entry(id: modelID),
-                let modelURL = ModelCatalog.localURL(for: entry, storage: storage) else {
+                ?? ModelCatalog.entry(id: modelID) else {
+                return .failure("The built-in model isn't downloaded. Open LokalBot → Settings → Models and download it, then ask again.")
+            }
+            guard let modelURL = await ModelDownloadManager.shared.verifiedExistingURL(
+                entry, storage: storage) else {
                 return .failure("The built-in model isn't downloaded. Open LokalBot → Settings → Models and download it, then ask again.")
             }
             return .model(modelURL)
@@ -142,7 +145,7 @@ final class AgentAccessManager: ObservableObject {
     /// Default wake handler: resolve the built-in model, then hold a TTL
     /// lease on the Main LLM.
     func wakeMainLLM(settings: AppSettings, storage: StorageManager) async -> String? {
-        switch Self.resolveBuiltInModelURL(settings: settings, storage: storage) {
+        switch await Self.resolveBuiltInModelURL(settings: settings, storage: storage) {
         case .failure(let reason):
             return reason
         case .model(let modelURL):

--- a/LokalBot/Services/AudioSourceMonitor.swift
+++ b/LokalBot/Services/AudioSourceMonitor.swift
@@ -148,13 +148,13 @@ final class AudioSourceMonitor: ObservableObject {
     // MARK: - Private
 
     private func seedCurrentState() {
-        let processes = (try? CoreAudioUtils.listAudioProcesses()) ?? []
+        let processes = MeetingDetector.currentAudioProcesses()
         knownActiveObjectIDs = Set(processes.filter(\.isRunningOutput).map(\.objectID))
     }
 
     private func poll() {
         guard !isRecordingActive else { return }
-        let processes = (try? CoreAudioUtils.listAudioProcesses()) ?? []
+        let processes = MeetingDetector.currentAudioProcesses()
         let active = processes.filter(\.isRunningOutput)
         let activeIDs = Set(active.map(\.objectID))
 

--- a/LokalBot/Services/EmbeddingIndex.swift
+++ b/LokalBot/Services/EmbeddingIndex.swift
@@ -1,6 +1,87 @@
 import Foundation
 import SQLite3
 
+/// Coalesces expensive embedding-model preparation by destination. Waiters
+/// can cancel independently; the shared operation is canceled only after its
+/// final waiter leaves, so one abandoned search cannot break active indexing.
+actor EmbeddingModelPreparationCoordinator {
+    typealias Operation = @Sendable () async throws -> URL
+
+    private struct Flight {
+        let id: UUID
+        let task: Task<URL, Error>
+        var waiters: [UUID: CheckedContinuation<URL, Error>]
+    }
+
+    private var flights: [String: Flight] = [:]
+
+    func prepare(key: String, operation: @escaping Operation) async throws -> URL {
+        let waiterID = UUID()
+        return try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            return try await withCheckedThrowingContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                enqueue(
+                    waiterID: waiterID,
+                    key: key,
+                    operation: operation,
+                    continuation: continuation)
+            }
+        } onCancel: {
+            Task { await self.cancel(waiterID: waiterID, key: key) }
+        }
+    }
+
+    func waiterCount(for key: String) -> Int {
+        flights[key]?.waiters.count ?? 0
+    }
+
+    private func enqueue(
+        waiterID: UUID,
+        key: String,
+        operation: @escaping Operation,
+        continuation: CheckedContinuation<URL, Error>
+    ) {
+        if var flight = flights[key] {
+            flight.waiters[waiterID] = continuation
+            flights[key] = flight
+            return
+        }
+        let flightID = UUID()
+        let task = Task { try await operation() }
+        flights[key] = Flight(
+            id: flightID,
+            task: task,
+            waiters: [waiterID: continuation])
+        Task { [weak self] in
+            let result = await task.result
+            await self?.finish(key: key, flightID: flightID, result: result)
+        }
+    }
+
+    private func cancel(waiterID: UUID, key: String) {
+        guard var flight = flights[key],
+              let continuation = flight.waiters.removeValue(forKey: waiterID) else { return }
+        continuation.resume(throwing: CancellationError())
+        // Keep the preparation flight alive even when its current waiter set
+        // becomes empty. Download/install cancellation is not guaranteed to be
+        // instantaneous; retaining the flight lets a later caller rejoin it
+        // instead of racing a second install against a still-unwinding first.
+        flights[key] = flight
+    }
+
+    private func finish(key: String, flightID: UUID, result: Result<URL, Error>) {
+        guard let flight = flights[key], flight.id == flightID else { return }
+        flights[key] = nil
+        for continuation in flight.waiters.values {
+            continuation.resume(with: result)
+        }
+    }
+}
+
 /// M6 semantic layer (design §4.1): transcript/summary chunks embedded with
 /// Qwen3-Embedding 0.6B GGUF, served by the second llama-server instance.
 /// Vectors live in SQLite; query = brute-force cosine (normalized dot) —
@@ -8,7 +89,7 @@ import SQLite3
 @MainActor
 final class EmbeddingIndex {
 
-    struct Hit: Identifiable {
+    struct Hit: Identifiable, Sendable {
         let id = UUID()
         let meetingID: UUID
         let start: TimeInterval
@@ -17,19 +98,21 @@ final class EmbeddingIndex {
     }
 
     private static let modelID = "qwen3-embedding-0.6b-q8"
-    private static let modelFile = "Qwen3-Embedding-0.6B-Q8_0.gguf"
-    private static let modelBytes: Int64 = 639_150_592
-    private static let modelSHA256 = "06507c7b42688469c4e7298b0a1e16deff06caf291cf0a5b278c308249c3e439"
-    private static let modelURL =
+    nonisolated private static let modelFile = "Qwen3-Embedding-0.6B-Q8_0.gguf"
+    nonisolated private static let modelBytes: Int64 = 639_150_592
+    nonisolated private static let modelSHA256 = "06507c7b42688469c4e7298b0a1e16deff06caf291cf0a5b278c308249c3e439"
+    nonisolated private static let modelURL =
         "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/370f27d7550e0def9b39c1f16d3fbaa13aa67728/Qwen3-Embedding-0.6B-Q8_0.gguf"
     private static let documentPrefix = "Document for meeting search: "
     private static let queryPrefix = """
         Instruct: Retrieve relevant meeting transcript and summary chunks for the user's query.
         Query:
         """
+    private static let modelPreparation = EmbeddingModelPreparationCoordinator()
 
     private let database: SQLiteDatabase?
     private let storage: StorageManager
+    private var locallyDeletedMeetingIDs: Set<UUID> = []
 
     init(databaseURL: URL, storage: StorageManager) {
         self.storage = storage
@@ -43,8 +126,17 @@ final class EmbeddingIndex {
                 model_id TEXT NOT NULL DEFAULT '');
             CREATE INDEX IF NOT EXISTS idx_embeddings_meeting_id
                 ON embeddings(meeting_id);
+            CREATE TABLE IF NOT EXISTS deleted_meetings (
+                meeting_id TEXT PRIMARY KEY,
+                deleted_at REAL NOT NULL
+            );
             """)
-        database?.exec("ALTER TABLE embedded_meetings ADD COLUMN model_id TEXT NOT NULL DEFAULT '';")
+        if database?.hasRow(
+            "SELECT 1 FROM pragma_table_info('embedded_meetings') WHERE name = 'model_id'"
+        ) == false {
+            database?.exec(
+                "ALTER TABLE embedded_meetings ADD COLUMN model_id TEXT NOT NULL DEFAULT '';")
+        }
         if let database {
             database.transaction {
                 database.run("""
@@ -58,18 +150,24 @@ final class EmbeddingIndex {
                     bind: [Self.modelID])
             }
         }
+        _ = reconcileDeletedMeetings()
     }
 
     // MARK: - Indexing
 
     func reindexAll(_ meetings: [Meeting]) async {
         for meeting in meetings {
+            guard !Task.isCancelled else { return }
             try? await index(meeting)
         }
     }
 
     func index(_ meeting: Meeting) async throws {
+        guard !isDeleted(meeting.id) else { return }
         let folder = meeting.folderURL(in: storage)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: folder.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else { return }
         let mtime = ["transcript.json", "summary.md"].compactMap {
             (try? FileManager.default.attributesOfItem(
                 atPath: folder.appendingPathComponent($0).path))?[.modificationDate] as? Date
@@ -101,6 +199,7 @@ final class EmbeddingIndex {
 
         let vectors = try await Self.embed(chunks.map(\.text), prefix: Self.documentPrefix,
                                            storage: storage)
+        try Task.checkCancellation()
         guard vectors.count == chunks.count else {
             throw TextEngineError.badResponse(
                 "embedding response contained \(vectors.count) vectors for \(chunks.count) chunks")
@@ -116,6 +215,24 @@ final class EmbeddingIndex {
         guard let database else { return }
         let meetingID = meeting.id.uuidString
         database.transaction {
+            do {
+                guard try !database.hasRowChecked(
+                    "SELECT 1 FROM deleted_meetings WHERE meeting_id = ?1",
+                    bind: [meetingID]),
+                      FileManager.default.fileExists(atPath: folder.path) else { return true }
+                // Embedding can suspend for minutes. Recheck freshness under
+                // BEGIN IMMEDIATE so an older request cannot replace a newer
+                // snapshot after it finally receives vectors.
+                if let indexed = try database.firstDoubleChecked(
+                    """
+                    SELECT source_mtime FROM embedded_meetings
+                    WHERE meeting_id = ?1 AND model_id = ?2
+                    """, bind: [meetingID, Self.modelID]), indexed >= mtime {
+                    return true
+                }
+            } catch {
+                return false
+            }
             guard database.run(
                 "DELETE FROM embeddings WHERE meeting_id = ?1",
                 bind: [meetingID]) else { return false }
@@ -136,44 +253,136 @@ final class EmbeddingIndex {
         }
     }
 
-    func remove(_ meetingID: UUID) {
-        guard let database else { return }
-        let id = meetingID.uuidString
-        database.transaction {
-            database.run("DELETE FROM embeddings WHERE meeting_id = ?1", bind: [id])
-                && database.run(
-                    "DELETE FROM embedded_meetings WHERE meeting_id = ?1",
-                    bind: [id])
-        }
+    @discardableResult
+    func remove(_ meetingID: UUID) -> Bool {
+        noteDeletion(meetingID)
+        guard let database else { return false }
+        return Self.remove(meetingID, in: database)
+    }
+
+    /// Immediately closes the async rank/delete race without waiting for a
+    /// potentially busy SQLite writer. AppState follows this in-memory marker
+    /// with durable utility-worker cleanup.
+    func noteDeletion(_ meetingID: UUID) {
+        locallyDeletedMeetingIDs.insert(meetingID)
+    }
+
+    /// Utility-worker entry point used by AppState deletion. It deliberately
+    /// opens its own FULLMUTEX connection so SQLite's busy timeout can never
+    /// stall the main actor.
+    @discardableResult
+    nonisolated static func remove(_ meetingID: UUID, databaseURL: URL) -> Bool {
+        guard let database = SQLiteDatabase(url: databaseURL) else { return false }
+        return remove(meetingID, in: database)
+    }
+
+    /// Completes cleanup for tombstones whose original deletion was
+    /// interrupted. The tombstone remains the source of truth and query paths
+    /// exclude it while these reconstructible rows are being removed.
+    @discardableResult
+    func reconcileDeletedMeetings() -> Bool {
+        guard let database else { return false }
+        return Self.reconcileDeletedMeetings(in: database)
+    }
+
+    @discardableResult
+    nonisolated static func reconcileDeletedMeetings(databaseURL: URL) -> Bool {
+        guard let database = SQLiteDatabase(url: databaseURL) else { return false }
+        return reconcileDeletedMeetings(in: database)
     }
 
     // MARK: - Query
 
     var hasEmbeddings: Bool {
-        database?.hasRow("SELECT 1 FROM embeddings LIMIT 1") ?? false
+        database?.hasRow("""
+            SELECT 1 FROM embeddings
+            WHERE NOT EXISTS (
+                SELECT 1 FROM deleted_meetings AS deleted
+                WHERE deleted.meeting_id = embeddings.meeting_id
+            )
+            LIMIT 1
+            """) ?? false
     }
 
     func search(_ query: String, limit: Int = 10) async -> [Hit] {
-        guard let database, hasEmbeddings else { return [] }
+        guard limit > 0, let database, hasEmbeddings else { return [] }
         guard let queryVector = try? await Self.embed([query], prefix: Self.queryPrefix,
                                                       storage: storage).first else { return [] }
-        let hits: [Hit] = database.query("SELECT meeting_id, start, text, vec FROM embeddings") { statement in
+        let candidates: [Candidate] = database.query(
+            """
+            SELECT meeting_id, start, text, vec FROM embeddings
+            WHERE NOT EXISTS (
+                SELECT 1 FROM deleted_meetings AS deleted
+                WHERE deleted.meeting_id = embeddings.meeting_id
+            )
+            """
+        ) { statement in
             guard let idText = sqlite3_column_text(statement, 0),
                   let meetingID = UUID(uuidString: String(cString: idText)),
+                  let text = sqlite3_column_text(statement, 2),
                   let blob = sqlite3_column_blob(statement, 3) else { return nil }
-            let count = Int(sqlite3_column_bytes(statement, 3)) / 4
-            guard count == queryVector.count else { return nil }
-            let vector = blob.withMemoryRebound(to: Float.self, capacity: count) {
-                Array(UnsafeBufferPointer(start: $0, count: count))
-            }
-            let score = zip(queryVector, vector).reduce(Float(0)) { $0 + $1.0 * $1.1 }
-            guard score > 0.45 else { return nil }
-            return Hit(meetingID: meetingID,
-                       start: sqlite3_column_double(statement, 1),
-                       text: String(cString: sqlite3_column_text(statement, 2)),
-                       score: score)
+            let byteCount = Int(sqlite3_column_bytes(statement, 3))
+            guard byteCount == queryVector.count * MemoryLayout<Float>.stride else { return nil }
+            return Candidate(
+                meetingID: meetingID,
+                start: sqlite3_column_double(statement, 1),
+                text: String(cString: text),
+                vector: Data(bytes: blob, count: byteCount))
         }
-        return Array(hits.sorted { $0.score > $1.score }.prefix(limit))
+        let ranked = await Task.detached(priority: .userInitiated) {
+            Self.rank(candidates, against: queryVector, limit: limit)
+        }.value
+        guard !Task.isCancelled else { return [] }
+        // Ranking yields the main actor. A meeting can be deleted after the
+        // candidate snapshot but before ranking completes, so validate again
+        // synchronously before publishing any hit.
+        return liveHits(from: ranked)
+    }
+
+    func liveHits(from hits: [Hit]) -> [Hit] {
+        hits.filter { !isDeleted($0.meetingID) }
+    }
+
+    private struct Candidate: Sendable {
+        let meetingID: UUID
+        let start: TimeInterval
+        let text: String
+        let vector: Data
+    }
+
+    /// Cosine scoring is the expensive part of brute-force retrieval. Keep it
+    /// off the main actor and retain only the best `limit` rows instead of
+    /// allocating and sorting a hit for every embedding in the library.
+    nonisolated private static func rank(
+        _ candidates: [Candidate],
+        against queryVector: [Float],
+        limit: Int
+    ) -> [Hit] {
+        var best: [Hit] = []
+        best.reserveCapacity(limit)
+
+        for candidate in candidates {
+            let score: Float = candidate.vector.withUnsafeBytes { bytes in
+                var total: Float = 0
+                for index in queryVector.indices {
+                    let value = bytes.loadUnaligned(
+                        fromByteOffset: index * MemoryLayout<Float>.stride,
+                        as: Float.self)
+                    total += queryVector[index] * value
+                }
+                return total
+            }
+            guard score > 0.45 else { continue }
+            let hit = Hit(meetingID: candidate.meetingID, start: candidate.start,
+                          text: candidate.text, score: score)
+            if best.count < limit {
+                best.append(hit)
+            } else if let weakest = best.indices.min(by: { best[$0].score < best[$1].score }),
+                      score > best[weakest].score {
+                best[weakest] = hit
+            }
+        }
+        return best.sorted { $0.score > $1.score }
     }
 
     // MARK: - Embedding via llama-server
@@ -188,6 +397,8 @@ final class EmbeddingIndex {
                 .appendingPathComponent("embeddings"))
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let authenticationToken = await LlamaServer.embedder.authenticationToken()
+            request.setValue("Bearer \(authenticationToken)", forHTTPHeaderField: "Authorization")
             request.timeoutInterval = 120
             request.httpBody = try JSONSerialization.data(withJSONObject: [
                 "input": texts.map { prefix + $0 },
@@ -208,7 +419,16 @@ final class EmbeddingIndex {
     }
 
     private static func ensureModel(storage: StorageManager) async throws -> URL {
-        let folder = storage.rootURL.appendingPathComponent("models", isDirectory: true)
+        let storageRoot = storage.rootURL
+        let key = storageRoot.appendingPathComponent("models/\(modelFile)")
+            .standardizedFileURL.resolvingSymlinksInPath().path
+        return try await modelPreparation.prepare(key: key) {
+            try await prepareModel(storageRoot: storageRoot)
+        }
+    }
+
+    private nonisolated static func prepareModel(storageRoot: URL) async throws -> URL {
+        let folder = storageRoot.appendingPathComponent("models", isDirectory: true)
         let path = folder.appendingPathComponent(modelFile)
         if ModelFileValidator.looksLikeGGUF(path),
            await DownloadIntegrity.verifiedExisting(
@@ -241,5 +461,66 @@ final class EmbeddingIndex {
         database?.firstDouble(
             "SELECT source_mtime FROM embedded_meetings WHERE meeting_id = ?1 AND model_id = ?2",
             bind: [id.uuidString, Self.modelID])
+    }
+
+    private func isDeleted(_ id: UUID) -> Bool {
+        if locallyDeletedMeetingIDs.contains(id) { return true }
+        guard let database else { return true }
+        return (try? database.hasRowChecked(
+            "SELECT 1 FROM deleted_meetings WHERE meeting_id = ?1",
+            bind: [id.uuidString])) != false
+    }
+
+    nonisolated private static func remove(_ meetingID: UUID,
+                                           in database: SQLiteDatabase) -> Bool {
+        let id = meetingID.uuidString
+        let marked = database.transaction {
+            database.run(
+                "INSERT OR IGNORE INTO deleted_meetings (meeting_id, deleted_at) VALUES (?1, ?2)",
+                bind: [id, Date().timeIntervalSince1970])
+        }
+        guard marked else { return false }
+        guard let tables = cleanupTablePresence(in: database) else { return false }
+        return database.transaction {
+            (!tables.embeddings
+             || database.run("DELETE FROM embeddings WHERE meeting_id = ?1", bind: [id]))
+                && (!tables.meetings
+                    || database.run(
+                        "DELETE FROM embedded_meetings WHERE meeting_id = ?1",
+                        bind: [id]))
+        }
+    }
+
+    nonisolated private static func reconcileDeletedMeetings(
+        in database: SQLiteDatabase
+    ) -> Bool {
+        guard let tables = cleanupTablePresence(in: database) else { return false }
+        return database.transaction {
+            (!tables.embeddings
+             || database.run("""
+                 DELETE FROM embeddings
+                 WHERE meeting_id IN (SELECT meeting_id FROM deleted_meetings)
+                 """))
+                && (!tables.meetings
+                    || database.run("""
+                        DELETE FROM embedded_meetings
+                        WHERE meeting_id IN (SELECT meeting_id FROM deleted_meetings)
+                        """))
+        }
+    }
+
+    nonisolated private static func cleanupTablePresence(
+        in database: SQLiteDatabase
+    ) -> (embeddings: Bool, meetings: Bool)? {
+        do {
+            return (
+                try database.hasRowChecked(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'embeddings'"),
+                try database.hasRowChecked(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'embedded_meetings'")
+            )
+        } catch {
+            return nil
+        }
     }
 }

--- a/LokalBot/Services/FileLogHandler.swift
+++ b/LokalBot/Services/FileLogHandler.swift
@@ -122,20 +122,14 @@ struct FileLogHandler: LogHandler {
         set { metadata[key] = newValue }
     }
 
-    func log(
-        level: Logging.Logger.Level,
-        message: Logging.Logger.Message,
-        metadata explicitMetadata: Logging.Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
+    func log(event: Logging.LogEvent) {
         let timestamp = Self.timestampFormatter.string(from: Date())
         let category = Self.shortCategory(from: label)
-        let merged = Self.merge(base: metadata, explicit: explicitMetadata)
+        let merged = Self.merge(base: metadata, explicit: event.metadata)
         let suffix = merged.isEmpty ? "" : " " + Self.render(merged)
-        sink.write("\(timestamp) \(level.rawValue.uppercased()) [\(category)] \(message)\(suffix)\n")
+        sink.write(
+            "\(timestamp) \(event.level.rawValue.uppercased()) "
+                + "[\(category)] \(event.message)\(suffix)\n")
     }
 
     /// `me.dotenv.LokalBot.networking` → `networking`. The trailing dot-segment

--- a/LokalBot/Services/HuggingFace/HuggingFaceAPIClient.swift
+++ b/LokalBot/Services/HuggingFace/HuggingFaceAPIClient.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// Stateless client for HuggingFace's public model REST API. Holds one
@@ -71,23 +72,32 @@ struct HuggingFaceAPIClient {
 
     /// List the `.gguf` files in a repository.
     ///
-    /// Reads the plain model record's `siblings`, which carry only `rfilename`
-    /// (no blob metadata) — hence `HFFile.sizeBytes` is usually nil here. Files
-    /// are returned in natural filename order so quantization variants group
-    /// sensibly in the UI.
+    /// Requests blob metadata so every downloadable file carries its immutable
+    /// LFS SHA-256 and can satisfy ModelDownloadManager's integrity policy.
+    /// Files are returned in natural filename order so quantization variants
+    /// group sensibly in the UI.
     func files(modelID: String) async throws -> [HFFile] {
+        guard Self.validModelID(modelID) else { throw APIError.invalidURL }
         var components = URLComponents()
         components.scheme = "https"
         components.host = "huggingface.co"
         // modelID is "owner/repo"; its slash is a real path separator, so set it
         // via `path` (URLComponents percent-encodes only the unsafe characters).
         components.path = "/api/models/\(modelID)"
+        components.queryItems = [URLQueryItem(name: "blobs", value: "true")]
         guard let url = components.url else { throw APIError.invalidURL }
 
         let record = try await fetch(ModelRecord.self, from: url)
         return record.siblings
             .filter { $0.rfilename.lowercased().hasSuffix(".gguf") }
-            .map { HFFile(id: $0.rfilename, modelID: modelID, sizeBytes: $0.size) }
+            .map {
+                HFFile(
+                    id: $0.rfilename,
+                    modelID: modelID,
+                    sizeBytes: $0.lfs?.size ?? $0.size,
+                    revision: record.sha ?? "main",
+                    sha256: Self.normalizedSHA256($0.lfs?.sha256 ?? $0.lfs?.oid))
+            }
             .sorted { $0.id.localizedStandardCompare($1.id) == .orderedAscending }
     }
 
@@ -127,13 +137,37 @@ struct HuggingFaceAPIClient {
     /// and less likely to hit shared rate limits.
     private static let userAgent = AppIdentifiers.bundleID
 
+    private static func validModelID(_ id: String) -> Bool {
+        let parts = id.split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return false }
+        return parts.allSatisfy { part in
+            !part.isEmpty && part != "." && part != ".."
+                && part.allSatisfy { $0.isLetter || $0.isNumber || "-_.".contains($0) }
+        }
+    }
+
+    private static func normalizedSHA256(_ oid: String?) -> String? {
+        guard var oid = oid?.lowercased() else { return nil }
+        if oid.hasPrefix("sha256:") { oid.removeFirst("sha256:".count) }
+        guard oid.count == 64, oid.allSatisfy({ $0.isHexDigit }) else { return nil }
+        return oid
+    }
+
     /// Wire shape of `GET /api/models/<id>` — only `siblings` is consumed; the
     /// many other keys are ignored by `JSONDecoder`.
     private struct ModelRecord: Decodable {
+        let sha: String?
         let siblings: [Sibling]
 
         struct Sibling: Decodable {
             let rfilename: String
+            let size: Int?
+            let lfs: LFS?
+        }
+
+        struct LFS: Decodable {
+            let sha256: String?
+            let oid: String?
             let size: Int?
         }
     }
@@ -175,9 +209,21 @@ struct HFFile: Identifiable, Hashable {
     let id: String
     /// Owning repository id (`owner/repo`); needed to build the resolve URL.
     let modelID: String
-    /// Byte size when the API reports it; nil from the plain model endpoint,
-    /// whose `siblings` omit blob metadata.
+    /// Byte size reported by the blob-enabled model endpoint.
     let sizeBytes: Int?
+    /// Immutable repository commit returned by the model API.
+    let revision: String
+    /// Hugging Face LFS object digest, when advertised by the API.
+    let sha256: String?
+
+    init(id: String, modelID: String, sizeBytes: Int?,
+         revision: String = "main", sha256: String? = nil) {
+        self.id = id
+        self.modelID = modelID
+        self.sizeBytes = sizeBytes
+        self.revision = revision
+        self.sha256 = sha256
+    }
 
     /// Direct download URL on HuggingFace's `resolve` endpoint. `URLSession`
     /// follows the CDN redirect automatically, so this is usable as-is by a
@@ -187,7 +233,12 @@ struct HFFile: Identifiable, Hashable {
         var components = URLComponents()
         components.scheme = "https"
         components.host = "huggingface.co"
-        components.path = "/\(modelID)/resolve/main/\(id)"
+        components.path = "/\(modelID)/resolve/\(revision)/\(id)"
+        // URL fragments are never sent to the server. ModelDownloadManager
+        // consumes this integrity hint before constructing its network URL,
+        // so existing UI plumbing carries the LFS digest without a parallel
+        // mutable lookup table.
+        if let sha256 { components.fragment = "sha256=\(sha256)" }
         // `url` is nil only for a malformed scheme/host, both constants here, so
         // the literal fallback is unreachable in practice.
         return components.url ?? URL(string: "https://huggingface.co")!
@@ -196,7 +247,14 @@ struct HFFile: Identifiable, Hashable {
     /// Leaf filename — repos sometimes nest files (e.g. `gguf/model.gguf`), and
     /// downloads should land flat under `<storage>/models/`.
     var fileName: String {
-        (id as NSString).lastPathComponent
+        let leaf = (id as NSString).lastPathComponent
+            .map { character -> Character in
+                character.isLetter || character.isNumber || "-_.".contains(character)
+                    ? character : "_"
+            }
+        let digest = SHA256.hash(data: Data("\(modelID)/\(id)".utf8))
+            .prefix(6).map { String(format: "%02x", $0) }.joined()
+        return "hf-\(digest)-\(String(leaf).suffix(180))"
     }
 
     /// Human-readable size, or nil when the endpoint didn't report one.

--- a/LokalBot/Services/LiveMeetingTranscriber.swift
+++ b/LokalBot/Services/LiveMeetingTranscriber.swift
@@ -14,9 +14,9 @@ enum LiveMeetingAudioPreparation: Equatable, Sendable {
 }
 
 /// Serializes the filesystem and PCM work for both live meeting tracks away
-/// from the main actor. `prepareNextChunk` has no suspension points, so one
-/// track's snapshot/read/cut/VAD/write transaction cannot interleave with the
-/// other track's temporary files or audio buffers.
+/// from the main actor. The source CAF is append-safe, so preparation opens a
+/// point-in-time reader and seeks directly to the unprocessed suffix; it never
+/// copies the full, ever-growing meeting file.
 actor LiveMeetingAudioPreparationWorker {
     private let storageRoot: URL
 
@@ -30,10 +30,8 @@ actor LiveMeetingAudioPreparationWorker {
         guard FileManager.default.fileExists(atPath: source.path) else { return .noWork }
 
         // Opening the append-only CAF just long enough to inspect its current
-        // readable frame count is much cheaper than copying the whole growing
-        // recording every time the poller wakes before four fresh seconds are
-        // available. If the live header is momentarily unreadable, fall back to
-        // the established snapshot path rather than treating it as a failure.
+        // readable frame count avoids allocating a chunk before four fresh
+        // seconds are available.
         if let availability = try? Self.availableAudio(at: source),
            LiveTranscriptChunker.nextChunk(
                processedFrames: processedFrames,
@@ -43,13 +41,7 @@ actor LiveMeetingAudioPreparationWorker {
         }
 
         try Task.checkCancellation()
-        let scratch = try scratchDirectory()
-        let snapshot = scratch.appendingPathComponent("snap-\(UUID().uuidString).caf")
-        try FileManager.default.copyItem(at: source, to: snapshot)
-        defer { try? FileManager.default.removeItem(at: snapshot) }
-
-        try Task.checkCancellation()
-        let reader = try AVAudioFile(forReading: snapshot)
+        let reader = try AVAudioFile(forReading: source)
         let sampleRate = reader.fileFormat.sampleRate
         guard let range = LiveTranscriptChunker.nextChunk(
             processedFrames: processedFrames,
@@ -89,7 +81,8 @@ actor LiveMeetingAudioPreparationWorker {
             return .advance(toFrame: chunkEnd)
         }
 
-        let chunk = scratch.appendingPathComponent("chunk-\(UUID().uuidString).caf")
+        let chunk = try scratchDirectory()
+            .appendingPathComponent("chunk-\(UUID().uuidString).caf")
         var keepChunk = false
         defer {
             if !keepChunk { try? FileManager.default.removeItem(at: chunk) }

--- a/LokalBot/Services/MediaPlaybackController.swift
+++ b/LokalBot/Services/MediaPlaybackController.swift
@@ -1,54 +1,104 @@
 import AppKit
+import Darwin
 import Foundation
-import IOKit
 
+/// Pauses media that was actively playing when dictation begins and resumes
+/// exactly that media when the dictation capture ends. AppleScript work runs in
+/// short-lived helper processes off the main actor and is forcibly bounded so
+/// an unresponsive media app can never delay push-to-talk indefinitely.
 enum MediaPlaybackController {
-    @MainActor
-    @discardableResult
-    static func pauseActiveMediaPlayers(reason: String) -> [String] {
+    struct PauseSession: Sendable {
+        fileprivate let targets: [PausedTarget]
+
+        var isEmpty: Bool { targets.isEmpty }
+        var processNames: [String] {
+            Array(Set(targets.flatMap(\.processNames))).sorted()
+        }
+    }
+
+    private struct PauseTarget: Sendable {
+        let controlBundleID: String
+        var processNames: Set<String> = []
+    }
+
+    fileprivate struct PausedTarget: Sendable {
+        let controlBundleID: String
+        let processNames: [String]
+        /// Opaque state returned by the pause script. QuickTime uses document
+        /// names; browsers use a per-dictation DOM marker token.
+        let resumeToken: String
+    }
+
+    static func pauseActiveMediaPlayers(reason: String) async -> PauseSession {
         let targets = activePauseTargets()
-        guard !targets.isEmpty else { return [] }
+        guard !targets.isEmpty else { return PauseSession(targets: []) }
 
-        let runningBundleIDs = Set(NSWorkspace.shared.runningApplications.compactMap(\.bundleIdentifier))
-        var paused: Set<String> = []
-
-        if targets.contains(where: \.requiresMediaKeyFallback),
-           postPlayPauseMediaKey() {
-            for target in targets where target.requiresMediaKeyFallback {
-                paused.formUnion(target.processNames)
+        let runningBundleIDs = await MainActor.run {
+            Set(NSWorkspace.shared.runningApplications.compactMap(\.bundleIdentifier))
+        }
+        let token = UUID().uuidString
+        let paused = await withTaskGroup(of: PausedTarget?.self) { group in
+            for target in targets where runningBundleIDs.contains(target.controlBundleID) {
+                group.addTask {
+                    guard let script = pauseScript(
+                        for: target.controlBundleID,
+                        browserMarker: token),
+                          let result = await runAppleScript(script),
+                          !result.isEmpty,
+                          result != "false",
+                          result != "0" else { return nil }
+                    return PausedTarget(
+                        controlBundleID: target.controlBundleID,
+                        processNames: target.processNames.sorted(),
+                        resumeToken: result == "browser" ? token : result)
+                }
             }
-        }
-
-        for target in targets {
-            guard runningBundleIDs.contains(target.controlBundleID),
-                  pauseScript(for: target.controlBundleID) != nil else { continue }
-            if runPauseScript(for: target.controlBundleID) {
-                paused.formUnion(target.processNames)
+            var result: [PausedTarget] = []
+            for await target in group {
+                if let target { result.append(target) }
             }
+            return result
         }
 
-        let names = paused.sorted()
-        if !names.isEmpty {
-            lokalbotLog("media paused for \(reason): \(names.joined(separator: ", "))")
+        let session = PauseSession(targets: paused)
+        if !session.isEmpty {
+            lokalbotLog(
+                "media paused for \(reason): \(session.processNames.joined(separator: ", "))")
         }
-        return names
+        return session
+    }
+
+    static func resume(_ session: PauseSession, reason: String) async {
+        guard !session.isEmpty else { return }
+        await withTaskGroup(of: Void.self) { group in
+            for target in session.targets {
+                group.addTask {
+                    guard let script = resumeScript(
+                        for: target.controlBundleID,
+                        token: target.resumeToken) else { return }
+                    _ = await runAppleScript(script)
+                }
+            }
+            await group.waitForAll()
+        }
+        lokalbotLog(
+            "media resumed after \(reason): \(session.processNames.joined(separator: ", "))")
     }
 
     private static func activePauseTargets() -> [PauseTarget] {
-        let processes = (try? CoreAudioUtils.listAudioProcesses()) ?? []
+        let processes = MeetingDetector.currentAudioProcesses()
         var targetsByBundleID: [String: PauseTarget] = [:]
 
         for process in processes {
             guard process.isRunningOutput,
                   let bundleID = process.bundleID,
-                  let controlBundleID = controllableMediaBundleID(forAudioBundleID: bundleID)
+                  let controlBundleID = controllableMediaBundleID(forAudioBundleID: bundleID),
+                  pauseScript(for: controlBundleID, browserMarker: "probe") != nil
             else { continue }
 
             var target = targetsByBundleID[controlBundleID]
                 ?? PauseTarget(controlBundleID: controlBundleID)
             target.processNames.insert(process.name)
-            target.requiresMediaKeyFallback = target.requiresMediaKeyFallback
-                || requiresMediaKeyFallback(controlBundleID: controlBundleID)
             targetsByBundleID[controlBundleID] = target
         }
 
@@ -67,125 +117,304 @@ enum MediaPlaybackController {
 
     private static func mediaHostBundleID(forAudioBundleID bundleID: String) -> String? {
         if AudioSourceMonitor.isMediaPlayer(bundleID) { return bundleID }
-
-        let normalizedBundleID = bundleID.lowercased()
-        return AudioSourceMonitor.mediaBundleIDs.first { mediaBundleID in
-            normalizedBundleID.hasPrefix("\(mediaBundleID.lowercased()).")
+        let normalized = bundleID.lowercased()
+        return AudioSourceMonitor.mediaBundleIDs.first {
+            normalized.hasPrefix("\($0.lowercased()).")
         }
     }
 
-    private static func requiresMediaKeyFallback(controlBundleID: String) -> Bool {
-        MeetingDetector.browsers.contains(controlBundleID)
-            || pauseScript(for: controlBundleID) == nil
-    }
-
-    private static func runPauseScript(for bundleID: String) -> Bool {
-        guard let source = pauseScript(for: bundleID),
-              let script = NSAppleScript(source: source) else {
-            return false
-        }
-        var error: NSDictionary?
-        script.executeAndReturnError(&error)
-        if let error {
-            lokalbotLog("media pause failed bundle=\(bundleID) error=\(error)")
-            return false
-        }
-        return true
-    }
-
-    private static func postPlayPauseMediaKey() -> Bool {
-        let keyCode = NX_KEYTYPE_PLAY
-        let keyDownData = (keyCode << 16) | (0xA << 8)
-        let keyUpData = (keyCode << 16) | (0xB << 8)
-
-        guard let keyDown = mediaKeyEvent(data1: keyDownData)?.cgEvent,
-              let keyUp = mediaKeyEvent(data1: keyUpData)?.cgEvent else {
-            return false
-        }
-
-        keyDown.post(tap: .cghidEventTap)
-        keyUp.post(tap: .cghidEventTap)
-        return true
-    }
-
-    private static func mediaKeyEvent(data1: Int32) -> NSEvent? {
-        NSEvent.otherEvent(
-            with: .systemDefined,
-            location: .zero,
-            modifierFlags: NSEvent.ModifierFlags(rawValue: UInt(0xA00)),
-            timestamp: 0,
-            windowNumber: 0,
-            context: nil,
-            subtype: Int16(NX_SUBTYPE_AUX_CONTROL_BUTTONS),
-            data1: Int(data1),
-            data2: -1)
-    }
-
-    private static func pauseScript(for bundleID: String) -> String? {
+    private static func pauseScript(for bundleID: String, browserMarker: String) -> String? {
         switch bundleID {
         case "com.spotify.client":
-            """
-            tell application id "com.spotify.client"
-                if player state is playing then pause
-            end tell
-            """
-        case "com.apple.Music",
-             "com.apple.iTunes",
-             "com.apple.podcasts",
-             "com.apple.TV",
-             "org.videolan.vlc":
-            """
-            tell application id "\(bundleID)" to pause
-            """
+            return playerPauseScript(bundleID: bundleID, stateExpression: "player state is playing")
+        case "com.apple.Music", "com.apple.iTunes", "com.apple.podcasts", "com.apple.TV":
+            return playerPauseScript(bundleID: bundleID, stateExpression: "player state is playing")
+        case "org.videolan.vlc":
+            return playerPauseScript(bundleID: bundleID, stateExpression: "playing")
         case "com.apple.QuickTimePlayerX":
-            """
+            return """
             tell application id "com.apple.QuickTimePlayerX"
+                set pausedNames to {}
                 repeat with openMovie in documents
                     try
-                        pause openMovie
+                        if playing of openMovie then
+                            set end of pausedNames to name of openMovie
+                            pause openMovie
+                        end if
+                    end try
+                end repeat
+                set AppleScript's text item delimiters to ASCII character 30
+                return pausedNames as text
+            end tell
+            """
+        case "com.google.Chrome", "com.microsoft.edgemac", "com.brave.Browser",
+             "company.thebrowser.Browser":
+            return chromiumPauseScript(bundleID: bundleID, marker: browserMarker)
+        case "com.apple.Safari":
+            return safariPauseScript(marker: browserMarker)
+        default:
+            return nil
+        }
+    }
+
+    private static func resumeScript(for bundleID: String, token: String) -> String? {
+        switch bundleID {
+        case "com.spotify.client", "com.apple.Music", "com.apple.iTunes",
+             "com.apple.podcasts", "com.apple.TV", "org.videolan.vlc":
+            return "tell application id \"\(bundleID)\" to play"
+        case "com.apple.QuickTimePlayerX":
+            let names = token.split(separator: Character(UnicodeScalar(30)))
+                .map { "\"\(appleScriptEscaped(String($0)))\"" }
+                .joined(separator: ", ")
+            guard !names.isEmpty else { return nil }
+            return """
+            tell application id "com.apple.QuickTimePlayerX"
+                set targetNames to {\(names)}
+                repeat with openMovie in documents
+                    try
+                        if targetNames contains (name of openMovie) then play openMovie
                     end try
                 end repeat
             end tell
             """
-        case "com.google.Chrome",
-             "com.microsoft.edgemac",
-             "com.brave.Browser",
+        case "com.google.Chrome", "com.microsoft.edgemac", "com.brave.Browser",
              "company.thebrowser.Browser":
-            """
-            tell application id "\(bundleID)"
-                repeat with browserWindow in windows
-                    repeat with browserTab in tabs of browserWindow
-                        try
-                            execute browserTab javascript "\(pauseHTMLMediaJavaScript)"
-                        end try
-                    end repeat
-                end repeat
-            end tell
-            """
+            return chromiumResumeScript(bundleID: bundleID, marker: token)
         case "com.apple.Safari":
-            """
-            tell application id "com.apple.Safari"
-                repeat with browserWindow in windows
-                    repeat with browserTab in tabs of browserWindow
-                        try
-                            do JavaScript "\(pauseHTMLMediaJavaScript)" in browserTab
-                        end try
-                    end repeat
-                end repeat
-            end tell
-            """
+            return safariResumeScript(marker: token)
         default:
-            nil
+            return nil
         }
     }
 
-    private static let pauseHTMLMediaJavaScript = """
-    (() => { for (const node of document.querySelectorAll('audio, video')) { try { node.pause(); } catch (_) {} } })()
-    """
+    private static func playerPauseScript(bundleID: String, stateExpression: String) -> String {
+        """
+        tell application id "\(bundleID)"
+            if \(stateExpression) then
+                pause
+                return "player"
+            end if
+        end tell
+        return ""
+        """
+    }
 
-    private struct PauseTarget {
-        let controlBundleID: String
-        var processNames: Set<String> = []
-        var requiresMediaKeyFallback = false
+    private static func chromiumPauseScript(bundleID: String, marker: String) -> String {
+        let javaScript = pauseHTMLMediaJavaScript(marker: marker)
+        return """
+        tell application id "\(bundleID)"
+            set didPause to false
+            repeat with browserWindow in windows
+                repeat with browserTab in tabs of browserWindow
+                    try
+                        set changedCount to execute browserTab javascript "\(javaScript)"
+                        if (changedCount as integer) > 0 then set didPause to true
+                    end try
+                end repeat
+            end repeat
+            if didPause then return "browser"
+        end tell
+        return ""
+        """
+    }
+
+    private static func chromiumResumeScript(bundleID: String, marker: String) -> String {
+        let javaScript = resumeHTMLMediaJavaScript(marker: marker)
+        return """
+        tell application id "\(bundleID)"
+            repeat with browserWindow in windows
+                repeat with browserTab in tabs of browserWindow
+                    try
+                        execute browserTab javascript "\(javaScript)"
+                    end try
+                end repeat
+            end repeat
+        end tell
+        """
+    }
+
+    private static func safariPauseScript(marker: String) -> String {
+        let javaScript = pauseHTMLMediaJavaScript(marker: marker)
+        return """
+        tell application id "com.apple.Safari"
+            set didPause to false
+            repeat with browserWindow in windows
+                repeat with browserTab in tabs of browserWindow
+                    try
+                        set changedCount to do JavaScript "\(javaScript)" in browserTab
+                        if (changedCount as integer) > 0 then set didPause to true
+                    end try
+                end repeat
+            end repeat
+            if didPause then return "browser"
+        end tell
+        return ""
+        """
+    }
+
+    private static func safariResumeScript(marker: String) -> String {
+        let javaScript = resumeHTMLMediaJavaScript(marker: marker)
+        return """
+        tell application id "com.apple.Safari"
+            repeat with browserWindow in windows
+                repeat with browserTab in tabs of browserWindow
+                    try
+                        do JavaScript "\(javaScript)" in browserTab
+                    end try
+                end repeat
+            end repeat
+        end tell
+        """
+    }
+
+    private static func pauseHTMLMediaJavaScript(marker: String) -> String {
+        let marker = javaScriptEscaped(marker)
+        return """
+        (() => { let n = 0; for (const node of document.querySelectorAll('audio, video')) { try { if (!node.paused) { node.dataset.lokalbotDictationPaused = '\(marker)'; node.pause(); n++; } } catch (_) {} } return n; })()
+        """
+        .replacingOccurrences(of: "\n", with: " ")
+        .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    private static func resumeHTMLMediaJavaScript(marker: String) -> String {
+        let marker = javaScriptEscaped(marker)
+        return """
+        (() => { for (const node of document.querySelectorAll('audio, video')) { try { if (node.dataset.lokalbotDictationPaused === '\(marker)') { delete node.dataset.lokalbotDictationPaused; node.play(); } } catch (_) {} } })()
+        """
+        .replacingOccurrences(of: "\n", with: " ")
+        .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    private static func appleScriptEscaped(_ value: String) -> String {
+        value.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    private static func javaScriptEscaped(_ value: String) -> String {
+        value.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+    }
+
+    private static func runAppleScript(_ source: String) async -> String? {
+        let controller = ScriptProcessController()
+        let execution = Task.detached(priority: .utility) { () -> String? in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+            process.arguments = ["-e", source]
+            let output = Pipe()
+            process.standardOutput = output
+            process.standardError = FileHandle.nullDevice
+            guard controller.attach(process) else { return nil }
+            defer { controller.detach(process) }
+            do { try process.run() } catch { return nil }
+            controller.processDidStart(process)
+            let data = output.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            return String(decoding: data, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let timeout = Task.detached {
+            try? await Task.sleep(for: .seconds(1.5))
+            guard !Task.isCancelled else { return }
+            controller.cancel()
+        }
+        defer { timeout.cancel() }
+        return await withTaskCancellationHandler {
+            let value = await execution.value
+            return Task.isCancelled ? nil : value
+        } onCancel: {
+            controller.cancel()
+            execution.cancel()
+        }
+    }
+}
+
+/// Bridges the AppleScript timeout/cancellation path to its blocking helper.
+/// SIGTERM gets a brief grace period before a PID-identity-checked SIGKILL so
+/// the stdout reader and `waitUntilExit()` cannot remain blocked forever.
+final class ScriptProcessController: @unchecked Sendable {
+    typealias ProcessStartTime = @Sendable (pid_t) -> UInt64?
+    typealias SignalSender = @Sendable (pid_t, Int32) -> Void
+
+    private let lock = NSLock()
+    private let terminationGraceSeconds: TimeInterval
+    private let processStartTime: ProcessStartTime
+    private let sendSignal: SignalSender
+    private var process: Process?
+    private var cancelled = false
+
+    init(
+        terminationGraceSeconds: TimeInterval = 0.25,
+        processStartTime: @escaping ProcessStartTime = {
+            SystemResourceSampler.processUsage(for: $0)?.startTime
+        },
+        sendSignal: @escaping SignalSender = { pid, signal in
+            _ = kill(pid, signal)
+        }
+    ) {
+        self.terminationGraceSeconds = terminationGraceSeconds
+        self.processStartTime = processStartTime
+        self.sendSignal = sendSignal
+    }
+
+    func attach(_ process: Process) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !cancelled else { return false }
+        self.process = process
+        return true
+    }
+
+    func detach(_ process: Process) {
+        lock.lock()
+        if self.process === process { self.process = nil }
+        lock.unlock()
+    }
+
+    func processDidStart(_ process: Process) {
+        lock.lock()
+        let shouldTerminate = cancelled && self.process === process
+        lock.unlock()
+        if shouldTerminate, process.isRunning { terminate(process) }
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        let process = self.process
+        lock.unlock()
+        guard let process, process.isRunning else { return }
+        terminate(process)
+    }
+
+    private func terminate(_ process: Process) {
+        let pid = process.processIdentifier
+        let expectedStartTime = processStartTime(pid)
+        process.terminate()
+        DispatchQueue.global(qos: .utility).asyncAfter(
+            deadline: .now() + terminationGraceSeconds
+        ) { [weak self, weak process] in
+            guard let self, let process else { return }
+            self.killIfStillAttached(
+                process, pid: pid, expectedStartTime: expectedStartTime)
+        }
+    }
+
+    private func killIfStillAttached(
+        _ process: Process,
+        pid: pid_t,
+        expectedStartTime: UInt64?
+    ) {
+        lock.lock()
+        let isSameCancelledProcess = cancelled && self.process === process
+        lock.unlock()
+        guard isSameCancelledProcess,
+              process.isRunning,
+              process.processIdentifier == pid,
+              let expectedStartTime,
+              processStartTime(pid) == expectedStartTime
+        else { return }
+        sendSignal(pid, SIGKILL)
     }
 }

--- a/LokalBot/Services/MeetingDetector.swift
+++ b/LokalBot/Services/MeetingDetector.swift
@@ -71,6 +71,7 @@ final class MeetingDetector {
     private var activeCalendarEvent: CalendarMeetingCandidate?
     private var timer: Timer?
     private var pendingStop: DispatchWorkItem?
+    private var workspaceObservers: [NSObjectProtocol] = []
 
     private var micListener: AudioObjectPropertyListenerBlock?
     private var listenedDevice = AudioObjectID(kAudioObjectUnknown)
@@ -78,7 +79,16 @@ final class MeetingDetector {
     /// callbacks (each mic open/close then fans out into a tick storm).
     private var deviceChangeListener: AudioObjectPropertyListenerBlock?
 
+    /// Core Audio process enumeration is comparatively expensive and several
+    /// meeting subsystems ask for the same answer in one detector/poller turn.
+    /// Keep a very short-lived snapshot so detection, helper handoff, and media
+    /// pausing share one system query without making process state feel stale.
+    private static let processSnapshotLock = NSLock()
+    private static var processSnapshot: (capturedAt: Date, processes: [AudioProcess])?
+    private static let processSnapshotLifetime: TimeInterval = 0.35
+
     func start() {
+        guard timer == nil else { return }
         // Safety-net poll (browser titles have no change notification).
         timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
             self?.tick()
@@ -88,9 +98,11 @@ final class MeetingDetector {
         let center = NSWorkspace.shared.notificationCenter
         for name in [NSWorkspace.didLaunchApplicationNotification,
                      NSWorkspace.didTerminateApplicationNotification] {
-            center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+            let observer = center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                Self.invalidateAudioProcessSnapshot()
                 self?.tick()
             }
+            workspaceObservers.append(observer)
         }
         tick()
     }
@@ -98,6 +110,11 @@ final class MeetingDetector {
     func stop() {
         timer?.invalidate()
         timer = nil
+        pendingStop?.cancel()
+        pendingStop = nil
+        let center = NSWorkspace.shared.notificationCenter
+        for observer in workspaceObservers { center.removeObserver(observer) }
+        workspaceObservers.removeAll()
         disarmAll()
     }
 
@@ -194,8 +211,17 @@ final class MeetingDetector {
                     requireCalendarForBrowser: requireCalendarForBrowser) {
                     pendingStop?.cancel()
                     pendingStop = nil
+                    let previousApp = activeApp
                     activeApp = replacementApp
                     activeCalendarEvent = calendarEvent
+                    if previousApp != replacementApp {
+                        onMeetingSwitched?(MeetingDetectionContext(
+                            detectedApp: replacementApp,
+                            calendarEvent: calendarEvent,
+                            confidence: MeetingMatcher.confidence(
+                                hasApp: true, hasCalendar: calendarEvent != nil),
+                            reason: "meeting-app-handoff"))
+                    }
                     return
                 }
                 scheduleStopIfNeeded(now: now)
@@ -359,12 +385,29 @@ final class MeetingDetector {
         return bundle == browser || bundle.hasPrefix("\(browser).helper")
     }
 
+    /// Whether an audio process belongs to the detected meeting application's
+    /// process family. Zoom routes call audio through `us.zoom.CptHost`, while
+    /// Chromium-family browsers use `.helper` bundle identifiers.
+    static func audioBundleID(_ bundleID: String, belongsTo appBundleID: String) -> Bool {
+        if browsers.contains(appBundleID) {
+            return browserAudioBundleID(bundleID, belongsTo: appBundleID)
+        }
+        let bundle = bundleID.lowercased()
+        let host = appBundleID.lowercased()
+        if host == "us.zoom.xos" {
+            return bundle == host
+                || bundle == "us.zoom.cpthost"
+                || bundle.hasPrefix("us.zoom.xos.")
+        }
+        return bundle == host || bundle.hasPrefix("\(host).helper")
+    }
+
     static func bestOutputAudioProcess(for app: DetectedApp,
                                        in processes: [AudioProcess]) -> AudioProcess? {
-        if browsers.contains(app.bundleID) {
+        if browsers.contains(app.bundleID) || app.bundleID == "us.zoom.xos" {
             let matches = processes.filter { process in
                 guard process.isRunningOutput, let bundleID = process.bundleID else { return false }
-                return browserAudioBundleID(bundleID, belongsTo: app.bundleID)
+                return audioBundleID(bundleID, belongsTo: app.bundleID)
             }
             // Chrome/Edge/Safari often emit meeting audio from helper processes,
             // while the browser host can still expose a tap that only delivers
@@ -379,8 +422,30 @@ final class MeetingDetector {
     }
 
     static func currentOutputAudioProcess(for app: DetectedApp) -> AudioProcess? {
-        let processes = (try? CoreAudioUtils.listAudioProcesses()) ?? []
+        let processes = currentAudioProcesses()
         return bestOutputAudioProcess(for: app, in: processes)
+    }
+
+    static func currentAudioProcesses(now: Date = Date()) -> [AudioProcess] {
+        processSnapshotLock.lock()
+        if let processSnapshot,
+           now.timeIntervalSince(processSnapshot.capturedAt) <= processSnapshotLifetime {
+            processSnapshotLock.unlock()
+            return processSnapshot.processes
+        }
+        processSnapshotLock.unlock()
+
+        let processes = (try? CoreAudioUtils.listAudioProcesses()) ?? []
+        processSnapshotLock.lock()
+        processSnapshot = (now, processes)
+        processSnapshotLock.unlock()
+        return processes
+    }
+
+    static func invalidateAudioProcessSnapshot() {
+        processSnapshotLock.lock()
+        processSnapshot = nil
+        processSnapshotLock.unlock()
     }
 
     private static func continuingApp(_ app: DetectedApp, in running: [NSRunningApplication]) -> DetectedApp? {

--- a/LokalBot/Services/MeetingPlayer.swift
+++ b/LokalBot/Services/MeetingPlayer.swift
@@ -26,6 +26,13 @@ final class MeetingPlayer: NSObject, ObservableObject {
     private var players: [AVAudioPlayer] = []
     private var ticker: Timer?
 
+    /// The longest source owns the meeting timeline. The system track can end
+    /// before the mic (or vice versa); clocking from `players.first` freezes or
+    /// jumps the scrubber as soon as that shorter player finishes.
+    private var timelinePlayer: AVAudioPlayer? {
+        players.max { $0.duration < $1.duration }
+    }
+
     func load(folder: URL, hasSystemTrack: Bool) {
         stop()
         // Share the file + gain policy with the offline export so what you hear
@@ -110,8 +117,8 @@ final class MeetingPlayer: NSObject, ObservableObject {
         stopTicker()
         ticker = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
-                guard let self, let first = self.players.first else { return }
-                self.currentTime = first.currentTime
+                guard let self, let timelinePlayer = self.timelinePlayer else { return }
+                self.currentTime = min(timelinePlayer.currentTime, self.duration)
             }
         }
     }

--- a/LokalBot/Services/MicRecorder.swift
+++ b/LokalBot/Services/MicRecorder.swift
@@ -1,5 +1,113 @@
 import AVFoundation
 
+struct AudioRecoverySilencePlan: Equatable {
+    let duration: TimeInterval
+    let wasCapped: Bool
+}
+
+enum AudioRecoverySilencePlanner {
+    static let minimumDuration: TimeInterval = 0.2
+    static let maximumDuration: TimeInterval = 30
+
+    static func plan(forElapsed elapsed: TimeInterval) -> AudioRecoverySilencePlan? {
+        guard elapsed.isFinite, elapsed >= minimumDuration else { return nil }
+        let duration = min(elapsed, maximumDuration)
+        return AudioRecoverySilencePlan(duration: duration, wasCapped: duration < elapsed)
+    }
+
+    static func plan(forElapsed elapsed: Duration) -> AudioRecoverySilencePlan? {
+        let components = elapsed.components
+        let seconds = Double(components.seconds)
+            + Double(components.attoseconds) / 1_000_000_000_000_000_000
+        return plan(forElapsed: seconds)
+    }
+}
+
+final class MicAudioBufferPool: @unchecked Sendable {
+    private let lock = NSLock()
+    private let format: AVAudioFormat
+    private let frameCapacity: AVAudioFrameCount
+    private var buffers: [AVAudioPCMBuffer]
+
+    init?(
+        format: AVAudioFormat,
+        bufferCount: Int,
+        frameCapacity: AVAudioFrameCount
+    ) {
+        guard bufferCount > 0, frameCapacity > 0 else { return nil }
+        var prepared: [AVAudioPCMBuffer] = []
+        prepared.reserveCapacity(bufferCount)
+        for _ in 0..<bufferCount {
+            guard let buffer = AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: frameCapacity
+            ) else { return nil }
+            prepared.append(buffer)
+        }
+        self.format = format
+        self.frameCapacity = frameCapacity
+        buffers = prepared
+    }
+
+    func borrow(for source: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        guard source.frameLength <= frameCapacity,
+              Self.formatsCompatible(source.format, format),
+              lock.try() else { return nil }
+        defer { lock.unlock() }
+        guard let buffer = buffers.popLast() else { return nil }
+        buffer.frameLength = source.frameLength
+        return buffer
+    }
+
+    func returnBuffer(_ buffer: AVAudioPCMBuffer) {
+        lock.lock()
+        buffers.append(buffer)
+        lock.unlock()
+    }
+
+    var availableBufferCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return buffers.count
+    }
+
+    private static func formatsCompatible(_ lhs: AVAudioFormat, _ rhs: AVAudioFormat) -> Bool {
+        lhs.commonFormat == rhs.commonFormat
+            && lhs.sampleRate == rhs.sampleRate
+            && lhs.channelCount == rhs.channelCount
+            && lhs.isInterleaved == rhs.isInterleaved
+    }
+}
+
+final class MicRealtimeDropCounter: @unchecked Sendable {
+    private let lock: NSLock
+    private var count = 0
+
+    init(lock: NSLock = NSLock()) {
+        self.lock = lock
+    }
+
+    @discardableResult
+    func recordDrop() -> Bool {
+        guard lock.try() else { return false }
+        count += 1
+        lock.unlock()
+        return true
+    }
+
+    func snapshot() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func reset() {
+        lock.lock()
+        count = 0
+        lock.unlock()
+    }
+}
+
 /// Records the default input device (your voice). Meeting recordings use AAC
 /// `.m4a`; short-lived dictation scratch files can use PCM `.caf` to avoid
 /// AAC container startup failures on some devices.
@@ -21,6 +129,9 @@ final class MicRecorder {
     private var framesWritten: AVAudioFramePosition = 0
     private var recordingSampleRate: Double = 0
     private var lastAudioWriteAt: Date?
+    private var lastAudioWriteInstant: ContinuousClock.Instant?
+    private var captureStartedInstant: ContinuousClock.Instant?
+    private var recoveryState: RecoveryState = .healthy
     /// Observes `AVAudioEngineConfigurationChange` so we can rebuild the
     /// tap graph in place when the audio device changes mid-recording
     /// (AirPods plug/unplug, default-input switch, sample-rate renegotiation).
@@ -32,8 +143,10 @@ final class MicRecorder {
     /// resampling, and filesystem writes here.
     private let ioQueue = DispatchQueue(label: "lokalbot.microphone.write",
                                         qos: .userInitiated)
-    private let pendingWriteSlots = DispatchSemaphore(value: 16)
-    private var droppedBufferCount = 0
+    private static let bufferPoolSize = 16
+    private static let pooledBufferFrameCapacity: AVAudioFrameCount = 32_768
+    private var bufferPool: MicAudioBufferPool?
+    private let dropCounter = MicRealtimeDropCounter()
 
     enum RecorderError: LocalizedError {
         case inputUnavailable
@@ -52,11 +165,25 @@ final class MicRecorder {
         }
     }
 
+    enum RecoveryState: Equatable {
+        case healthy
+        case recovering(attempt: Int)
+        case degraded(errorDescription: String)
+    }
+
+    static let maximumReconfigurationAttempts = 4
+
+    static func reconfigurationRetryDelay(forAttempt attempt: Int) -> TimeInterval? {
+        guard attempt > 0, attempt <= maximumReconfigurationAttempts else { return nil }
+        return min(Double(attempt), 5)
+    }
+
     struct CaptureHealth {
         let duration: TimeInterval
         let lastAudioWriteAt: Date?
         let isEngineRunning: Bool
         let droppedBufferCount: Int
+        let recoveryState: RecoveryState
     }
 
     static func requestPermission() async -> Bool {
@@ -102,6 +229,7 @@ final class MicRecorder {
             converter = nil
             converterInputFormat = nil
         }
+        updateRecoveryState(.healthy)
         resetCaptureHealth(sampleRate: recordingFormat.sampleRate)
 
         do {
@@ -115,6 +243,7 @@ final class MicRecorder {
                 previewTee?.close()
                 previewTee = nil
             }
+            bufferPool = nil
             resetCaptureHealth(sampleRate: 0)
             throw error
         }
@@ -133,6 +262,7 @@ final class MicRecorder {
         isRecording = false
         reconfigurationTask?.cancel()
         reconfigurationTask = nil
+        updateRecoveryState(.healthy)
         if let configChangeObserver {
             NotificationCenter.default.removeObserver(configChangeObserver)
             self.configChangeObserver = nil
@@ -150,6 +280,7 @@ final class MicRecorder {
             previewTee?.close()
             previewTee = nil
         }
+        bufferPool = nil
     }
 
     func captureHealth() -> CaptureHealth {
@@ -158,30 +289,38 @@ final class MicRecorder {
             ? Double(framesWritten) / recordingSampleRate
             : 0
         let lastAudioWriteAt = self.lastAudioWriteAt
-        let droppedBufferCount = self.droppedBufferCount
+        let recoveryState = self.recoveryState
         healthLock.unlock()
+        let droppedBufferCount = dropCounter.snapshot()
         return CaptureHealth(duration: duration,
                              lastAudioWriteAt: lastAudioWriteAt,
                              isEngineRunning: engine.isRunning,
-                             droppedBufferCount: droppedBufferCount)
+                             droppedBufferCount: droppedBufferCount,
+                             recoveryState: recoveryState)
     }
 
     func restartCapture() throws {
         guard isRecording, let recordingFormat else { return }
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
-        let inputFormat = engine.inputNode.outputFormat(forBus: 0)
-        guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
-            scheduleReconfigurationRetry()
-            throw RecorderError.inputUnavailable
-        }
         do {
+            drainAndResetConverter()
+            try appendRecoverySilence(
+                until: ContinuousClock.now,
+                wallDate: Date(),
+                format: recordingFormat)
+            let inputFormat = engine.inputNode.outputFormat(forBus: 0)
+            guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
+                throw RecorderError.inputUnavailable
+            }
             try installTapAndStart(inputFormat: inputFormat,
-                                   recordingFormat: recordingFormat)
+                                   recordingFormat: recordingFormat,
+                                   shouldDrainExistingConverter: false)
             reconfigurationTask?.cancel()
             reconfigurationTask = nil
+            updateRecoveryState(.healthy)
         } catch {
-            scheduleReconfigurationRetry()
+            scheduleReconfigurationRetry(lastError: error.localizedDescription)
             throw error
         }
     }
@@ -191,34 +330,41 @@ final class MicRecorder {
     /// Builds the converter (only when input ≠ recording format), installs
     /// the tap, and starts the engine. Shared by `start()` and the
     /// configuration-change reinstall.
-    private func installTapAndStart(inputFormat _: AVAudioFormat,
-                                    recordingFormat: AVAudioFormat) throws {
-        ioQueue.sync {
-            // A device switch can leave resampler output buffered. Emit it
-            // before replacing the converter for the new hardware format.
-            drainConverter()
-            converter = nil
-            converterInputFormat = nil
+    private func installTapAndStart(
+        inputFormat: AVAudioFormat,
+        recordingFormat: AVAudioFormat,
+        shouldDrainExistingConverter: Bool = true
+    ) throws {
+        if shouldDrainExistingConverter {
+            drainAndResetConverter()
         }
         let input = engine.inputNode
+        guard let pool = MicAudioBufferPool(
+            format: inputFormat,
+            bufferCount: Self.bufferPoolSize,
+            frameCapacity: Self.pooledBufferFrameCapacity
+        ) else {
+            throw RecorderError.unsupportedInputFormat
+        }
+        bufferPool = pool
         // Let AVAudioEngine choose the current hardware format. During a live
         // device switch, `outputFormat(forBus:)` can briefly report a stale
         // client format while the input unit has already moved to the new
         // hardware rate, and passing that stale format makes installTap raise.
         input.installTap(onBus: 0, bufferSize: 4096, format: nil) { [weak self] buffer, _ in
             guard let self else { return }
-            guard self.pendingWriteSlots.wait(timeout: .now()) == .success else {
+            guard let pool = self.bufferPool,
+                  let copy = pool.borrow(for: buffer) else {
                 self.noteDroppedBuffer()
                 return
             }
-            guard let copy = Self.copyBuffer(buffer) else {
-                self.pendingWriteSlots.signal()
+            guard Self.copyBuffer(buffer, into: copy) else {
+                self.ioQueue.async { [pool] in pool.returnBuffer(copy) }
                 self.noteDroppedBuffer()
                 return
             }
-            let writeSlot = self.pendingWriteSlots
-            self.ioQueue.async { [weak self, writeSlot] in
-                defer { writeSlot.signal() }
+            self.ioQueue.async { [weak self, pool] in
+                defer { pool.returnBuffer(copy) }
                 do {
                     try self?.write(copy)
                 } catch {
@@ -231,6 +377,7 @@ final class MicRecorder {
             try engine.start()
         } catch {
             input.removeTap(onBus: 0)
+            bufferPool = nil
             ioQueue.sync {
                 converter = nil
                 converterInputFormat = nil
@@ -267,37 +414,77 @@ final class MicRecorder {
         guard isRecording else { return }
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
-        scheduleReconfigurationRetry()
+        scheduleReconfigurationRetry(lastError: "The audio input configuration changed.")
     }
 
-    private func scheduleReconfigurationRetry() {
+    private enum ReconfigurationAttemptResult: Sendable {
+        case recovered
+        case retry(String)
+        case stopped
+    }
+
+    private func scheduleReconfigurationRetry(lastError initialError: String) {
         guard isRecording else { return }
         guard reconfigurationTask == nil else { return }
+        updateRecoveryState(.recovering(attempt: 0))
         reconfigurationTask = Task { [weak self] in
-            var attempt = 1
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(min(Double(attempt), 5.0)))
+            var lastError = initialError
+            for attempt in 1...Self.maximumReconfigurationAttempts {
+                guard let delay = Self.reconfigurationRetryDelay(forAttempt: attempt) else { break }
+                self?.updateRecoveryState(.recovering(attempt: attempt))
+                do {
+                    try await Task.sleep(for: .seconds(delay))
+                } catch {
+                    return
+                }
                 guard !Task.isCancelled else { return }
-                await MainActor.run {
-                    guard let self, self.isRecording else { return }
+                let result = await MainActor.run { [weak self] in
+                    guard let self, self.isRecording else {
+                        return ReconfigurationAttemptResult.stopped
+                    }
                     self.engine.inputNode.removeTap(onBus: 0)
-                    guard let recordingFormat = self.recordingFormat else { return }
+                    guard let recordingFormat = self.recordingFormat else {
+                        return ReconfigurationAttemptResult.stopped
+                    }
                     let inputFormat = self.engine.inputNode.outputFormat(forBus: 0)
                     guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
                         NSLog("MicRecorder reconfig retry: no usable input device")
-                        return
+                        return ReconfigurationAttemptResult.retry(
+                            RecorderError.inputUnavailable.localizedDescription)
                     }
                     do {
+                        self.drainAndResetConverter()
+                        try self.appendRecoverySilence(
+                            until: ContinuousClock.now,
+                            wallDate: Date(),
+                            format: recordingFormat)
                         try self.installTapAndStart(inputFormat: inputFormat,
-                                                    recordingFormat: recordingFormat)
+                                                    recordingFormat: recordingFormat,
+                                                    shouldDrainExistingConverter: false)
                         NSLog("MicRecorder reconfig retry succeeded")
-                        self.reconfigurationTask?.cancel()
                         self.reconfigurationTask = nil
+                        self.updateRecoveryState(.healthy)
+                        return ReconfigurationAttemptResult.recovered
                     } catch {
                         NSLog("MicRecorder reconfig retry failed: \(error.localizedDescription)")
+                        return ReconfigurationAttemptResult.retry(error.localizedDescription)
                     }
                 }
-                attempt += 1
+                switch result {
+                case .recovered, .stopped:
+                    return
+                case .retry(let errorDescription):
+                    lastError = errorDescription
+                }
+            }
+            guard !Task.isCancelled else { return }
+            let terminalError = lastError
+            await MainActor.run { [weak self] in
+                guard let self, self.isRecording else { return }
+                self.reconfigurationTask = nil
+                self.updateRecoveryState(.degraded(errorDescription: terminalError))
+                NSLog(
+                    "MicRecorder recovery exhausted after \(Self.maximumReconfigurationAttempts) attempts: \(terminalError)")
             }
         }
     }
@@ -305,6 +492,14 @@ final class MicRecorder {
     /// Flush the converter's internal buffer on stop. Without this, the tail
     /// (the last few hundred ms — more with resampling) is dropped because
     /// the streaming write loop only ever signals `.noDataNow`, never EOS.
+    private func drainAndResetConverter() {
+        ioQueue.sync {
+            drainConverter()
+            converter = nil
+            converterInputFormat = nil
+        }
+    }
+
     private func drainConverter() {
         guard let converter, let recordingFormat, let file else { return }
         // Loop because the converter may need multiple output buffers to
@@ -384,56 +579,109 @@ final class MicRecorder {
 
     /// Makes the tap buffer safe to retain after the callback returns. Copying
     /// through `AudioBufferList` handles both interleaved and planar layouts.
-    static func copyBuffer(_ source: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+    static func copyBuffer(
+        _ source: AVAudioPCMBuffer,
+        into destination: AVAudioPCMBuffer
+    ) -> Bool {
         guard source.frameLength > 0,
-              let destination = AVAudioPCMBuffer(
-                pcmFormat: source.format,
-                frameCapacity: source.frameLength)
-        else { return nil }
+              source.frameLength <= destination.frameCapacity else { return false }
         destination.frameLength = source.frameLength
-
         let sourceBuffers = UnsafeMutableAudioBufferListPointer(
             UnsafeMutablePointer(mutating: source.audioBufferList))
         let destinationBuffers = UnsafeMutableAudioBufferListPointer(
             destination.mutableAudioBufferList)
-        guard sourceBuffers.count == destinationBuffers.count else { return nil }
+        guard sourceBuffers.count == destinationBuffers.count else { return false }
         for (src, dst) in zip(sourceBuffers, destinationBuffers) {
             guard src.mDataByteSize <= dst.mDataByteSize,
                   let srcData = src.mData,
                   let dstData = dst.mData
-            else { return nil }
+            else { return false }
             memcpy(dstData, srcData, Int(src.mDataByteSize))
         }
-        return destination
+        return true
     }
 
     private func resetCaptureHealth(sampleRate: Double) {
+        let now = ContinuousClock.now
         healthLock.lock()
         framesWritten = 0
         recordingSampleRate = sampleRate
         lastAudioWriteAt = nil
-        droppedBufferCount = 0
+        lastAudioWriteInstant = nil
+        captureStartedInstant = sampleRate > 0 ? now : nil
+        recoveryState = .healthy
+        healthLock.unlock()
+        dropCounter.reset()
+    }
+
+    private func updateRecoveryState(_ state: RecoveryState) {
+        healthLock.lock()
+        recoveryState = state
         healthLock.unlock()
     }
 
-    private func noteDroppedBuffer() {
-        healthLock.lock()
-        droppedBufferCount += 1
-        let count = droppedBufferCount
-        healthLock.unlock()
-        if count == 1 || count.isMultiple(of: 100) {
-            NSLog("MicRecorder dropped \(count) buffer(s): writer queue saturated")
+    /// Device changes can leave the microphone graph stopped for several
+    /// seconds. Preserve that monotonic elapsed interval as silence before rebuilding
+    /// the tap so the mic timeline remains aligned with system audio and with
+    /// transcript timestamps after recovery.
+    private func appendRecoverySilence(
+        until now: ContinuousClock.Instant,
+        wallDate: Date,
+        format: AVAudioFormat
+    ) throws {
+        try ioQueue.sync {
+            healthLock.lock()
+            let anchor = lastAudioWriteInstant ?? captureStartedInstant
+            healthLock.unlock()
+            guard let anchor, let file else { return }
+            guard let plan = AudioRecoverySilencePlanner.plan(
+                forElapsed: anchor.duration(to: now)),
+                  format.sampleRate > 0 else { return }
+
+            var remaining = AVAudioFramePosition(plan.duration * format.sampleRate)
+            var appended: AVAudioFramePosition = 0
+            while remaining > 0 {
+                let count = AVAudioFrameCount(min(remaining, 4_096))
+                guard let silence = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: count) else {
+                    throw RecorderError.unsupportedInputFormat
+                }
+                silence.frameLength = count
+                let buffers = UnsafeMutableAudioBufferListPointer(silence.mutableAudioBufferList)
+                for buffer in buffers where buffer.mData != nil {
+                    memset(buffer.mData!, 0, Int(buffer.mDataByteSize))
+                }
+                try file.write(from: silence)
+                previewTee?.write(silence)
+                appended += AVAudioFramePosition(count)
+                remaining -= AVAudioFramePosition(count)
+            }
+            healthLock.lock()
+            framesWritten += appended
+            lastAudioWriteAt = wallDate
+            lastAudioWriteInstant = now
+            healthLock.unlock()
+            if plan.wasCapped {
+                NSLog(
+                    "MicRecorder recovery gap capped at "
+                        + "\(AudioRecoverySilencePlanner.maximumDuration)s")
+            }
         }
+    }
+
+    private func noteDroppedBuffer() {
+        dropCounter.recordDrop()
     }
 
     private func noteWrittenAudio(_ buffer: AVAudioPCMBuffer) {
         guard buffer.frameLength > 0 else { return }
+        let now = ContinuousClock.now
         healthLock.lock()
         if recordingSampleRate <= 0 {
             recordingSampleRate = buffer.format.sampleRate
         }
         framesWritten += AVAudioFramePosition(buffer.frameLength)
         lastAudioWriteAt = Date()
+        lastAudioWriteInstant = now
         healthLock.unlock()
     }
 }

--- a/LokalBot/Services/PipelineJobStore.swift
+++ b/LokalBot/Services/PipelineJobStore.swift
@@ -26,70 +26,126 @@ final class PipelineJobStore {
     static let maxAutoResumeAttempts = 3
 
     private let database: SQLiteDatabase?
+    private let databaseURL: URL
 
     init(databaseURL: URL) {
+        self.databaseURL = databaseURL
         database = SQLiteDatabase(url: databaseURL)
-        database?.exec("""
-            CREATE TABLE IF NOT EXISTS pipeline_jobs (
-                meeting_id TEXT PRIMARY KEY,
-                transcribe INTEGER NOT NULL,
-                summarize INTEGER NOT NULL,
-                attempts INTEGER NOT NULL DEFAULT 0,
-                enqueued_at REAL NOT NULL
-            );
-            """)
+        do {
+            try requiredDatabase().execute("""
+                CREATE TABLE IF NOT EXISTS pipeline_jobs (
+                    meeting_id TEXT PRIMARY KEY,
+                    transcribe INTEGER NOT NULL,
+                    summarize INTEGER NOT NULL,
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    enqueued_at REAL NOT NULL
+                );
+                """)
+        } catch {
+            lokalbotLog("pipeline queue initialization failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func requiredDatabase() throws -> SQLiteDatabase {
+        guard let database else {
+            throw SQLiteDatabase.DatabaseError.unavailable(path: databaseURL.path)
+        }
+        return database
     }
 
     /// Record a fresh enqueue. Resets `attempts`: an explicit re-enqueue is a
     /// deliberate retry, not a crash-loop continuation.
-    func enqueue(meetingID: UUID, transcribe: Bool, summarize: Bool, at date: Date = Date()) {
-        database?.run("""
-            INSERT INTO pipeline_jobs (meeting_id, transcribe, summarize, attempts, enqueued_at)
-            VALUES (?1, ?2, ?3, 0, ?4)
-            ON CONFLICT(meeting_id) DO UPDATE SET
-                transcribe = excluded.transcribe,
-                summarize = excluded.summarize,
-                attempts = 0,
-                enqueued_at = excluded.enqueued_at
-            """, bind: [meetingID.uuidString, transcribe ? 1 : 0, summarize ? 1 : 0,
-                        date.timeIntervalSince1970])
+    @discardableResult
+    func enqueue(meetingID: UUID, transcribe: Bool, summarize: Bool,
+                 at date: Date = Date()) -> Bool {
+        write("enqueue") { database in
+            try database.runChecked("""
+                INSERT INTO pipeline_jobs (meeting_id, transcribe, summarize, attempts, enqueued_at)
+                VALUES (?1, ?2, ?3, 0, ?4)
+                ON CONFLICT(meeting_id) DO UPDATE SET
+                    transcribe = excluded.transcribe,
+                    summarize = excluded.summarize,
+                    attempts = 0,
+                    enqueued_at = excluded.enqueued_at
+                """, bind: [meetingID.uuidString, transcribe ? 1 : 0, summarize ? 1 : 0,
+                             date.timeIntervalSince1970])
+        }
     }
 
     /// Burn one attempt the moment processing starts, so a crash mid-job is
     /// already counted when the row is read back on the next launch.
-    func markStarted(meetingID: UUID) {
-        database?.run("UPDATE pipeline_jobs SET attempts = attempts + 1 WHERE meeting_id = ?1",
-                      bind: [meetingID.uuidString])
+    @discardableResult
+    func markStarted(meetingID: UUID) -> Bool {
+        write("mark started") { database in
+            try database.runChecked(
+                "UPDATE pipeline_jobs SET attempts = attempts + 1 WHERE meeting_id = ?1",
+                bind: [meetingID.uuidString])
+        }
     }
 
-    func markCompleted(meetingID: UUID) {
-        database?.run("DELETE FROM pipeline_jobs WHERE meeting_id = ?1",
-                      bind: [meetingID.uuidString])
+    @discardableResult
+    func markCompleted(meetingID: UUID) -> Bool {
+        write("mark completed") { database in
+            try database.runChecked(
+                "DELETE FROM pipeline_jobs WHERE meeting_id = ?1",
+                bind: [meetingID.uuidString])
+        }
     }
 
     /// Jobs eligible for launch auto-resume, oldest first.
     func pendingJobs() -> [PendingJob] {
-        database?.query("""
-            SELECT meeting_id, transcribe, summarize, attempts FROM pipeline_jobs
-            WHERE attempts < ?1 ORDER BY enqueued_at
-            """, bind: [Self.maxAutoResumeAttempts]) { statement -> PendingJob? in
-            guard let text = sqlite3_column_text(statement, 0),
-                  let id = UUID(uuidString: String(cString: text)) else { return nil }
-            return PendingJob(meetingID: id,
-                              transcribe: sqlite3_column_int64(statement, 1) != 0,
-                              summarize: sqlite3_column_int64(statement, 2) != 0,
-                              attempts: Int(sqlite3_column_int64(statement, 3)))
-        } ?? []
+        do {
+            return try requiredDatabase().queryChecked("""
+                SELECT meeting_id, transcribe, summarize, attempts FROM pipeline_jobs
+                WHERE attempts < ?1 ORDER BY enqueued_at
+                """, bind: [Self.maxAutoResumeAttempts]) { statement -> PendingJob? in
+                guard let text = sqlite3_column_text(statement, 0),
+                      let id = UUID(uuidString: String(cString: text)) else { return nil }
+                return PendingJob(meetingID: id,
+                                  transcribe: sqlite3_column_int64(statement, 1) != 0,
+                                  summarize: sqlite3_column_int64(statement, 2) != 0,
+                                  attempts: Int(sqlite3_column_int64(statement, 3)))
+            }
+        } catch {
+            lokalbotLog("pipeline queue read failed: \(error.localizedDescription)")
+            return []
+        }
     }
 
     /// Drop rows whose meeting no longer exists (deleted from the library
     /// between the crash and this launch).
-    func prune(existing meetingIDs: Set<UUID>) {
-        let rows = database?.query("SELECT meeting_id FROM pipeline_jobs") { statement -> String? in
-            sqlite3_column_text(statement, 0).map { String(cString: $0) }
-        } ?? []
-        for id in rows where UUID(uuidString: id).map({ !meetingIDs.contains($0) }) ?? true {
-            database?.run("DELETE FROM pipeline_jobs WHERE meeting_id = ?1", bind: [id])
+    @discardableResult
+    func prune(existing meetingIDs: Set<UUID>) -> Bool {
+        do {
+            let database = try requiredDatabase()
+            let rows = try database.queryChecked(
+                "SELECT meeting_id FROM pipeline_jobs") { statement -> String? in
+                sqlite3_column_text(statement, 0).map { String(cString: $0) }
+            }
+            let staleIDs = rows.filter {
+                UUID(uuidString: $0).map { !meetingIDs.contains($0) } ?? true
+            }
+            try database.withTransaction {
+                for id in staleIDs {
+                    try database.runChecked(
+                        "DELETE FROM pipeline_jobs WHERE meeting_id = ?1", bind: [id])
+                }
+            }
+            return true
+        } catch {
+            lokalbotLog("pipeline queue prune failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    private func write(_ operation: String,
+                       body: (SQLiteDatabase) throws -> Void) -> Bool {
+        do {
+            try body(requiredDatabase())
+            return true
+        } catch {
+            lokalbotLog("pipeline queue \(operation) failed: \(error.localizedDescription)")
+            return false
         }
     }
 }

--- a/LokalBot/Services/ProcessingPipeline.swift
+++ b/LokalBot/Services/ProcessingPipeline.swift
@@ -12,8 +12,10 @@ final class ProcessingPipeline: ObservableObject {
     enum Stage: Equatable {
         case queued
         case preparingTranscriptionModel
+        case preparingDiarizationModel
         case preparingSummaryModel
         case transcribing
+        case diarizing
         case summarizing
         case failed(String)
 
@@ -22,9 +24,12 @@ final class ProcessingPipeline: ObservableObject {
             case .queued: "Queued…"
             case .preparingTranscriptionModel:
                 "Preparing transcription model (download size depends on your selection)…"
+            case .preparingDiarizationModel:
+                "Preparing speaker diarization model…"
             case .preparingSummaryModel:
                 "Preparing summary model (download size depends on your selection)…"
             case .transcribing: "Transcribing…"
+            case .diarizing: "Identifying speakers…"
             case .summarizing: "Summarizing…"
             case .failed(let message): "Failed: \(message)"
             }
@@ -51,6 +56,7 @@ final class ProcessingPipeline: ObservableObject {
     /// loses nothing — see `resumePending(meetings:)`.
     private var queue: [Job] = []
     private var isDraining = false
+    private var activeMeetingID: Meeting.ID?
     private let diarizer = NeuralDiarizationEngine()
     private let jobStore: PipelineJobStore?
     /// Fired after transcript/summary files land on disk (search re-index).
@@ -68,7 +74,33 @@ final class ProcessingPipeline: ObservableObject {
     }
 
     func enqueue(_ meeting: Meeting, transcribe: Bool = true, summarize: Bool = true) {
-        jobStore?.enqueue(meetingID: meeting.id, transcribe: transcribe, summarize: summarize)
+        if let index = queue.firstIndex(where: { $0.meeting.id == meeting.id }) {
+            let mergedTranscribe = queue[index].transcribe || transcribe
+            let mergedSummarize = queue[index].summarize || summarize
+            if let jobStore,
+               !jobStore.enqueue(
+                    meetingID: meeting.id,
+                    transcribe: mergedTranscribe,
+                    summarize: mergedSummarize) {
+                stages[meeting.id] = .failed("Could not persist the processing queue update.")
+                return
+            }
+            queue[index].transcribe = mergedTranscribe
+            queue[index].summarize = mergedSummarize
+            queue[index].resumed = false
+            lokalbotLog("pipeline coalesced queued meeting=\(meeting.id)")
+            return
+        }
+        guard activeMeetingID != meeting.id else {
+            lokalbotLog("pipeline duplicate ignored while active meeting=\(meeting.id)")
+            return
+        }
+        if let jobStore,
+           !jobStore.enqueue(
+                meetingID: meeting.id, transcribe: transcribe, summarize: summarize) {
+            stages[meeting.id] = .failed("Could not persist the processing job.")
+            return
+        }
         queue.append(Job(meeting: meeting, transcribe: transcribe, summarize: summarize))
         stages[meeting.id] = .queued
         drain()
@@ -82,7 +114,9 @@ final class ProcessingPipeline: ObservableObject {
     /// not crash-loop every launch.
     func resumePending(meetings: [Meeting]) {
         guard let jobStore else { return }
-        jobStore.prune(existing: Set(meetings.map(\.id)))
+        if !jobStore.prune(existing: Set(meetings.map(\.id))) {
+            lokalbotLog("pipeline resume continued after queue prune failure")
+        }
         let byID = Dictionary(uniqueKeysWithValues: meetings.map { ($0.id, $0) })
         for job in jobStore.pendingJobs() {
             guard let meeting = byID[job.meetingID], stages[meeting.id] == nil else { continue }
@@ -106,7 +140,9 @@ final class ProcessingPipeline: ObservableObject {
         Task {
             while !queue.isEmpty {
                 let job = queue.removeFirst()
+                activeMeetingID = job.meeting.id
                 await process(job)
+                activeMeetingID = nil
             }
             isDraining = false
         }
@@ -116,7 +152,10 @@ final class ProcessingPipeline: ObservableObject {
         let meeting = job.meeting
         let folder = meeting.folderURL(in: storage)
         let config = settings()
-        jobStore?.markStarted(meetingID: meeting.id)
+        if let jobStore, !jobStore.markStarted(meetingID: meeting.id) {
+            stages[meeting.id] = .failed("Could not durably start this processing job.")
+            return
+        }
         do {
             if job.transcribe || !FileManager.default.fileExists(
                 atPath: folder.appendingPathComponent("transcript.json").path) {
@@ -131,10 +170,18 @@ final class ProcessingPipeline: ObservableObject {
                 stages[meeting.id] = .transcribing
                 var transcript = try await transcribeTracks(meeting: meeting, folder: folder,
                                                             engine: engine, config: config)
-                transcript = await refineSpeakers(transcript: transcript,
-                                                  meeting: meeting,
-                                                  folder: folder,
-                                                  config: config)
+                if config.multiSpeakerDiarization,
+                   MeetingAudioFiles.transcribableURL(for: .system, in: folder) != nil {
+                    stages[meeting.id] = .preparingDiarizationModel
+                    await prepareDiarizationModels()
+                    stages[meeting.id] = .diarizing
+                    transcript = await refineSpeakers(
+                        transcript: transcript,
+                        meeting: meeting,
+                        folder: folder,
+                        config: config,
+                        modelsPrepared: true)
+                }
                 transcript = SpeakerAutoNamer.applyingAliases(
                     to: transcript, participantNames: meeting.participantNameHints ?? [])
                 try write(transcript, to: folder)
@@ -179,7 +226,7 @@ final class ProcessingPipeline: ObservableObject {
                         summary = try await summarize(transcript, meeting: meeting, config: config)
                     }
                 } catch {
-                    outcomesTask?.cancel()
+                    await Self.cancelAndWaitForOutcomes(outcomesTask)
                     throw error
                 }
                 try summary.data(using: .utf8)?.write(
@@ -191,8 +238,13 @@ final class ProcessingPipeline: ObservableObject {
                                           config: config)
                 }
             }
+            if let jobStore, !jobStore.markCompleted(meetingID: meeting.id) {
+                stages[meeting.id] = .failed(
+                    "Artifacts were saved, but the durable processing queue could not be completed.")
+                onArtifactsWritten?(meeting)
+                return
+            }
             stages[meeting.id] = nil
-            jobStore?.markCompleted(meetingID: meeting.id)
             onArtifactsWritten?(meeting)
         } catch {
             // The persisted job row stays — the next launch re-enqueues it
@@ -308,12 +360,13 @@ final class ProcessingPipeline: ObservableObject {
     private func refineSpeakers(transcript: Transcript,
                                 meeting: Meeting,
                                 folder: URL,
-                                config: AppSettings) async -> Transcript {
+                                config: AppSettings,
+                                modelsPrepared: Bool = false) async -> Transcript {
         guard config.multiSpeakerDiarization else { return transcript }
         guard let systemURL = MeetingAudioFiles.transcribableURL(for: .system, in: folder) else {
             return transcript
         }
-        await diarizer.prepareModels()
+        if !modelsPrepared { await prepareDiarizationModels() }
         let segments = await diarizer.diarize(url: systemURL)
         guard !segments.isEmpty else { return transcript }
 
@@ -338,6 +391,19 @@ final class ProcessingPipeline: ObservableObject {
             }
         }
         return labelled
+    }
+
+    /// Shared by recording-time prewarm and the post-meeting stage. The
+    /// `NeuralDiarizationEngine` instance is retained by this pipeline, so the
+    /// downloaded/prepared models are reused instead of rebuilt per job.
+    func prepareDiarizationModels() async {
+        await diarizer.prepareModels()
+        // A recording-time prewarm may already own the engine's preparation.
+        // `prepareModels()` is idempotent and returns for secondary callers, so
+        // wait for that retained instance to finish before entering diarization.
+        while diarizer.isPreparing, !Task.isCancelled {
+            try? await Task.sleep(for: .milliseconds(100))
+        }
     }
 
     private func write(_ transcript: Transcript, to folder: URL) throws {
@@ -444,6 +510,7 @@ final class ProcessingPipeline: ObservableObject {
     private func extractOutcomes(transcript: Transcript, summary: String,
                                  folder: URL, config: AppSettings) async {
         do {
+            try Task.checkCancellation()
             let engine = try await makeTextEngine(config)
             let output = try await engine.generate(
                 system: OutcomesExtractor.systemPrompt,
@@ -451,14 +518,25 @@ final class ProcessingPipeline: ObservableObject {
                                                  summary: summary),
                 context: MeetingNotes.promptContext(in: folder),
                 schema: OutcomesExtractor.schema)
+            try Task.checkCancellation()
             guard let outcomes = OutcomesExtractor.parse(output) else {
                 lokalbotLog("outcomes extraction unparseable, skipping")
                 return
             }
+            try Task.checkCancellation()
             try outcomes.write(to: folder)
         } catch {
             lokalbotLog("outcomes extraction failed error=\(error.localizedDescription)")
         }
+    }
+
+    /// Cancellation is cooperative; some inference backends may not return
+    /// immediately. A failed summary must not let its sibling outcomes task
+    /// outlive the job and race a retry's artifact writes.
+    nonisolated static func cancelAndWaitForOutcomes(_ task: Task<Void, Never>?) async {
+        guard let task else { return }
+        task.cancel()
+        await task.value
     }
 
     /// Day digest (M4/M6) — shared by the Timeline UI and `--digest`. `ocr` is
@@ -513,10 +591,11 @@ final class ProcessingPipeline: ObservableObject {
                 throw PipelineError.badServerURL
             }
             let modelURL = try await prepareBuiltInModel(config)
+            let authenticationToken = await server.authenticationToken()
             let engine = OpenAICompatibleEngine(
                 baseURL: server.baseURL,
                 model: entry.id,
-                apiKey: nil,
+                apiKey: authenticationToken,
                 extraBody: entry.disablesThinking
                     ? ["chat_template_kwargs": ["enable_thinking": false]] : [:],
                 displayNameOverride: "Built-in — \(entry.displayName)")

--- a/LokalBot/Services/ProcessingPipeline.swift
+++ b/LokalBot/Services/ProcessingPipeline.swift
@@ -644,9 +644,8 @@ final class ProcessingPipeline: ObservableObject {
                 ?? ModelCatalog.entry(id: ModelCatalog.recommendedSummarizationID) else {
             throw PipelineError.badServerURL
         }
-        if let existing = ModelCatalog.localURL(for: entry, storage: storage) {
-            return existing
-        }
+        // The preparer also validates legacy on-disk models. Bypassing it for a
+        // GGUF header match would skip the newly pinned SHA-256 digest.
         return try await builtInModelPreparer(entry, storage)
     }
 

--- a/LokalBot/Services/RecordingController.swift
+++ b/LokalBot/Services/RecordingController.swift
@@ -1,6 +1,22 @@
 import Foundation
 import Combine
 
+struct SystemAudioSamePIDRetryBudget: Equatable {
+    static let maximumAttempts = 2
+
+    private(set) var attempts = 0
+
+    var canRetry: Bool { attempts < Self.maximumAttempts }
+
+    mutating func recordRetry() {
+        attempts = min(attempts + 1, Self.maximumAttempts)
+    }
+
+    mutating func reset() {
+        attempts = 0
+    }
+}
+
 /// Owns the meeting-recording lifecycle: the two recorders (mic + system tap),
 /// the start/stop state machine, the capture-health watchdog, the menu-bar
 /// timer tick, and transcription-model prewarm. `AppState` keeps a reference,
@@ -11,6 +27,7 @@ final class RecordingController: ObservableObject {
 
     enum Status: Equatable {
         case idle
+        case starting
         case recording(meetingID: UUID)
     }
 
@@ -46,7 +63,7 @@ final class RecordingController: ObservableObject {
     private var didWarnAboutMicCaptureStall = false
     private var lastSystemAudioReattachAt: Date?
     private var didWarnAboutSilentSystemAudio = false
-    private var samePIDSystemAudioRetryCount = 0
+    private var samePIDSystemAudioRetryBudget = SystemAudioSamePIDRetryBudget()
     private static let recordingHealthWatchdogInterval: TimeInterval = 5
     private static let micCaptureInitialGrace: TimeInterval = 8
     private static let micCaptureStallGrace: TimeInterval = 15
@@ -66,11 +83,9 @@ final class RecordingController: ObservableObject {
     private var recordingTick: AnyCancellable?
     private var transcriptionPrewarmTask: Task<Void, Never>?
     private var summaryPrewarmTask: Task<Void, Never>?
-
-    /// Synchronous re-entrancy latch: `status` only flips inside the async
-    /// start task, so without this, rapid triggers (detector ticks, double
-    /// clicks) all pass the `!isRecording` guard and create empty meetings.
-    private var isStartingRecording = false
+    private var diarizationPrewarmTask: Task<Void, Never>?
+    private var startTask: Task<Void, Never>?
+    private var systemAudioHandoffTask: Task<Void, Never>?
 
     init(storage: StorageManager,
          settingsStore: SettingsStore,
@@ -86,17 +101,15 @@ final class RecordingController: ObservableObject {
         self.isInteractive = isInteractive
         self.onError = onError
         self.onMeetingFinished = onMeetingFinished
-        systemRecorder.onCapturedProcessTerminated = { [weak self] in
-            guard let self, self.isRecording else { return }
-            self.onError("Meeting app exited — recording stopped.")
-            self.stop()
+        systemRecorder.onCapturedProcessTerminated = { [weak self] pid in
+            self?.handleCapturedProcessTermination(pid)
         }
     }
 
     private var settings: AppSettings { settingsStore.current }
 
     var isRecording: Bool { if case .recording = status { true } else { false } }
-    var isStarting: Bool { isStartingRecording }
+    var isStarting: Bool { if case .starting = status { true } else { false } }
     var elapsed: TimeInterval {
         guard let m = currentMeeting else { return 0 }
         return max(0, now.timeIntervalSince(m.startedAt))
@@ -116,13 +129,15 @@ final class RecordingController: ObservableObject {
         transcriptionPrewarmTask = nil
         summaryPrewarmTask?.cancel()
         summaryPrewarmTask = nil
-        if isRecording { stop(process: false) }
+        diarizationPrewarmTask?.cancel()
+        diarizationPrewarmTask = nil
+        if isRecording || isStarting { stop(process: false) }
     }
 
     // MARK: - Start / stop
 
     func start(context: MeetingDetectionContext? = nil, source: String = "ui") {
-        guard !isRecording, !isStartingRecording else { return }
+        guard case .idle = status, startTask == nil else { return }
         let detectedApp = context?.detectedApp
         let calendarEvent = context?.calendarEvent
         // Don't immediately re-record the same scheduled event after one ended.
@@ -133,20 +148,26 @@ final class RecordingController: ObservableObject {
             lokalbotLog("startRecording suppressed: calendar event \(calendarEvent?.externalID ?? "?") within cooldown")
             return
         }
-        isStartingRecording = true
+        status = .starting
         audioMonitor.isRecordingActive = true
         audioMonitor.accept()
         lokalbotLog("startRecording source=\(source) app=\(detectedApp?.name ?? "manual") calendar=\(calendarEvent?.title ?? "none")")
-        Task {
-            defer { isStartingRecording = false }
+        startTask = Task { [weak self] in
+            guard let self else { return }
+            var created: Meeting?
+            defer {
+                self.startTask = nil
+                if case .starting = self.status { self.status = .idle }
+            }
             guard await MicRecorder.requestPermission() else {
+                guard !Task.isCancelled else { return }
                 onError("Microphone permission denied.")
                 audioMonitor.isRecordingActive = false
                 audioMonitor.reseed()
                 return
             }
-            var created: Meeting?
             do {
+                try Task.checkCancellation()
                 let title = MeetingMatcher.recordingTitle(
                     calendarTitle: calendarEvent?.title,
                     useCalendarTitles: settings.useCalendarTitles,
@@ -166,11 +187,13 @@ final class RecordingController: ObservableObject {
                     try? storage.saveMeta(meeting)
                 }
                 created = meeting
+                try Task.checkCancellation()
                 try micRecorder.start(
                     writingTo: meeting.folderURL(in: storage).appendingPathComponent("mic.m4a"),
                     previewTee: meeting.folderURL(in: storage)
                         .appendingPathComponent(AudioPreviewTee.micFileName))
                 startRecordingHealthWatchdog()
+                try Task.checkCancellation()
 
                 if let detectedApp {
                     let captureProcess = MeetingDetector.currentOutputAudioProcess(for: detectedApp)
@@ -196,6 +219,7 @@ final class RecordingController: ObservableObject {
                         lokalbotLog("system audio tap FAILED: \(error.localizedDescription)")
                     }
                 }
+                try Task.checkCancellation()
                 currentMeeting = meeting
                 status = .recording(meetingID: meeting.id)
                 startRecordingTick()
@@ -203,7 +227,10 @@ final class RecordingController: ObservableObject {
                     RecordingNotifier.shared.recordingStarted(title: meeting.title)
                     prewarmSelectedTranscriptionModel(reason: source)
                     prewarmSelectedSummaryModel(reason: source)
+                    prewarmDiarizationModels(reason: source)
                 }
+            } catch is CancellationError {
+                cleanupCancelledStart(created: created)
             } catch {
                 onError("Could not start recording: \(error.localizedDescription)")
                 lokalbotLog("startRecording FAILED: \(error.localizedDescription)")
@@ -212,13 +239,24 @@ final class RecordingController: ObservableObject {
                 audioMonitor.isRecordingActive = false
                 audioMonitor.reseed()
                 // Don't leave a 0-minute husk in the library.
-                if let husk = created { storage.deleteMeeting(husk) }
+                micRecorder.stop()
+                systemRecorder.stop()
+                if let husk = created { try? storage.deleteMeeting(husk) }
             }
         }
     }
 
     func stop(process: Bool = true) {
+        if isStarting {
+            startTask?.cancel()
+            status = .idle
+            audioMonitor.isRecordingActive = false
+            audioMonitor.reseed()
+            return
+        }
         guard isRecording, var meeting = currentMeeting else { return }
+        systemAudioHandoffTask?.cancel()
+        systemAudioHandoffTask = nil
         stopRecordingHealthWatchdog()
         micRecorder.stop()
         systemRecorder.stop()
@@ -266,17 +304,31 @@ final class RecordingController: ObservableObject {
     }
 
     func splitForCalendarHandoff(_ context: MeetingDetectionContext) {
-        guard isRecording, !isStartingRecording,
-              let currentMeeting,
-              let nextEventID = context.calendarEvent?.externalID,
+        guard isRecording, !isStarting, let currentMeeting else { return }
+        guard let nextEventID = context.calendarEvent?.externalID,
               MeetingMatcher.shouldSplitForCalendarHandoff(
-                  activeEventID: currentMeeting.calendarEventID,
-                  nextEventID: nextEventID)
-        else { return }
+                activeEventID: currentMeeting.calendarEventID,
+                nextEventID: nextEventID) else {
+            if let detectedApp = context.detectedApp {
+                retargetSystemAudio(to: detectedApp)
+            }
+            return
+        }
         lokalbotLog(
             "calendar handoff split old=\(currentMeeting.calendarEventID ?? "?") new=\(nextEventID)")
         stop()
         start(context: context, source: "calendar-handoff")
+    }
+
+    private func cleanupCancelledStart(created: Meeting?) {
+        stopRecordingHealthWatchdog()
+        micRecorder.stop()
+        systemRecorder.stop()
+        systemAudioTarget = nil
+        audioMonitor.isRecordingActive = false
+        audioMonitor.reseed()
+        if let created { try? storage.deleteMeeting(created) }
+        lokalbotLog("recording start cancelled")
     }
 
     private func prewarmSelectedTranscriptionModel(reason: String) {
@@ -324,6 +376,17 @@ final class RecordingController: ObservableObject {
         }
     }
 
+    private func prewarmDiarizationModels(reason: String) {
+        guard settings.multiSpeakerDiarization, diarizationPrewarmTask == nil else { return }
+        diarizationPrewarmTask = Task { [weak self, reason] in
+            lokalbotLog("diarization prewarm start reason=\(reason)")
+            await self?.pipeline.prepareDiarizationModels()
+            guard !Task.isCancelled else { return }
+            lokalbotLog("diarization prewarm ready reason=\(reason)")
+            self?.diarizationPrewarmTask = nil
+        }
+    }
+
     /// Start/stop the once-a-second clock that keeps the menu bar timer live.
     private func startRecordingTick() {
         now = Date()
@@ -345,7 +408,7 @@ final class RecordingController: ObservableObject {
         didWarnAboutMicCaptureStall = false
         lastSystemAudioReattachAt = nil
         didWarnAboutSilentSystemAudio = false
-        samePIDSystemAudioRetryCount = 0
+        samePIDSystemAudioRetryBudget.reset()
         recordingHealthWatchdog = Timer.publish(
             every: Self.recordingHealthWatchdogInterval,
             on: .main,
@@ -364,7 +427,7 @@ final class RecordingController: ObservableObject {
         didWarnAboutMicCaptureStall = false
         lastSystemAudioReattachAt = nil
         didWarnAboutSilentSystemAudio = false
-        samePIDSystemAudioRetryCount = 0
+        samePIDSystemAudioRetryBudget.reset()
     }
 
     private func checkMicCapture() {
@@ -374,8 +437,25 @@ final class RecordingController: ObservableObject {
         guard elapsed >= Self.micCaptureInitialGrace else { return }
 
         let health = micRecorder.captureHealth()
+        switch health.recoveryState {
+        case .healthy:
+            if health.isEngineRunning { didWarnAboutMicCaptureStall = false }
+        case .recovering:
+            // MicRecorder owns the bounded device-reconfiguration recovery.
+            // Avoid racing it with a second graph rebuild from this watchdog.
+            return
+        case .degraded(let errorDescription):
+            if !didWarnAboutMicCaptureStall {
+                didWarnAboutMicCaptureStall = true
+                onError(
+                    "Microphone capture could not recover (\(errorDescription)). "
+                        + "Recording is continuing with system audio when available.")
+            }
+            return
+        }
         let captureLag = elapsed - health.duration
-        guard captureLag >= Self.micCaptureStallGrace else { return }
+        let silentFor = now.timeIntervalSince(health.lastAudioWriteAt ?? meeting.startedAt)
+        guard !health.isEngineRunning || silentFor >= Self.micCaptureStallGrace else { return }
 
         if let lastMicRestartAt,
            now.timeIntervalSince(lastMicRestartAt) < Self.micCaptureRestartCooldown {
@@ -387,15 +467,11 @@ final class RecordingController: ObservableObject {
             lastMicRestartAt = now
             didWarnAboutMicCaptureStall = false
             lokalbotLog(
-                "mic recorder restarted elapsed=\(String(format: "%.2fs", elapsed)) captured=\(String(format: "%.2fs", health.duration)) lag=\(String(format: "%.2fs", captureLag)) engineRunning=\(health.isEngineRunning)")
+                "mic recorder restarted elapsed=\(String(format: "%.2fs", elapsed)) captured=\(String(format: "%.2fs", health.duration)) lag=\(String(format: "%.2fs", captureLag)) silentFor=\(String(format: "%.2fs", silentFor)) engineRunning=\(health.isEngineRunning)")
         } catch {
             lastMicRestartAt = now
-            if !didWarnAboutMicCaptureStall {
-                didWarnAboutMicCaptureStall = true
-                onError("Microphone capture stalled (\(error.localizedDescription)); LokalBot is still trying to recover system audio.")
-            }
             lokalbotLog(
-                "mic recorder restart FAILED elapsed=\(String(format: "%.2fs", elapsed)) captured=\(String(format: "%.2fs", health.duration)) lag=\(String(format: "%.2fs", captureLag)): \(error.localizedDescription)")
+                "mic recorder restart deferred to bounded recovery elapsed=\(String(format: "%.2fs", elapsed)) captured=\(String(format: "%.2fs", health.duration)) lag=\(String(format: "%.2fs", captureLag)): \(error.localizedDescription)")
         }
     }
 
@@ -434,7 +510,7 @@ final class RecordingController: ObservableObject {
                                            peakRMS: health.peakRMSLevel)
             return
         }
-        guard !isSamePIDRetry || samePIDSystemAudioRetryCount < 2 else {
+        guard !isSamePIDRetry || samePIDSystemAudioRetryBudget.canRetry else {
             warnOnceAboutSilentSystemAudio(elapsed: elapsed, captured: health.duration,
                                            audible: health.audibleDuration,
                                            rms: health.lastRMSLevel,
@@ -448,7 +524,11 @@ final class RecordingController: ObservableObject {
             target.pid = candidate.id
             systemAudioTarget = target
             lastSystemAudioReattachAt = now
-            samePIDSystemAudioRetryCount = isSamePIDRetry ? samePIDSystemAudioRetryCount + 1 : 0
+            if isSamePIDRetry {
+                samePIDSystemAudioRetryBudget.recordRetry()
+            } else {
+                samePIDSystemAudioRetryBudget.reset()
+            }
             didWarnAboutSilentSystemAudio = false
             lokalbotLog(
                 "system audio reattached oldPID=\(previousPID) newPID=\(candidate.id) bundle=\(candidate.bundleID ?? "unknown") captured=\(String(format: "%.2fs", health.duration)) audible=\(String(format: "%.2fs", health.audibleDuration)) silentFor=\(String(format: "%.2fs", silentFor)) rms=\(String(format: "%.6f", health.lastRMSLevel)) peakRMS=\(String(format: "%.6f", health.peakRMSLevel))")
@@ -464,6 +544,64 @@ final class RecordingController: ObservableObject {
             name: target.bundleID,
             bundleID: target.bundleID,
             pid: target.pid))
+    }
+
+    /// Helper processes routinely exit during a live browser/Zoom meeting.
+    /// Give Core Audio a short window to publish the replacement and reattach
+    /// the existing writer; the detector, not helper churn, owns whole-meeting
+    /// termination. Microphone recording continues throughout.
+    private func handleCapturedProcessTermination(_ terminatedPID: pid_t) {
+        guard isRecording, systemAudioTarget?.pid == terminatedPID else { return }
+        systemAudioHandoffTask?.cancel()
+        systemAudioHandoffTask = Task { [weak self] in
+            guard let self else { return }
+            let delays: [TimeInterval] = [0.15, 0.35, 0.7, 1.2, 2.0]
+            for delay in delays {
+                do { try await Task.sleep(for: .seconds(delay)) } catch { return }
+                guard self.isRecording, var target = self.systemAudioTarget,
+                      target.pid == terminatedPID else { return }
+                MeetingDetector.invalidateAudioProcessSnapshot()
+                guard let candidate = self.currentSystemAudioCandidate(for: target),
+                      candidate.id != terminatedPID else { continue }
+                do {
+                    try self.systemRecorder.reattach(capturingPID: candidate.id)
+                    target.pid = candidate.id
+                    self.systemAudioTarget = target
+                    self.lastSystemAudioReattachAt = Date()
+                    self.samePIDSystemAudioRetryBudget.reset()
+                    self.didWarnAboutSilentSystemAudio = false
+                    lokalbotLog(
+                        "system audio helper handoff oldPID=\(terminatedPID) newPID=\(candidate.id) bundle=\(candidate.bundleID ?? "unknown")")
+                    self.systemAudioHandoffTask = nil
+                    return
+                } catch {
+                    lokalbotLog("system audio helper handoff retry failed: \(error.localizedDescription)")
+                }
+            }
+            guard self.isRecording, self.systemAudioTarget?.pid == terminatedPID else { return }
+            self.onError("System audio capture was interrupted; LokalBot is still recording the microphone and will keep looking for the meeting app.")
+            self.systemAudioHandoffTask = nil
+        }
+    }
+
+    private func retargetSystemAudio(to app: MeetingDetector.DetectedApp) {
+        guard isRecording else { return }
+        MeetingDetector.invalidateAudioProcessSnapshot()
+        guard let candidate = MeetingDetector.currentOutputAudioProcess(for: app) else { return }
+        if systemAudioTarget?.bundleID == app.bundleID,
+           systemAudioTarget?.pid == candidate.id { return }
+        do {
+            try systemRecorder.reattach(capturingPID: candidate.id)
+            systemAudioTarget = SystemAudioTarget(bundleID: app.bundleID, pid: candidate.id)
+            lastSystemAudioReattachAt = Date()
+            samePIDSystemAudioRetryBudget.reset()
+            didWarnAboutSilentSystemAudio = false
+            lokalbotLog(
+                "system audio meeting handoff app=\(app.bundleID) pid=\(candidate.id)")
+        } catch {
+            onError("Could not switch system audio capture to \(app.name); microphone recording is continuing.")
+            lokalbotLog("system audio meeting handoff FAILED: \(error.localizedDescription)")
+        }
     }
 
     private func warnOnceAboutSilentSystemAudio(elapsed: TimeInterval, captured: TimeInterval,

--- a/LokalBot/Services/RecordingNotifier.swift
+++ b/LokalBot/Services/RecordingNotifier.swift
@@ -1,6 +1,45 @@
 import Foundation
 import UserNotifications
 
+@MainActor
+struct RecordingPromptRegistry {
+    struct PendingPrompt {
+        let expiresAt: Date
+        let record: @MainActor () -> Void
+    }
+
+    private var prompts: [String: PendingPrompt] = [:]
+
+    mutating func insert(identifier: String, expiresAt: Date,
+                         record: @escaping @MainActor () -> Void) {
+        prompts[identifier] = PendingPrompt(expiresAt: expiresAt, record: record)
+    }
+
+    func contains(_ identifier: String) -> Bool {
+        prompts[identifier] != nil
+    }
+
+    mutating func remove(_ identifier: String) -> PendingPrompt? {
+        prompts.removeValue(forKey: identifier)
+    }
+
+    mutating func removeAll() -> [String] {
+        let identifiers = Array(prompts.keys)
+        prompts.removeAll()
+        return identifiers
+    }
+
+    mutating func removeExpired(now: Date) -> [String] {
+        let identifiers = prompts.compactMap { identifier, prompt in
+            prompt.expiresAt <= now ? identifier : nil
+        }
+        for identifier in identifiers {
+            prompts.removeValue(forKey: identifier)
+        }
+        return identifiers
+    }
+}
+
 /// Local notifications that announce recording start/stop, so the user knows a
 /// meeting is being captured without keeping the window open. This is the
 /// "push" half of the menu-bar-only experience; the always-visible menu bar
@@ -18,12 +57,7 @@ final class RecordingNotifier: NSObject, UNUserNotificationCenterDelegate {
     private static let recordAction = "lokalbot.record-detected-meeting"
     private static let ignoreAction = "lokalbot.ignore-detected-meeting"
 
-    private struct PendingDetection {
-        let expiresAt: Date
-        let record: @MainActor () -> Void
-    }
-
-    private var pendingDetections: [String: PendingDetection] = [:]
+    private var pendingDetections = RecordingPromptRegistry()
 
     /// Install the foreground-presentation delegate. Called once at launch from
     /// the interactive (non-headless, non-UI-test) path.
@@ -63,8 +97,10 @@ final class RecordingNotifier: NSObject, UNUserNotificationCenterDelegate {
                          expiresAfter: TimeInterval = 2 * 60,
                          onRecord: @escaping @MainActor () -> Void) {
         purgeExpiredDetections()
+        invalidateMeetingDetections()
         let identifier = "meeting-detected-\(UUID().uuidString)"
-        pendingDetections[identifier] = PendingDetection(
+        pendingDetections.insert(
+            identifier: identifier,
             expiresAt: Date().addingTimeInterval(expiresAfter),
             record: onRecord)
         post(
@@ -97,15 +133,44 @@ final class RecordingNotifier: NSObject, UNUserNotificationCenterDelegate {
                 authorized = (try? await center.requestAuthorization(options: [.alert, .sound])) == true
             }
             guard authorized else {
-                pendingDetections.removeValue(forKey: identifier)
+                _ = pendingDetections.remove(identifier)
                 return
             }
-            try? await center.add(request)
+            if categoryIdentifier == Self.detectionCategory,
+               !pendingDetections.contains(identifier) {
+                return
+            }
+            do {
+                try await center.add(request)
+            } catch {
+                if categoryIdentifier == Self.detectionCategory {
+                    _ = pendingDetections.remove(identifier)
+                }
+                return
+            }
+            // `add` suspends. A meeting can end while the notification center
+            // is accepting the request, after invalidation already tried to
+            // remove it. Clean up the newly added request on resume as well.
+            if categoryIdentifier == Self.detectionCategory,
+               !pendingDetections.contains(identifier) {
+                removeNotifications(withIdentifiers: [identifier])
+            }
         }
     }
 
+    func invalidateMeetingDetections() {
+        removeNotifications(withIdentifiers: pendingDetections.removeAll())
+    }
+
     private func purgeExpiredDetections(now: Date = Date()) {
-        pendingDetections = pendingDetections.filter { $0.value.expiresAt > now }
+        removeNotifications(withIdentifiers: pendingDetections.removeExpired(now: now))
+    }
+
+    private func removeNotifications(withIdentifiers identifiers: [String]) {
+        guard !identifiers.isEmpty else { return }
+        let center = UNUserNotificationCenter.current()
+        center.removePendingNotificationRequests(withIdentifiers: identifiers)
+        center.removeDeliveredNotifications(withIdentifiers: identifiers)
     }
 
     // Show the banner even when LokalBot happens to be the active app (e.g. the
@@ -126,7 +191,7 @@ final class RecordingNotifier: NSObject, UNUserNotificationCenterDelegate {
 
     private func handle(_ response: UNNotificationResponse) {
         let identifier = response.notification.request.identifier
-        guard let pending = pendingDetections.removeValue(forKey: identifier) else { return }
+        guard let pending = pendingDetections.remove(identifier) else { return }
         guard response.actionIdentifier == Self.recordAction,
               pending.expiresAt > Date() else { return }
         pending.record()

--- a/LokalBot/Services/RecordingNotifier.swift
+++ b/LokalBot/Services/RecordingNotifier.swift
@@ -14,23 +14,38 @@ import UserNotifications
 final class RecordingNotifier: NSObject, UNUserNotificationCenterDelegate {
     static let shared = RecordingNotifier()
 
-    private var didRequestAuthorization = false
+    private static let detectionCategory = "lokalbot.meeting-detected"
+    private static let recordAction = "lokalbot.record-detected-meeting"
+    private static let ignoreAction = "lokalbot.ignore-detected-meeting"
+
+    private struct PendingDetection {
+        let expiresAt: Date
+        let record: @MainActor () -> Void
+    }
+
+    private var pendingDetections: [String: PendingDetection] = [:]
 
     /// Install the foreground-presentation delegate. Called once at launch from
     /// the interactive (non-headless, non-UI-test) path.
     func bootstrap() {
-        UNUserNotificationCenter.current().delegate = self
-    }
-
-    private func ensureAuthorization() {
-        guard !didRequestAuthorization else { return }
-        didRequestAuthorization = true
-        UNUserNotificationCenter.current()
-            .requestAuthorization(options: [.alert, .sound]) { _, _ in }
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
+        let record = UNNotificationAction(
+            identifier: Self.recordAction,
+            title: "Record",
+            options: [.foreground])
+        let ignore = UNNotificationAction(
+            identifier: Self.ignoreAction,
+            title: "Ignore")
+        let category = UNNotificationCategory(
+            identifier: Self.detectionCategory,
+            actions: [record, ignore],
+            intentIdentifiers: [],
+            options: [.customDismissAction])
+        center.setNotificationCategories([category])
     }
 
     func recordingStarted(title: String) {
-        ensureAuthorization()
         post(title: "Recording started", body: title)
     }
 
@@ -41,15 +56,56 @@ final class RecordingNotifier: NSObject, UNUserNotificationCenterDelegate {
         post(title: "Recording saved", body: body)
     }
 
-    private func post(title: String, body: String) {
+    /// Posts a real, actionable prompt for `.ask` recording mode. The action
+    /// expires so clicking an old notification cannot begin capturing an
+    /// unrelated meeting hours later.
+    func meetingDetected(title: String,
+                         expiresAfter: TimeInterval = 2 * 60,
+                         onRecord: @escaping @MainActor () -> Void) {
+        purgeExpiredDetections()
+        let identifier = "meeting-detected-\(UUID().uuidString)"
+        pendingDetections[identifier] = PendingDetection(
+            expiresAt: Date().addingTimeInterval(expiresAfter),
+            record: onRecord)
+        post(
+            title: "Meeting detected",
+            body: "Record \(title)?",
+            identifier: identifier,
+            categoryIdentifier: Self.detectionCategory)
+    }
+
+    private func post(title: String,
+                      body: String,
+                      identifier: String = UUID().uuidString,
+                      categoryIdentifier: String? = nil) {
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
+        if let categoryIdentifier {
+            content.categoryIdentifier = categoryIdentifier
+        }
         // `trigger: nil` delivers immediately. A fresh identifier each time so a
         // start and a stop don't coalesce into one another.
         let request = UNNotificationRequest(
-            identifier: UUID().uuidString, content: content, trigger: nil)
-        UNUserNotificationCenter.current().add(request)
+            identifier: identifier, content: content, trigger: nil)
+        let center = UNUserNotificationCenter.current()
+        Task {
+            let settings = await center.notificationSettings()
+            var authorized = settings.authorizationStatus == .authorized
+                || settings.authorizationStatus == .provisional
+            if settings.authorizationStatus == .notDetermined {
+                authorized = (try? await center.requestAuthorization(options: [.alert, .sound])) == true
+            }
+            guard authorized else {
+                pendingDetections.removeValue(forKey: identifier)
+                return
+            }
+            try? await center.add(request)
+        }
+    }
+
+    private func purgeExpiredDetections(now: Date = Date()) {
+        pendingDetections = pendingDetections.filter { $0.value.expiresAt > now }
     }
 
     // Show the banner even when LokalBot happens to be the active app (e.g. the
@@ -59,5 +115,20 @@ final class RecordingNotifier: NSObject, UNUserNotificationCenterDelegate {
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
         [.banner, .list, .sound]
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        await handle(response)
+    }
+
+    private func handle(_ response: UNNotificationResponse) {
+        let identifier = response.notification.request.identifier
+        guard let pending = pendingDetections.removeValue(forKey: identifier) else { return }
+        guard response.actionIdentifier == Self.recordAction,
+              pending.expiresAt > Date() else { return }
+        pending.record()
     }
 }

--- a/LokalBot/Services/SQLiteDatabase.swift
+++ b/LokalBot/Services/SQLiteDatabase.swift
@@ -1,16 +1,103 @@
 import Foundation
 import SQLite3
 
+/// Small SQLite wrapper shared by the app's indexes and durable queues.
+///
+/// The checked APIs preserve SQLite failures as typed errors. The legacy
+/// boolean/empty-result APIs remain for source compatibility, but now log the
+/// same failure instead of silently hiding it.
 final class SQLiteDatabase {
+    enum DatabaseError: Swift.Error, LocalizedError {
+        case unavailable(path: String)
+        case open(path: String, code: Int32, message: String)
+        case configure(operation: String, code: Int32, message: String)
+        case execute(sql: String, code: Int32, message: String)
+        case prepare(sql: String, code: Int32, message: String)
+        case bind(index: Int32, code: Int32, message: String)
+        case reset(code: Int32, message: String)
+        case step(sql: String?, code: Int32, message: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .unavailable(let path):
+                "SQLite database is unavailable at \(path)"
+            case .open(let path, let code, let message):
+                "SQLite open failed (\(code)) at \(path): \(message)"
+            case .configure(let operation, let code, let message):
+                "SQLite configuration failed for \(operation) (\(code)): \(message)"
+            case .execute(let sql, let code, let message):
+                "SQLite execute failed (\(code)): \(message) [\(Self.summary(sql))]"
+            case .prepare(let sql, let code, let message):
+                "SQLite prepare failed (\(code)): \(message) [\(Self.summary(sql))]"
+            case .bind(let index, let code, let message):
+                "SQLite bind failed at parameter \(index) (\(code)): \(message)"
+            case .reset(let code, let message):
+                "SQLite statement reset failed (\(code)): \(message)"
+            case .step(let sql, let code, let message):
+                "SQLite step failed (\(code)): \(message)"
+                    + (sql.map { " [\(Self.summary($0))]" } ?? "")
+            }
+        }
+
+        private static func summary(_ sql: String) -> String {
+            let singleLine = sql.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+            return String(singleLine.prefix(180))
+        }
+    }
+
     static let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
     private let db: OpaquePointer
+    private(set) var lastError: DatabaseError?
+    private var errorGeneration: UInt64 = 0
 
     init?(url: URL) {
         var opened: OpaquePointer?
-        guard sqlite3_open(url.path, &opened) == SQLITE_OK, let opened else {
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
+        let result = sqlite3_open_v2(url.path, &opened, flags, nil)
+        guard result == SQLITE_OK, let opened else {
+            let message = opened.map { String(cString: sqlite3_errmsg($0)) }
+                ?? String(cString: sqlite3_errstr(result))
             if let opened { sqlite3_close(opened) }
+            let error = DatabaseError.open(path: url.path, code: result, message: message)
+            AppLog.line(error.localizedDescription)
             return nil
+        }
+        sqlite3_extended_result_codes(opened, 1)
+
+        let timeoutResult = sqlite3_busy_timeout(opened, 5_000)
+        guard timeoutResult == SQLITE_OK else {
+            let error = DatabaseError.configure(
+                operation: "busy_timeout", code: timeoutResult,
+                message: String(cString: sqlite3_errmsg(opened)))
+            AppLog.line(error.localizedDescription)
+            sqlite3_close(opened)
+            return nil
+        }
+
+        // Multiple app components own independent connections to the same
+        // database. WAL lets readers proceed during a writer transaction;
+        // NORMAL keeps the durability/performance tradeoff appropriate for
+        // locally reconstructible indexes and queues. Configure the raw handle
+        // before assigning `db`, so a failed failable initializer owns exactly
+        // one close path.
+        for (operation, sql) in [
+            ("journal_mode", "PRAGMA journal_mode=WAL;"),
+            ("synchronous", "PRAGMA synchronous=NORMAL;"),
+            ("foreign_keys", "PRAGMA foreign_keys=ON;"),
+        ] {
+            var errorMessage: UnsafeMutablePointer<CChar>?
+            let configureResult = sqlite3_exec(opened, sql, nil, nil, &errorMessage)
+            guard configureResult == SQLITE_OK else {
+                let message = errorMessage.map { String(cString: $0) }
+                    ?? String(cString: sqlite3_errmsg(opened))
+                if let errorMessage { sqlite3_free(errorMessage) }
+                let error = DatabaseError.configure(
+                    operation: operation, code: configureResult, message: message)
+                AppLog.line(error.localizedDescription)
+                sqlite3_close(opened)
+                return nil
+            }
         }
         db = opened
     }
@@ -19,9 +106,141 @@ final class SQLiteDatabase {
         sqlite3_close(db)
     }
 
+    // MARK: - Checked APIs
+
+    func execute(_ sql: String) throws {
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(db, sql, nil, nil, &errorMessage)
+        guard result == SQLITE_OK else {
+            let message = errorMessage.map { String(cString: $0) }
+                ?? String(cString: sqlite3_errmsg(db))
+            if let errorMessage { sqlite3_free(errorMessage) }
+            throw record(.execute(sql: sql, code: result, message: message))
+        }
+    }
+
+    func runChecked(_ sql: String, bind values: [Any] = []) throws {
+        try withPreparedStatement(sql, bind: values) { statement in
+            try stepToCompletion(statement, sql: sql)
+        }
+    }
+
+    /// Executes an already-prepared statement, resetting and rebinding it so
+    /// callers can reuse one statement for a batch of rows.
+    func runChecked(_ statement: OpaquePointer, bind values: [Any] = []) throws {
+        let resetResult = sqlite3_reset(statement)
+        guard resetResult == SQLITE_OK else {
+            throw record(.reset(code: resetResult, message: message))
+        }
+        sqlite3_clear_bindings(statement)
+        try bindChecked(values, to: statement)
+        try stepToCompletion(statement, sql: nil)
+    }
+
+    /// Runs a group of writes atomically. Any thrown error rolls the whole
+    /// group back before it is propagated to the caller.
+    func withTransaction<T>(_ body: () throws -> T) throws -> T {
+        try execute("BEGIN IMMEDIATE TRANSACTION")
+        do {
+            let value = try body()
+            try execute("COMMIT")
+            return value
+        } catch {
+            do {
+                try execute("ROLLBACK")
+            } catch let rollbackError {
+                AppLog.line("SQLite rollback also failed: \(rollbackError.localizedDescription)")
+            }
+            throw error
+        }
+    }
+
+    func queryChecked<T>(_ sql: String, bind values: [Any] = [],
+                         row: (OpaquePointer) -> T?) throws -> [T] {
+        try withPreparedStatement(sql, bind: values) { statement in
+            var rows: [T] = []
+            var result = sqlite3_step(statement)
+            while result == SQLITE_ROW {
+                if let value = row(statement) {
+                    rows.append(value)
+                }
+                result = sqlite3_step(statement)
+            }
+            guard result == SQLITE_DONE else {
+                throw record(.step(sql: sql, code: result, message: message))
+            }
+            return rows
+        }
+    }
+
+    /// Stream rows without building an intermediate array. Returning `false`
+    /// from `row` intentionally stops iteration (useful for bounded context
+    /// assembly); SQLite failures encountered before that point still throw.
+    func forEachRowChecked(_ sql: String, bind values: [Any] = [],
+                           row: (OpaquePointer) -> Bool) throws {
+        try withPreparedStatement(sql, bind: values) { statement in
+            var result = sqlite3_step(statement)
+            while result == SQLITE_ROW {
+                guard row(statement) else { return }
+                result = sqlite3_step(statement)
+            }
+            guard result == SQLITE_DONE else {
+                throw record(.step(sql: sql, code: result, message: message))
+            }
+        }
+    }
+
+    func firstDoubleChecked(_ sql: String, bind values: [Any] = []) throws -> Double? {
+        try withPreparedStatement(sql, bind: values) { statement in
+            let result = sqlite3_step(statement)
+            switch result {
+            case SQLITE_ROW:
+                return sqlite3_column_double(statement, 0)
+            case SQLITE_DONE:
+                return nil
+            default:
+                throw record(.step(sql: sql, code: result, message: message))
+            }
+        }
+    }
+
+    func hasRowChecked(_ sql: String, bind values: [Any] = []) throws -> Bool {
+        try withPreparedStatement(sql, bind: values) { statement in
+            let result = sqlite3_step(statement)
+            switch result {
+            case SQLITE_ROW:
+                return true
+            case SQLITE_DONE:
+                return false
+            default:
+                throw record(.step(sql: sql, code: result, message: message))
+            }
+        }
+    }
+
+    @discardableResult
+    func withPreparedStatement<T>(_ sql: String, bind values: [Any] = [],
+                                  _ body: (OpaquePointer) throws -> T) throws -> T {
+        var statement: OpaquePointer?
+        let result = sqlite3_prepare_v2(db, sql, -1, &statement, nil)
+        guard result == SQLITE_OK, let statement else {
+            throw record(.prepare(sql: sql, code: result, message: message))
+        }
+        defer { sqlite3_finalize(statement) }
+        try bindChecked(values, to: statement)
+        return try body(statement)
+    }
+
+    // MARK: - Compatibility APIs
+
     @discardableResult
     func exec(_ sql: String) -> Bool {
-        sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK
+        do {
+            try execute(sql)
+            return true
+        } catch {
+            return false
+        }
     }
 
     /// Rowid of the most recent successful INSERT on this connection.
@@ -31,68 +250,80 @@ final class SQLiteDatabase {
 
     @discardableResult
     func run(_ sql: String, bind values: [Any] = []) -> Bool {
-        withStatement(sql) { statement in
-            run(statement, bind: values)
-        } ?? false
-    }
-
-    /// Executes an already-prepared statement, resetting and rebinding it so
-    /// callers can reuse the same statement for a batch of rows.
-    @discardableResult
-    func run(_ statement: OpaquePointer, bind values: [Any] = []) -> Bool {
-        guard sqlite3_reset(statement) == SQLITE_OK else { return false }
-        sqlite3_clear_bindings(statement)
-        guard bind(values, to: statement) else { return false }
-        return sqlite3_step(statement) == SQLITE_DONE
-    }
-
-    /// Runs a group of writes atomically. Returning `false` from `body` rolls
-    /// the transaction back, including when a prepared statement fails.
-    @discardableResult
-    func transaction(_ body: () -> Bool) -> Bool {
-        guard exec("BEGIN IMMEDIATE TRANSACTION") else { return false }
-        guard body(), exec("COMMIT") else {
-            exec("ROLLBACK")
+        do {
+            try runChecked(sql, bind: values)
+            return true
+        } catch {
             return false
         }
-        return true
+    }
+
+    @discardableResult
+    func run(_ statement: OpaquePointer, bind values: [Any] = []) -> Bool {
+        do {
+            try runChecked(statement, bind: values)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    @discardableResult
+    func transaction(_ body: () -> Bool) -> Bool {
+        let generationAtStart = errorGeneration
+        do {
+            return try withTransaction {
+                guard body() else {
+                    if errorGeneration != generationAtStart, let lastError { throw lastError }
+                    throw record(.step(
+                        sql: nil, code: SQLITE_ABORT, message: "transaction body returned false")
+                    )
+                }
+                return true
+            }
+        } catch {
+            return false
+        }
     }
 
     func query<T>(_ sql: String, bind values: [Any] = [], row: (OpaquePointer) -> T?) -> [T] {
-        withStatement(sql, bind: values) { statement in
-            var rows: [T] = []
-            while sqlite3_step(statement) == SQLITE_ROW {
-                if let value = row(statement) {
-                    rows.append(value)
-                }
-            }
-            return rows
-        } ?? []
+        (try? queryChecked(sql, bind: values, row: row)) ?? []
     }
 
     func firstDouble(_ sql: String, bind values: [Any] = []) -> Double? {
-        withStatement(sql, bind: values) { statement in
-            sqlite3_step(statement) == SQLITE_ROW ? sqlite3_column_double(statement, 0) : nil
-        } ?? nil
+        (try? firstDoubleChecked(sql, bind: values)) ?? nil
     }
 
     func hasRow(_ sql: String, bind values: [Any] = []) -> Bool {
-        withStatement(sql, bind: values) { statement in
-            sqlite3_step(statement) == SQLITE_ROW
-        } ?? false
+        (try? hasRowChecked(sql, bind: values)) ?? false
     }
 
     @discardableResult
-    func withStatement<T>(_ sql: String, bind values: [Any] = [], _ body: (OpaquePointer) -> T) -> T? {
-        var statement: OpaquePointer?
-        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK,
-              let statement else { return nil }
-        defer { sqlite3_finalize(statement) }
-        guard bind(values, to: statement) else { return nil }
-        return body(statement)
+    func withStatement<T>(_ sql: String, bind values: [Any] = [],
+                          _ body: (OpaquePointer) -> T) -> T? {
+        try? withPreparedStatement(sql, bind: values, body)
     }
 
-    private func bind(_ values: [Any], to statement: OpaquePointer) -> Bool {
+    // MARK: - Internals
+
+    private var message: String { String(cString: sqlite3_errmsg(db)) }
+
+    @discardableResult
+    private func record(_ error: DatabaseError) -> DatabaseError {
+        errorGeneration &+= 1
+        lastError = error
+        AppLog.line(error.localizedDescription)
+        return error
+    }
+
+    private func stepToCompletion(_ statement: OpaquePointer, sql: String?) throws {
+        let result = sqlite3_step(statement)
+        guard result == SQLITE_DONE else {
+            throw record(.step(sql: sql, code: result, message: message))
+        }
+    }
+
+    private func bindChecked(_ values: [Any], to statement: OpaquePointer) throws {
         for (index, value) in values.enumerated() {
             let position = Int32(index + 1)
             let result: Int32
@@ -105,17 +336,25 @@ final class SQLiteDatabase {
                 result = sqlite3_bind_int64(statement, position, sqlite3_int64(number))
             case let number as Int64:
                 result = sqlite3_bind_int64(statement, position, sqlite3_int64(number))
+            case let data as Data where data.isEmpty:
+                result = sqlite3_bind_zeroblob(statement, position, 0)
             case let data as Data:
                 result = data.withUnsafeBytes { bytes in
                     sqlite3_bind_blob(statement, position, bytes.baseAddress,
                                       Int32(data.count), Self.transient)
                 }
+            case is NSNull:
+                result = sqlite3_bind_null(statement, position)
             default:
-                assertionFailure("SQLiteDatabase: unsupported bind type \(type(of: value))")
-                return false
+                let error = DatabaseError.bind(
+                    index: position, code: SQLITE_MISMATCH,
+                    message: "unsupported value type \(type(of: value))")
+                assertionFailure(error.localizedDescription)
+                throw record(error)
             }
-            guard result == SQLITE_OK else { return false }
+            guard result == SQLITE_OK else {
+                throw record(.bind(index: position, code: result, message: message))
+            }
         }
-        return true
     }
 }

--- a/LokalBot/Services/ScreenshotService.swift
+++ b/LokalBot/Services/ScreenshotService.swift
@@ -55,6 +55,112 @@ struct ScreenCapturePolicy {
     mutating func noteCheck(at now: Date = Date()) { lastCheck = now }
 }
 
+/// Pure capture-layout selection. ScreenCaptureKit objects cannot be created
+/// in unit tests, so production metadata is reduced to these value types before
+/// choosing the focused display and every privacy-excluded window on it.
+struct ScreenshotCaptureLayout {
+    struct Display {
+        let id: CGDirectDisplayID
+        let frame: CGRect
+    }
+
+    struct Window {
+        let id: CGWindowID
+        let processID: pid_t
+        let appName: String
+        let title: String
+        let frame: CGRect
+    }
+
+    struct Selection: Equatable {
+        let displayID: CGDirectDisplayID
+        let excludedWindowIDs: Set<CGWindowID>
+    }
+
+    static func selection(
+        displays: [Display],
+        windows: [Window],
+        frontmostProcessID: pid_t,
+        focusedWindowTitle: String,
+        excludedApps: [String],
+        mainDisplayID: CGDirectDisplayID = CGMainDisplayID()
+    ) -> Selection? {
+        guard !displays.isEmpty else { return nil }
+
+        let frontmostWindows = windows.filter {
+            $0.processID == frontmostProcessID && !$0.frame.isEmpty && !$0.frame.isNull
+        }
+        let focusedWindow: Window?
+        if focusedWindowTitle.isEmpty {
+            focusedWindow = frontmostWindows.first
+        } else {
+            focusedWindow = frontmostWindows.first {
+                $0.title.compare(focusedWindowTitle, options: [.caseInsensitive, .diacriticInsensitive])
+                    == .orderedSame
+            } ?? frontmostWindows.first
+        }
+
+        let selectedDisplay: Display
+        if let focusedWindow,
+           let overlappingDisplay = displays.max(by: {
+               intersectionArea($0.frame, focusedWindow.frame)
+                   < intersectionArea($1.frame, focusedWindow.frame)
+           }), intersectionArea(overlappingDisplay.frame, focusedWindow.frame) > 0 {
+            selectedDisplay = overlappingDisplay
+        } else {
+            selectedDisplay = displays.first(where: { $0.id == mainDisplayID }) ?? displays[0]
+        }
+
+        let excludedWindowIDs = Set(windows.compactMap { window -> CGWindowID? in
+            guard isExcluded(appName: window.appName, excludedApps: excludedApps),
+                  intersectionArea(window.frame, selectedDisplay.frame) > 0 else { return nil }
+            return window.id
+        })
+        return Selection(displayID: selectedDisplay.id, excludedWindowIDs: excludedWindowIDs)
+    }
+
+    static func isExcluded(appName: String, excludedApps: [String]) -> Bool {
+        excludedApps.contains { rawTerm in
+            let term = rawTerm.trimmingCharacters(in: .whitespacesAndNewlines)
+            return !term.isEmpty && appName.localizedCaseInsensitiveContains(term)
+        }
+    }
+
+    private static func intersectionArea(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+        let intersection = lhs.intersection(rhs)
+        guard !intersection.isNull, !intersection.isEmpty else { return 0 }
+        return intersection.width * intersection.height
+    }
+}
+
+/// Main-actor gate that prevents repeated menu clicks and simultaneous sampler
+/// events from launching overlapping ScreenCaptureKit requests.
+struct ScreenshotCaptureGate {
+    private(set) var isCapturing = false
+
+    mutating func begin() -> Bool {
+        guard !isCapturing else { return false }
+        isCapturing = true
+        return true
+    }
+
+    mutating func end() {
+        isCapturing = false
+    }
+}
+
+enum ScreenshotWindowFocusValidation {
+    static func matches(
+        expectedTitle: String,
+        current: FocusedWindowTitleLookupResult
+    ) -> Bool {
+        guard !current.timedOut else { return false }
+        return (current.title ?? "").compare(
+            expectedTitle,
+            options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
+    }
+}
+
 /// Immutable inputs passed across the main-actor/worker boundary. `CGImage` is
 /// an immutable Core Foundation value and is safe to read concurrently, but it
 /// is not annotated `Sendable` by every supported SDK, so the wrapper records
@@ -119,6 +225,14 @@ actor ScreenshotProcessingWorker {
         try dependencies.write(sealed, request.fileURL)
         lastContentHash = contentHash
         return .stored(contentHash: contentHash, ocrText: ocrText)
+    }
+
+    /// A file write is not a completed capture until its SQLite rows commit.
+    /// Let an identical screen retry when that later persistence step fails.
+    func discardStored(contentHash: Data) {
+        if lastContentHash == contentHash {
+            lastContentHash = nil
+        }
     }
 }
 
@@ -194,16 +308,20 @@ final class ScreenshotService: ObservableObject {
     private let settings: () -> AppSettings
     private let isMeetingRecordingActive: () -> Bool
     private let sampler: ActivitySampler
+    private let windowTitleLookup: FocusedWindowTitleLookup
     private let processingWorker = ScreenshotProcessingWorker()
     private var timer: Timer?
     private var policy = ScreenCapturePolicy()
+    private var captureGate = ScreenshotCaptureGate()
 
     init(store: ActivityStore, storage: StorageManager, sampler: ActivitySampler,
+         windowTitleLookup: FocusedWindowTitleLookup = .shared,
          isMeetingRecordingActive: @escaping () -> Bool = { false },
          settings: @escaping () -> AppSettings) {
         self.store = store
         self.storage = storage
         self.sampler = sampler
+        self.windowTitleLookup = windowTitleLookup
         self.isMeetingRecordingActive = isMeetingRecordingActive
         self.settings = settings
     }
@@ -272,13 +390,29 @@ final class ScreenshotService: ObservableObject {
         guard let frontmostApp = NSWorkspace.shared.frontmostApplication,
               let frontmost = frontmostApp.localizedName,
               frontmost != "loginwindow" else { lokalbotLog("shot skip: lock screen"); return }
-        guard !config.excludedAppList.contains(where: { frontmost.localizedCaseInsensitiveContains($0) })
+        guard !ScreenshotCaptureLayout.isExcluded(
+            appName: frontmost, excludedApps: config.excludedAppList)
         else { lokalbotLog("shot skip: excluded (\(frontmost))"); return }
 
+        guard captureGate.begin() else {
+            lokalbotLog("shot skip: capture already in flight (\(trigger.rawValue))")
+            return
+        }
+        defer { captureGate.end() }
+
+        let initialTitle = await windowTitleLookup.title(
+            for: frontmostApp.processIdentifier)
+        guard !initialTitle.timedOut,
+              NSWorkspace.shared.frontmostApplication?.processIdentifier
+                == frontmostApp.processIdentifier else {
+            lokalbotLog("shot skip: focused-window lookup timed out or focus changed")
+            return
+        }
         do {
             try await capture(frontApp: frontmost,
-                              windowTitle: ActivitySampler.focusedWindowTitle(
-                                  pid: frontmostApp.processIdentifier) ?? "",
+                              frontmostProcessID: frontmostApp.processIdentifier,
+                              windowTitle: initialTitle.title ?? "",
+                              excludedApps: config.excludedAppList,
                               trigger: trigger)
             lastError = nil
         } catch {
@@ -287,11 +421,37 @@ final class ScreenshotService: ObservableObject {
         }
     }
 
-    private func capture(frontApp: String, windowTitle: String,
+    private func capture(frontApp: String, frontmostProcessID: pid_t, windowTitle: String,
+                         excludedApps: [String],
                          trigger: ScreenCaptureTrigger) async throws {
         let content = try await SCShareableContent.excludingDesktopWindows(
             false, onScreenWindowsOnly: true)
-        guard let display = content.displays.first else { return }
+        guard NSWorkspace.shared.frontmostApplication?.processIdentifier == frontmostProcessID else {
+            lokalbotLog("shot skip: focus changed while preparing capture")
+            return
+        }
+        let layout = ScreenshotCaptureLayout.selection(
+            displays: content.displays.map {
+                .init(id: $0.displayID, frame: CGDisplayBounds($0.displayID))
+            },
+            windows: content.windows.compactMap { window in
+                guard let application = window.owningApplication else { return nil }
+                return .init(
+                    id: window.windowID,
+                    processID: application.processID,
+                    appName: application.applicationName,
+                    title: window.title ?? "",
+                    frame: window.frame)
+            },
+            frontmostProcessID: frontmostProcessID,
+            focusedWindowTitle: windowTitle,
+            excludedApps: excludedApps)
+        guard let layout,
+              let display = content.displays.first(where: { $0.displayID == layout.displayID })
+        else { return }
+        let excludedWindows = content.windows.filter {
+            layout.excludedWindowIDs.contains($0.windowID)
+        }
 
         // Capture at NATIVE pixel resolution — OCR needs full-size glyphs.
         // The stored image is downscaled afterwards; the text is the value.
@@ -300,34 +460,51 @@ final class ScreenshotService: ObservableObject {
         configuration.width = mode?.pixelWidth ?? display.width * 2
         configuration.height = mode?.pixelHeight ?? display.height * 2
         configuration.showsCursor = false
-        let filter = SCContentFilter(display: display, excludingWindows: [])
+        let filter = SCContentFilter(display: display, excludingWindows: excludedWindows)
         let image = try await SCScreenshotManager.captureImage(
             contentFilter: filter, configuration: configuration)
+        let currentTitle = await windowTitleLookup.title(for: frontmostProcessID)
+        guard NSWorkspace.shared.frontmostApplication?.processIdentifier == frontmostProcessID,
+              ScreenshotWindowFocusValidation.matches(
+                expectedTitle: windowTitle,
+                current: currentTitle) else {
+            // ScreenCaptureKit requests suspend. Do not persist a display image
+            // under stale app/window metadata if the user switches meanwhile.
+            lokalbotLog("shot skip: focus changed during capture")
+            return
+        }
 
         let timestamp = Date()
 
         // The worker keeps the hash → dedup → OCR → encryption → atomic-write
         // sequence serial and off the main actor. The check still arms the
         // cooldown/idle clock when an unchanged frame is skipped.
-        let day = timestamp.formatted(.iso8601.year().month().day())
-        let file = storage.rootURL
-            .appendingPathComponent("activity/\(day)/shots", isDirectory: true)
-            .appendingPathComponent("\(Int(timestamp.timeIntervalSince1970)).heic.enc")
+        let file = Self.captureFileURL(rootURL: storage.rootURL, timestamp: timestamp)
         let outcome = try await processingWorker.process(ScreenshotProcessingRequest(
             image: image,
             trigger: trigger,
             key: try Self.encryptionKey(),
             fileURL: file))
 
-        guard case .stored(_, let ocrText) = outcome else {
+        guard case .stored(let contentHash, let ocrText) = outcome else {
             policy.noteCheck(at: timestamp)
             lokalbotLog("shot skip: unchanged frame (\(trigger.rawValue), app: \(frontApp))")
             return
         }
 
-        store.insertScreenshot(ts: timestamp, path: file.path, app: frontApp,
-                               windowTitle: windowTitle, trigger: trigger.rawValue,
-                               ocr: ocrText)
+        do {
+            try store.insertScreenshot(ts: timestamp, path: file.path, app: frontApp,
+                                       windowTitle: windowTitle, trigger: trigger.rawValue,
+                                       ocr: ocrText)
+        } catch {
+            do {
+                try FileManager.default.removeItem(at: file)
+            } catch let cleanupError {
+                lokalbotLog("shot rollback file cleanup failed: \(cleanupError.localizedDescription)")
+            }
+            await processingWorker.discardStored(contentHash: contentHash)
+            throw error
+        }
         policy.noteCheck(at: timestamp)
         lastCapture = timestamp
         lokalbotLog("shot ok: \(file.lastPathComponent) (\(ocrText.count) OCR chars, "
@@ -363,11 +540,19 @@ final class ScreenshotService: ObservableObject {
     func pruneOldScreenshots() {
         let cutoff = Date().addingTimeInterval(-Double(settings().retentionDays) * 86_400)
         for path in store.screenshotPaths(olderThan: cutoff) {
-            try? FileManager.default.removeItem(atPath: path)
+            do {
+                if FileManager.default.fileExists(atPath: path) {
+                    try FileManager.default.removeItem(atPath: path)
+                }
+                try store.clearScreenshotPath(path)
+            } catch {
+                // Keep the database path when deletion fails, so a later
+                // retention pass can retry instead of orphaning the file.
+                lokalbotLog("shot retention failed path=\(path): \(error.localizedDescription)")
+            }
         }
-        store.clearScreenshotPaths(olderThan: cutoff)
         if !settings().keepOCRTextForever {
-            store.clearOCRText(olderThan: cutoff)
+            _ = store.clearOCRText(olderThan: cutoff)
         }
     }
 
@@ -378,6 +563,19 @@ final class ScreenshotService: ObservableObject {
         recordingActive: Bool
     ) -> Bool {
         !recordingActive || trigger == .manual
+    }
+
+    nonisolated static func captureFileURL(
+        rootURL: URL,
+        timestamp: Date,
+        identifier: UUID = UUID()
+    ) -> URL {
+        let day = timestamp.formatted(.iso8601.year().month().day())
+        let milliseconds = Int64((timestamp.timeIntervalSince1970 * 1_000).rounded(.down))
+        return rootURL
+            .appendingPathComponent("activity/\(day)/shots", isDirectory: true)
+            .appendingPathComponent(
+                "\(milliseconds)-\(identifier.uuidString.lowercased()).heic.enc")
     }
 
     /// Per-install AES-256 key in the user Keychain (design §3.4), via the

--- a/LokalBot/Services/SearchIndex.swift
+++ b/LokalBot/Services/SearchIndex.swift
@@ -5,7 +5,6 @@ import SQLite3
 /// transcript segments and summaries. Lives at <storage root>/lokalbotv3.sqlite.
 /// Segment-level rows let transcript hits deep-link to their audio timestamp.
 /// macOS ships SQLite with FTS5 enabled, so this adds no dependency.
-@MainActor
 final class SearchIndex {
 
     private static let documentRowsMigration = "search-document-rows-v1"
@@ -26,6 +25,7 @@ final class SearchIndex {
     }
 
     private let database: SQLiteDatabase?
+    private var locallyDeletedMeetingIDs: Set<UUID> = []
 
     init(databaseURL: URL) {
         guard let database = SQLiteDatabase(url: databaseURL) else {
@@ -56,19 +56,32 @@ final class SearchIndex {
             CREATE TABLE IF NOT EXISTS search_index_migrations (
                 name TEXT PRIMARY KEY
             );
+            CREATE TABLE IF NOT EXISTS deleted_meetings (
+                meeting_id TEXT PRIMARY KEY,
+                deleted_at REAL NOT NULL
+            );
             """)
         Self.backfillDocumentRowsIfNeeded(in: database)
+        _ = reconcileDeletedMeetings()
     }
 
     // MARK: - Indexing
 
     /// Re-index every meeting whose files changed since the last pass.
     func reindexAll(_ meetings: [Meeting], storage: StorageManager) {
-        for meeting in meetings { reindex(meeting, storage: storage) }
+        for meeting in meetings {
+            guard !Task.isCancelled else { return }
+            reindex(meeting, storage: storage)
+        }
     }
 
-    func reindex(_ meeting: Meeting, storage: StorageManager) {
+    func reindex(_ meeting: Meeting, storage: StorageManager,
+                 beforeTransaction: (() -> Void)? = nil) {
+        guard !locallyDeletedMeetingIDs.contains(meeting.id) else { return }
         let folder = meeting.folderURL(in: storage)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: folder.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else { return }
         let mtime = Self.latestMtime(in: folder)
         if let indexed = indexedMtime(of: meeting.id), indexed >= mtime { return }
 
@@ -95,9 +108,33 @@ final class SearchIndex {
                                                  start: document.start, speaker: document.speaker)
         }
 
-        guard let database else { return }
+        guard !Task.isCancelled, let database else { return }
         let meetingID = meeting.id.uuidString
+        // Test seam for deterministically exercising an older snapshot that
+        // reaches its transaction after a newer independent connection.
+        beforeTransaction?()
+        guard !Task.isCancelled else { return }
         database.transaction {
+            // Deletion and indexing use independent SQLite connections. Check
+            // the durable tombstone inside this write transaction so either
+            // indexing commits first and deletion removes it, or deletion
+            // commits first and this late worker becomes a no-op.
+            do {
+                guard try !database.hasRowChecked(
+                    "SELECT 1 FROM deleted_meetings WHERE meeting_id = ?1",
+                    bind: [meetingID]),
+                      FileManager.default.fileExists(atPath: folder.path) else { return true }
+                // The optimistic check above avoids unnecessary file reads.
+                // Repeat it under BEGIN IMMEDIATE so an older worker cannot
+                // commit after and overwrite a newer snapshot.
+                if let indexed = try database.firstDoubleChecked(
+                    "SELECT source_mtime FROM indexed_meetings WHERE meeting_id = ?1",
+                    bind: [meetingID]), indexed >= mtime {
+                    return true
+                }
+            } catch {
+                return false
+            }
             guard Self.deleteDocuments(for: meetingID, in: database) else { return false }
             let inserted = database.withStatement(
                 "INSERT INTO docs (text, meeting_id, kind, start, speaker) VALUES (?1, ?2, ?3, ?4, ?5)"
@@ -123,12 +160,49 @@ final class SearchIndex {
         }
     }
 
-    func remove(_ meetingID: UUID) {
-        guard let database else { return }
+    @discardableResult
+    func remove(_ meetingID: UUID) -> Bool {
+        noteDeletion(meetingID)
+        guard let database else { return false }
         let id = meetingID.uuidString
-        database.transaction {
+        let marked = database.transaction {
+            database.run(
+                "INSERT OR IGNORE INTO deleted_meetings (meeting_id, deleted_at) VALUES (?1, ?2)",
+                bind: [id, Date().timeIntervalSince1970])
+        }
+        guard marked else { return false }
+        return database.transaction {
             Self.deleteDocuments(for: id, in: database)
                 && database.run("DELETE FROM indexed_meetings WHERE meeting_id = ?1", bind: [id])
+        }
+    }
+
+    func noteDeletion(_ meetingID: UUID) {
+        locallyDeletedMeetingIDs.insert(meetingID)
+    }
+
+    /// Finishes cleanup for durable tombstones left by a prior failed or
+    /// interrupted deletion. Queries exclude tombstones even before this pass
+    /// succeeds, so reconciliation can safely be retried at startup and in-app.
+    @discardableResult
+    func reconcileDeletedMeetings() -> Bool {
+        guard let database else { return false }
+        return database.transaction {
+            database.run("""
+                DELETE FROM docs
+                WHERE rowid IN (
+                    SELECT doc_rowid FROM search_document_rows
+                    WHERE meeting_id IN (SELECT meeting_id FROM deleted_meetings)
+                )
+                """)
+                && database.run("""
+                    DELETE FROM search_document_rows
+                    WHERE meeting_id IN (SELECT meeting_id FROM deleted_meetings)
+                    """)
+                && database.run("""
+                    DELETE FROM indexed_meetings
+                    WHERE meeting_id IN (SELECT meeting_id FROM deleted_meetings)
+                    """)
         }
     }
 
@@ -147,6 +221,10 @@ final class SearchIndex {
             SELECT meeting_id, kind, start, speaker,
                    snippet(docs, 0, '«', '»', '…', 14)
             FROM docs WHERE docs MATCH ?1
+              AND NOT EXISTS (
+                  SELECT 1 FROM deleted_meetings AS deleted
+                  WHERE deleted.meeting_id = docs.meeting_id
+              )
             """
         if kind != nil { sql += " AND kind = ?2" }
         sql += " ORDER BY rank LIMIT \(limit)"
@@ -168,7 +246,7 @@ final class SearchIndex {
                        start: sqlite3_column_double(statement, 2),
                        snippet: String(cString: snippetText),
                        speaker: speaker)
-        }
+        }.filter { !locallyDeletedMeetingIDs.contains($0.meetingID) }
     }
 
     /// Common English function words that carry no retrieval signal. Stripped

--- a/LokalBot/Services/SettingsStore.swift
+++ b/LokalBot/Services/SettingsStore.swift
@@ -12,11 +12,30 @@ import Foundation
 /// writes through here, so the store is always current.
 @MainActor
 final class SettingsStore {
+    private var persistTask: Task<Void, Never>?
+
     var current: AppSettings {
-        didSet { current.save() }
+        didSet {
+            guard current != oldValue else { return }
+            persistTask?.cancel()
+            let snapshot = current
+            persistTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .milliseconds(250))
+                guard !Task.isCancelled else { return }
+                snapshot.save()
+                self?.persistTask = nil
+            }
+        }
     }
 
     init() {
         current = AppSettings.load()
+    }
+
+    /// Flush debounced text-field edits before application termination.
+    func flush() {
+        persistTask?.cancel()
+        persistTask = nil
+        current.save()
     }
 }

--- a/LokalBot/Services/StorageManager.swift
+++ b/LokalBot/Services/StorageManager.swift
@@ -99,8 +99,11 @@ final class StorageManager {
         return result.sorted { $0.startedAt > $1.startedAt }
     }
 
-    func deleteMeeting(_ meeting: Meeting) {
-        try? FileManager.default.removeItem(at: meeting.folderURL(in: self))
+    /// Delete the durable meeting folder. Callers must only remove the meeting
+    /// from in-memory/UI state after this succeeds; swallowing the filesystem
+    /// error made failed deletions reappear on the next launch.
+    func deleteMeeting(_ meeting: Meeting) throws {
+        try FileManager.default.removeItem(at: meeting.folderURL(in: self))
     }
 
     static func slugify(_ s: String) -> String {

--- a/LokalBot/Services/SystemAudioRecorder.swift
+++ b/LokalBot/Services/SystemAudioRecorder.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Accelerate
 import AppKit
 import AudioToolbox
 import CoreAudio
@@ -42,15 +43,25 @@ final class SystemAudioRecorder {
     private var audibleFramesWritten: AVAudioFramePosition = 0
     private var recordingSampleRate: Double = 0
     private var lastAudioWriteAt: Date?
+    private var lastAudioWriteInstant: ContinuousClock.Instant?
+    private var captureStartedInstant: ContinuousClock.Instant?
     private var lastAudibleWriteAt: Date?
     private var lastRMSLevel: Float = 0
     private var peakRMSLevel: Float = 0
+    private var droppedBufferCount = 0
     private static let audibleRMSThreshold: Float = 0.0005
+    private static let bufferPoolSize = 16
+    private static let pooledBufferFrameCapacity: AVAudioFrameCount = 32_768
 
     /// IOProc writes hop here so the Core Audio real-time thread never
     /// blocks on AAC encoding or filesystem I/O. Serial → ordered writes.
     private let ioQueue = DispatchQueue(label: "lokalbot.systemaudio.write",
                                         qos: .userInitiated)
+    /// The tap callback borrows from this fixed pool with a non-blocking lock.
+    /// It never allocates an AVAudioPCMBuffer or waits for the writer queue.
+    private let bufferPoolLock = NSLock()
+    private var bufferPool: [AVAudioPCMBuffer] = []
+    private let dropLock = NSLock()
 
     /// Captured app's PID, so we can detect the process terminating and
     /// stop instead of silently recording a blank track.
@@ -59,7 +70,7 @@ final class SystemAudioRecorder {
 
     /// Fired on the main thread when the captured process exits before
     /// `stop()` was called (crash, user-quit, browser tab close).
-    var onCapturedProcessTerminated: (() -> Void)?
+    var onCapturedProcessTerminated: ((pid_t) -> Void)?
 
     struct CaptureHealth {
         let duration: TimeInterval
@@ -69,6 +80,7 @@ final class SystemAudioRecorder {
         let capturedPID: pid_t
         let lastRMSLevel: Float
         let peakRMSLevel: Float
+        let droppedBufferCount: Int
     }
 
     /// `previewTee` mirrors the capture into a snapshot-safe PCM `.caf` for
@@ -82,15 +94,21 @@ final class SystemAudioRecorder {
         do {
             outputURL = url
             previewTeeURL = previewURL
+            let startedInstant = ContinuousClock.now
             ioQueue.sync {
                 framesWritten = 0
                 audibleFramesWritten = 0
                 recordingSampleRate = 0
                 lastAudioWriteAt = nil
+                lastAudioWriteInstant = nil
+                captureStartedInstant = startedInstant
                 lastAudibleWriteAt = nil
                 lastRMSLevel = 0
                 peakRMSLevel = 0
             }
+            dropLock.lock()
+            droppedBufferCount = 0
+            dropLock.unlock()
             try attachTap(processObject: processObject, writingTo: url)
         } catch {
             cleanup(closeFile: true)
@@ -113,6 +131,9 @@ final class SystemAudioRecorder {
         }
         teardownTap()
         do {
+            try appendRecoverySilence(
+                until: ContinuousClock.now,
+                wallDate: Date())
             try attachTap(processObject: processObject, writingTo: outputURL)
             installTerminationObserver(for: pid)
         } catch {
@@ -122,7 +143,10 @@ final class SystemAudioRecorder {
     }
 
     func captureHealth() -> CaptureHealth {
-        ioQueue.sync {
+        dropLock.lock()
+        let dropped = droppedBufferCount
+        dropLock.unlock()
+        return ioQueue.sync {
             let duration = recordingSampleRate > 0
                 ? Double(framesWritten) / recordingSampleRate
                 : 0
@@ -135,7 +159,8 @@ final class SystemAudioRecorder {
                                  lastAudibleWriteAt: lastAudibleWriteAt,
                                  capturedPID: capturedPID,
                                  lastRMSLevel: lastRMSLevel,
-                                 peakRMSLevel: peakRMSLevel)
+                                 peakRMSLevel: peakRMSLevel,
+                                 droppedBufferCount: dropped)
         }
     }
 
@@ -193,6 +218,7 @@ final class SystemAudioRecorder {
                                    commonFormat: format.commonFormat,
                                    interleaved: format.isInterleaved)
             previewTee = previewTeeURL.flatMap { AudioPreviewTee(url: $0, sourceFormat: format) }
+            try prepareBufferPool(format: format)
             ioQueue.sync {
                 recordingSampleRate = format.sampleRate
             }
@@ -204,28 +230,39 @@ final class SystemAudioRecorder {
         //    audio thread — copy the samples, then hop to a serial queue.
         err = AudioDeviceCreateIOProcIDWithBlock(&ioProcID, aggregateID, nil) { [weak self] _, inInputData, _, _, _ in
             guard let self, let fmt = self.tapFormat,
-                  fmt.commonFormat == .pcmFormatFloat32,
-                  let src = AVAudioPCMBuffer(pcmFormat: fmt,
-                                             bufferListNoCopy: inInputData,
-                                             deallocator: nil),
-                  src.frameLength > 0,
-                  let copy = AVAudioPCMBuffer(pcmFormat: fmt,
-                                              frameCapacity: src.frameLength)
-            else { return }
-            copy.frameLength = src.frameLength
-            let rmsLevel = Self.copyAndMeasureRMS(from: src, into: copy)
-            // Snapshot the file ref on the audio thread (atomic class read);
-            // strongly retained by the dispatched block until the write returns.
-            let fileRef = self.file
-            let teeRef = self.previewTee
+                  fmt.commonFormat == .pcmFormatFloat32 else { return }
+            let streamDescription = fmt.streamDescription
+            guard streamDescription.pointee.mBytesPerFrame > 0 else { return }
+            let sourceBuffers = UnsafeMutableAudioBufferListPointer(
+                UnsafeMutablePointer(mutating: inInputData))
+            guard let firstBuffer = sourceBuffers.first else { return }
+            let frameLength = AVAudioFrameCount(
+                firstBuffer.mDataByteSize / streamDescription.pointee.mBytesPerFrame)
+            guard frameLength > 0,
+                  let copy = self.borrowBuffer(frameLength: frameLength) else {
+                self.noteDroppedBuffer()
+                return
+            }
+            guard Self.copyBufferList(inInputData, into: copy) else {
+                self.returnBuffer(copy)
+                self.noteDroppedBuffer()
+                return
+            }
             self.ioQueue.async {
-                guard let fileRef else { return }
+                defer { self.returnBuffer(copy) }
+                guard let fileRef = self.file else { return }
                 do {
+                    // The real-time callback only performs one bounded copy.
+                    // RMS traversal, AAC encoding, preview conversion, and I/O
+                    // all stay on this serial writer queue.
+                    let rmsLevel = Self.measureRMS(of: copy)
                     try fileRef.write(from: copy)
-                    teeRef?.write(copy)
+                    self.previewTee?.write(copy)
                     let now = Date()
+                    let nowInstant = ContinuousClock.now
                     self.framesWritten += AVAudioFramePosition(copy.frameLength)
                     self.lastAudioWriteAt = now
+                    self.lastAudioWriteInstant = nowInstant
                     self.lastRMSLevel = rmsLevel
                     self.peakRMSLevel = max(self.peakRMSLevel, rmsLevel)
                     if rmsLevel >= Self.audibleRMSThreshold {
@@ -266,7 +303,7 @@ final class SystemAudioRecorder {
             guard let self,
                   let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
                   app.processIdentifier == self.capturedPID else { return }
-            self.onCapturedProcessTerminated?()
+            self.onCapturedProcessTerminated?(app.processIdentifier)
         }
     }
 
@@ -312,10 +349,101 @@ final class SystemAudioRecorder {
             audibleFramesWritten = 0
             recordingSampleRate = 0
             lastAudioWriteAt = nil
+            lastAudioWriteInstant = nil
+            captureStartedInstant = nil
             lastAudibleWriteAt = nil
             lastRMSLevel = 0
             peakRMSLevel = 0
         }
+        dropLock.lock()
+        droppedBufferCount = 0
+        dropLock.unlock()
+        bufferPoolLock.lock()
+        bufferPool.removeAll(keepingCapacity: false)
+        bufferPoolLock.unlock()
+    }
+
+    /// Fill the elapsed-time hole left by a process-helper handoff. Keeping the
+    /// original writer open preserves the samples already captured; padding
+    /// the missing interval keeps both tracks and transcript timestamps aligned
+    /// instead of compressing everything after the interruption earlier.
+    private func appendRecoverySilence(
+        until now: ContinuousClock.Instant,
+        wallDate: Date
+    ) throws {
+        try ioQueue.sync {
+            guard let file, let format = tapFormat,
+                  let anchor = lastAudioWriteInstant ?? captureStartedInstant,
+                  let plan = AudioRecoverySilencePlanner.plan(
+                      forElapsed: anchor.duration(to: now)),
+                  format.sampleRate > 0 else { return }
+            var remaining = AVAudioFramePosition(plan.duration * format.sampleRate)
+            while remaining > 0 {
+                let count = AVAudioFrameCount(min(remaining, 4_096))
+                guard let silence = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: count) else {
+                    throw RecorderError.badTapFormat
+                }
+                silence.frameLength = count
+                let buffers = UnsafeMutableAudioBufferListPointer(silence.mutableAudioBufferList)
+                for buffer in buffers where buffer.mData != nil {
+                    memset(buffer.mData!, 0, Int(buffer.mDataByteSize))
+                }
+                try file.write(from: silence)
+                previewTee?.write(silence)
+                framesWritten += AVAudioFramePosition(count)
+                remaining -= AVAudioFramePosition(count)
+            }
+            self.lastAudioWriteAt = wallDate
+            lastAudioWriteInstant = now
+            lastRMSLevel = 0
+            if plan.wasCapped {
+                NSLog(
+                    "SystemAudioRecorder recovery gap capped at "
+                        + "\(AudioRecoverySilencePlanner.maximumDuration)s")
+            }
+        }
+    }
+
+    private func noteDroppedBuffer() {
+        // Capture-health accounting is best-effort. Never wait behind its reader
+        // or emit a log from Core Audio's realtime callback.
+        guard dropLock.try() else { return }
+        droppedBufferCount += 1
+        dropLock.unlock()
+    }
+
+    private func prepareBufferPool(format: AVAudioFormat) throws {
+        var prepared: [AVAudioPCMBuffer] = []
+        prepared.reserveCapacity(Self.bufferPoolSize)
+        for _ in 0..<Self.bufferPoolSize {
+            guard let buffer = AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: Self.pooledBufferFrameCapacity
+            ) else {
+                throw RecorderError.badTapFormat
+            }
+            prepared.append(buffer)
+        }
+        bufferPoolLock.lock()
+        bufferPool = prepared
+        bufferPoolLock.unlock()
+    }
+
+    /// Runs on Core Audio's real-time callback. `try()` makes saturation a
+    /// dropped-buffer event instead of priority-inverting on a contended lock.
+    private func borrowBuffer(frameLength: AVAudioFrameCount) -> AVAudioPCMBuffer? {
+        guard frameLength <= Self.pooledBufferFrameCapacity,
+              bufferPoolLock.try() else { return nil }
+        defer { bufferPoolLock.unlock() }
+        guard let buffer = bufferPool.popLast() else { return nil }
+        buffer.frameLength = frameLength
+        return buffer
+    }
+
+    private func returnBuffer(_ buffer: AVAudioPCMBuffer) {
+        bufferPoolLock.lock()
+        bufferPool.append(buffer)
+        bufferPoolLock.unlock()
     }
 
     private static func formatsCompatible(_ lhs: AVAudioFormat, _ rhs: AVAudioFormat) -> Bool {
@@ -344,7 +472,7 @@ final class SystemAudioRecorder {
             UnsafeMutablePointer(mutating: source.audioBufferList))
         let destinationBuffers = UnsafeMutableAudioBufferListPointer(
             destination.mutableAudioBufferList)
-        var sumSquares = 0.0
+        var sumSquares: Double = 0
         var sampleCount = 0
         for (src, dst) in zip(sourceBuffers, destinationBuffers) {
             guard let srcData = src.mData, let dstData = dst.mData else { continue }
@@ -352,13 +480,62 @@ final class SystemAudioRecorder {
             memcpy(dstData, srcData, bytes)
             let samples = srcData.assumingMemoryBound(to: Float.self)
             let count = bytes / MemoryLayout<Float>.size
-            for index in 0..<count {
-                let sample = Double(samples[index])
-                sumSquares += sample * sample
-            }
+            var partial: Float = 0
+            vDSP_svesq(samples, 1, &partial, vDSP_Length(count))
+            sumSquares += Double(partial)
             sampleCount += count
         }
         guard sampleCount > 0 else { return 0 }
         return Float(sqrt(sumSquares / Double(sampleCount)))
+    }
+
+    private static func copyBuffer(_ source: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        guard let destination = AVAudioPCMBuffer(
+            pcmFormat: source.format,
+            frameCapacity: source.frameLength) else { return nil }
+        destination.frameLength = source.frameLength
+        return copyBuffer(source, into: destination) ? destination : nil
+    }
+
+    private static func copyBuffer(
+        _ source: AVAudioPCMBuffer,
+        into destination: AVAudioPCMBuffer
+    ) -> Bool {
+        copyBufferList(source.audioBufferList, into: destination)
+    }
+
+    private static func copyBufferList(
+        _ source: UnsafePointer<AudioBufferList>,
+        into destination: AVAudioPCMBuffer
+    ) -> Bool {
+        let sourceBuffers = UnsafeMutableAudioBufferListPointer(
+            UnsafeMutablePointer(mutating: source))
+        let destinationBuffers = UnsafeMutableAudioBufferListPointer(
+            destination.mutableAudioBufferList)
+        guard sourceBuffers.count == destinationBuffers.count else { return false }
+        for (source, destination) in zip(sourceBuffers, destinationBuffers) {
+            guard source.mDataByteSize <= destination.mDataByteSize,
+                  let sourceData = source.mData,
+                  let destinationData = destination.mData else { return false }
+            memcpy(destinationData, sourceData, Int(source.mDataByteSize))
+        }
+        return true
+    }
+
+    private static func measureRMS(of buffer: AVAudioPCMBuffer) -> Float {
+        let buffers = UnsafeMutableAudioBufferListPointer(
+            UnsafeMutablePointer(mutating: buffer.audioBufferList))
+        var sumSquares: Double = 0
+        var sampleCount = 0
+        for buffer in buffers {
+            guard let data = buffer.mData else { continue }
+            let samples = data.assumingMemoryBound(to: Float.self)
+            let count = Int(buffer.mDataByteSize) / MemoryLayout<Float>.size
+            var partial: Float = 0
+            vDSP_svesq(samples, 1, &partial, vDSP_Length(count))
+            sumSquares += Double(partial)
+            sampleCount += count
+        }
+        return sampleCount > 0 ? Float(sqrt(sumSquares / Double(sampleCount))) : 0
     }
 }

--- a/LokalBot/Support/DownloadIntegrity.swift
+++ b/LokalBot/Support/DownloadIntegrity.swift
@@ -18,13 +18,25 @@ enum DownloadIntegrity {
 
     static func verifiedExisting(at url: URL, expectedBytes: Int64,
                                  expectedSHA256: String) async -> Bool {
-        guard exactSize(of: url) == expectedBytes else { return false }
+        (try? await verifyExisting(
+            at: url,
+            expectedBytes: expectedBytes,
+            expectedSHA256: expectedSHA256)) == true
+    }
+
+    /// Throwing variant used by callers that must distinguish an unreadable
+    /// file from a verified digest mismatch before deciding whether to delete it.
+    static func verifyExisting(at url: URL, expectedBytes: Int64,
+                               expectedSHA256: String) async throws -> Bool {
+        try Task.checkCancellation()
+        guard try checkedSize(of: url) == expectedBytes else { return false }
         let expected = expectedSHA256.lowercased()
         if (try? String(contentsOf: markerURL(for: url), encoding: .utf8)
             .trimmingCharacters(in: .whitespacesAndNewlines)) == expected {
             return true
         }
-        guard let digest = try? await digest(of: url), digest == expected else { return false }
+        guard try await digest(of: url) == expected else { return false }
+        try Task.checkCancellation()
         try? expected.write(to: markerURL(for: url), atomically: true, encoding: .utf8)
         return true
     }
@@ -59,6 +71,13 @@ enum DownloadIntegrity {
     private static func exactSize(of url: URL) -> Int64? {
         let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
         return (attributes?[.size] as? NSNumber)?.int64Value
+    }
+
+    /// Preserve filesystem errors so callers do not classify an unreadable
+    /// model as corrupt and attempt to delete it.
+    private static func checkedSize(of url: URL) throws -> Int64? {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes[.size] as? NSNumber)?.int64Value
     }
 
     private static func digest(of url: URL) async throws -> String {

--- a/LokalBot/Views/AgentSessionView.swift
+++ b/LokalBot/Views/AgentSessionView.swift
@@ -30,13 +30,13 @@ struct AgentSessionView: View {
         .onChange(of: controller.state) {
             focusComposerWhenReady()
         }
-        .alert("Allow every change this session?", isPresented: $confirmingAutoApprove) {
-            Button("Allow All Changes", role: .destructive) {
+        .alert("Allow every file change this session?", isPresented: $confirmingAutoApprove) {
+            Button("Allow All File Changes", role: .destructive) {
                 controller.autoApproveSession = true
             }
             Button("Keep Asking", role: .cancel) {}
         } message: {
-            Text("The agent will be able to edit files and run shell commands without showing each request first. This resets when the session closes.")
+            Text("The agent will be able to write and edit files without showing each request first. Shell commands and reads outside the working folder will still ask every time. This resets when the session closes.")
         }
     }
 
@@ -62,7 +62,7 @@ struct AgentSessionView: View {
 
             statusBadge
             Spacer()
-            Toggle("Allow all changes", isOn: Binding(
+            Toggle("Allow all file changes", isOn: Binding(
                 get: { controller.autoApproveSession },
                 set: { enabled in
                     if enabled {
@@ -73,8 +73,8 @@ struct AgentSessionView: View {
                 }))
                 .toggleStyle(.switch)
                 .controlSize(.small)
-                .help("Skip approval cards for file edits and shell commands in this session")
-                .accessibilityHint("When enabled, edits and commands run without individual confirmation")
+                .help("Skip approval cards for file writes and edits in this session")
+                .accessibilityHint("When enabled, file writes and edits run without individual confirmation; shell commands still ask")
                 .accessibilityIdentifier("agent.autoApprove")
         }
         .padding(.horizontal, 12)
@@ -320,14 +320,16 @@ struct AgentSessionView: View {
 
                 Spacer()
 
-                Button("Allow \(request.tool) for Session") {
-                    Task {
-                        await controller.respondToApproval(
-                            id: request.id, approved: true, scope: .session)
+                if controller.canAllowForSession(request) {
+                    Button("Allow \(request.tool) for Session") {
+                        Task {
+                            await controller.respondToApproval(
+                                id: request.id, approved: true, scope: .session)
+                        }
                     }
+                    .help("Automatically allow future \(request.tool) requests until this session closes")
+                    .accessibilityIdentifier("agent.approve.session")
                 }
-                .help("Automatically allow future \(request.tool) requests until this session closes")
-                .accessibilityIdentifier("agent.approve.session")
 
                 Button("Allow Once") {
                     Task {

--- a/LokalBot/Views/AgentView.swift
+++ b/LokalBot/Views/AgentView.swift
@@ -15,6 +15,9 @@ struct AgentView: View {
             }
         }
         .navigationTitle("Agent")
+        .task {
+            await installer.refreshInstalledState()
+        }
     }
 
     private var sessionTabs: some View {
@@ -49,6 +52,9 @@ struct AgentView: View {
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: 420)
             switch installer.phase {
+            case .checking:
+                ProgressView().controlSize(.small)
+                Text("Checking Agent runtime…").font(.caption).foregroundStyle(.secondary)
             case .idle:
                 Button("Download & Enable Agent Mode") {
                     Task { await installer.installIfNeeded() }

--- a/LokalBot/Views/ModelsView.swift
+++ b/LokalBot/Views/ModelsView.swift
@@ -27,6 +27,10 @@ struct ModelsView: View {
     @State private var showingHFBrowse = false
     @State private var hfSelectedModel: String?
     @State private var hfFiles: [HFFile] = []
+    @State private var openAIAPIKeyDraft = ""
+    @State private var openAIAPIKeySavedValue = ""
+    @State private var didLoadOpenAIAPIKey = false
+    @State private var openAIAPIKeySaved = false
 
     var body: some View {
         ScrollView {
@@ -50,6 +54,12 @@ struct ModelsView: View {
         .onAppear {
             refreshTranscriptionDownloads()
             refreshSpeechModel()
+            if !didLoadOpenAIAPIKey {
+                let savedKey = app.settings.openAIAPIKey
+                openAIAPIKeyDraft = savedKey
+                openAIAPIKeySavedValue = savedKey
+                didLoadOpenAIAPIKey = true
+            }
         }
         .sheet(isPresented: $showingHFBrowse) { huggingFaceBrowser }
     }
@@ -189,7 +199,21 @@ struct ModelsView: View {
             case .openAICompatible:
                 TextField("Base URL (…/v1)", text: $app.settings.openAIBaseURL)
                 TextField("Model name", text: $app.settings.openAIModel)
-                SecureField("API key (optional)", text: $app.settings.openAIAPIKey)
+                HStack(spacing: 8) {
+                    SecureField("API key (optional)", text: $openAIAPIKeyDraft)
+                        .onChange(of: openAIAPIKeyDraft) { _, _ in
+                            openAIAPIKeySaved = false
+                        }
+                    Button(openAIAPIKeySaved ? "Saved" : "Save key") {
+                        app.settings.openAIAPIKey = openAIAPIKeyDraft
+                        openAIAPIKeySavedValue = openAIAPIKeyDraft
+                        openAIAPIKeySaved = true
+                    }
+                    .disabled(openAIAPIKeyDraft == openAIAPIKeySavedValue)
+                }
+                Text("The key is written to Keychain only when you choose Save key.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 remoteEndpointDisclosure(rawURL: app.settings.openAIBaseURL)
             }
 
@@ -211,17 +235,26 @@ struct ModelsView: View {
     private func remoteEndpointDisclosure(rawURL: String) -> some View {
         if let url = URL(string: rawURL), InferenceEndpointPolicy.requiresApproval(url),
            let origin = InferenceEndpointPolicy.origin(for: url) {
-            VStack(alignment: .leading, spacing: 6) {
-                Label("Remote server: meeting transcripts, screen text, and agent context may leave this Mac.",
-                      systemImage: "exclamationmark.triangle.fill")
+            if url.scheme?.lowercased() != "https" {
+                Label("Blocked: remote inference must use HTTPS so transcripts and screen text are encrypted in transit.",
+                      systemImage: "lock.slash.fill")
                     .font(.caption)
-                    .foregroundStyle(.orange)
-                Toggle("Allow sending inference context to \(origin)",
-                       isOn: remoteApprovalBinding(rawURL: rawURL))
-                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .padding(8)
+                    .background(.red.opacity(0.08), in: RoundedRectangle(cornerRadius: 7))
+            } else {
+                VStack(alignment: .leading, spacing: 6) {
+                    Label("Remote server: meeting transcripts, screen text, and agent context may leave this Mac.",
+                          systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                    Toggle("Allow sending inference context to \(origin)",
+                           isOn: remoteApprovalBinding(rawURL: rawURL))
+                        .font(.caption)
+                }
+                .padding(8)
+                .background(.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 7))
             }
-            .padding(8)
-            .background(.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 7))
         } else if let url = URL(string: rawURL), InferenceEndpointPolicy.isLoopback(url) {
             Label("Loopback server: inference context stays on this Mac.",
                   systemImage: "checkmark.shield.fill")

--- a/LokalBot/Views/ModelsView.swift
+++ b/LokalBot/Views/ModelsView.swift
@@ -467,6 +467,8 @@ struct ModelsView: View {
                                             displayName: file.fileName,
                                             fileName: file.fileName,
                                             url: file.downloadURL.absoluteString,
+                                            sha256: file.sha256,
+                                            sizeBytes: file.sizeBytes.map(Int64.init),
                                             sizeGB: file.sizeBytes.map { Double($0) / 1_000_000_000 } ?? 0,
                                             blurb: "Downloaded from \(file.modelID).",
                                             disablesThinking: false)

--- a/LokalBotTests/ActivityStoreTests.swift
+++ b/LokalBotTests/ActivityStoreTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import CoreGraphics
 @testable import LokalBot
 
 @MainActor
@@ -29,7 +30,7 @@ final class ActivityStoreTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
         let store = ActivityStore(databaseURL: url)
 
-        let id = store.insertScreenshot(
+        let id = try store.insertScreenshot(
             ts: Date(), path: "/tmp/a.heic.enc", app: "Safari",
             windowTitle: "Quarterly report — Google Docs", trigger: "window_change",
             ocr: "Q3 revenue grew 14 percent")
@@ -47,13 +48,13 @@ final class ActivityStoreTests: XCTestCase {
         XCTAssertEqual(store.searchOCR("quarterly").count, 1)
     }
 
-    func testSearchOCRRelaxedFallbackRescuesNaturalLanguage() {
+    func testSearchOCRRelaxedFallbackRescuesNaturalLanguage() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("ActivityStoreTests-\(UUID().uuidString).sqlite")
         defer { try? FileManager.default.removeItem(at: url) }
         let store = ActivityStore(databaseURL: url)
-        store.insertScreenshot(ts: Date(), path: "/tmp/a.heic.enc", app: "Safari",
-                               ocr: "kubernetes deployment rollback steps")
+        try store.insertScreenshot(ts: Date(), path: "/tmp/a.heic.enc", app: "Safari",
+                                   ocr: "kubernetes deployment rollback steps")
 
         // Strict ANDs the stop words and misses…
         XCTAssertTrue(store.searchOCR("what were the rollback steps").isEmpty)
@@ -95,11 +96,28 @@ final class ActivityStoreTests: XCTestCase {
         XCTAssertEqual(store.searchOCR("grocery").count, 1)
 
         // New-shape inserts work on the migrated tables.
-        store.insertScreenshot(ts: Date(), path: "/tmp/new.heic.enc", app: "Xcode",
-                               windowTitle: "build log", trigger: "app_switch",
-                               ocr: "compile succeeded")
+        try store.insertScreenshot(ts: Date(), path: "/tmp/new.heic.enc", app: "Xcode",
+                                   windowTitle: "build log", trigger: "app_switch",
+                                   ocr: "compile succeeded")
         XCTAssertEqual(store.searchOCR("compile").first?.windowTitle, "build log")
         XCTAssertEqual(store.screenshots(on: Date()).count, 2)
+    }
+
+    func testScreenshotAndOCRRowsRollbackTogetherWhenOCRInsertFails() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ActivityStoreTests-\(UUID().uuidString).sqlite")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = ActivityStore(databaseURL: url)
+        let database = try XCTUnwrap(SQLiteDatabase(url: url))
+        try database.execute("DROP TABLE ocr_fts")
+
+        XCTAssertThrowsError(try store.insertScreenshot(
+            ts: Date(), path: "/tmp/rollback.heic.enc", app: "Safari",
+            ocr: "this OCR insert must fail"))
+
+        XCTAssertEqual(
+            try database.firstDoubleChecked("SELECT COUNT(*) FROM screenshots"), 0,
+            "The screenshot row must roll back when its searchable OCR pair fails")
     }
 
     // MARK: - Capture policy
@@ -151,6 +169,163 @@ final class ActivityStoreTests: XCTestCase {
             recordingActive: false))
     }
 
+    func testCaptureLayoutUsesFocusedWindowDisplayAndExcludesEveryPrivateWindowOnIt() throws {
+        let displays = [
+            ScreenshotCaptureLayout.Display(
+                id: 1, frame: CGRect(x: 0, y: 0, width: 1_000, height: 800)),
+            ScreenshotCaptureLayout.Display(
+                id: 2, frame: CGRect(x: 1_000, y: 0, width: 1_000, height: 800)),
+        ]
+        let windows = [
+            // Same frontmost app on both displays; the title identifies the
+            // actual focused window on display 2 rather than array order.
+            ScreenshotCaptureLayout.Window(
+                id: 10, processID: 42, appName: "Safari", title: "Other tab",
+                frame: CGRect(x: 100, y: 100, width: 600, height: 500)),
+            ScreenshotCaptureLayout.Window(
+                id: 11, processID: 42, appName: "Safari", title: "Focused report",
+                frame: CGRect(x: 1_100, y: 100, width: 700, height: 500)),
+            ScreenshotCaptureLayout.Window(
+                id: 20, processID: 90, appName: "1Password", title: "Secrets",
+                frame: CGRect(x: 1_200, y: 200, width: 400, height: 400)),
+            ScreenshotCaptureLayout.Window(
+                id: 21, processID: 91, appName: "Signal", title: "Private chat",
+                frame: CGRect(x: 1_650, y: 50, width: 300, height: 500)),
+            // This excluded window is not on the selected display and does not
+            // need to be handed to that display's ScreenCaptureKit filter.
+            ScreenshotCaptureLayout.Window(
+                id: 22, processID: 92, appName: "1Password", title: "Vault",
+                frame: CGRect(x: 20, y: 20, width: 300, height: 300)),
+        ]
+
+        let selection = try XCTUnwrap(ScreenshotCaptureLayout.selection(
+            displays: displays,
+            windows: windows,
+            frontmostProcessID: 42,
+            focusedWindowTitle: "focused report",
+            excludedApps: ["1password", "SIGNAL"],
+            mainDisplayID: 1))
+
+        XCTAssertEqual(selection.displayID, 2)
+        XCTAssertEqual(selection.excludedWindowIDs, Set<CGWindowID>([20, 21]))
+    }
+
+    func testCaptureLayoutFallsBackToMainDisplayWithoutFocusedWindow() {
+        let selection = ScreenshotCaptureLayout.selection(
+            displays: [
+                .init(id: 1, frame: CGRect(x: 0, y: 0, width: 800, height: 600)),
+                .init(id: 2, frame: CGRect(x: 800, y: 0, width: 800, height: 600)),
+            ],
+            windows: [],
+            frontmostProcessID: 42,
+            focusedWindowTitle: "",
+            excludedApps: [],
+            mainDisplayID: 2)
+
+        XCTAssertEqual(selection?.displayID, 2)
+    }
+
+    func testCaptureFileNamesAndInFlightGateCannotCollide() {
+        let root = URL(fileURLWithPath: "/tmp/screenshot-path-test", isDirectory: true)
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000.125)
+        let first = ScreenshotService.captureFileURL(
+            rootURL: root, timestamp: timestamp,
+            identifier: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+        let second = ScreenshotService.captureFileURL(
+            rootURL: root, timestamp: timestamp,
+            identifier: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+
+        XCTAssertNotEqual(first, second)
+        XCTAssertTrue(first.lastPathComponent.hasPrefix("1700000000125-"))
+
+        var gate = ScreenshotCaptureGate()
+        XCTAssertTrue(gate.begin())
+        XCTAssertFalse(gate.begin())
+        gate.end()
+        XCTAssertTrue(gate.begin())
+    }
+
+    func testFocusedWindowTitleLookupRunsOffMainAndReturnsValue() async {
+        let lookup = FocusedWindowTitleLookup { _ in
+            Thread.isMainThread ? "main" : "background"
+        }
+
+        let result = await lookup.title(for: 42)
+
+        XCTAssertFalse(result.timedOut)
+        XCTAssertEqual(result.title, "background")
+    }
+
+    func testFocusedWindowTitleLookupFailsClosedAtWholeOperationDeadline() async {
+        let lookup = FocusedWindowTitleLookup(deadlineMilliseconds: 20) { _ in
+            Thread.sleep(forTimeInterval: 0.2)
+            return "too late"
+        }
+        let started = ContinuousClock.now
+
+        let result = await lookup.title(for: 42)
+
+        XCTAssertTrue(result.timedOut)
+        XCTAssertNil(result.title)
+        XCTAssertLessThan(started.duration(to: .now), .milliseconds(150))
+    }
+
+    func testStalledWindowTitleLookupDoesNotQueueAnotherTarget() async {
+        let blocker = DispatchSemaphore(value: 0)
+        let probe = ActivityResolverInvocationProbe()
+        let lookup = FocusedWindowTitleLookup(deadlineMilliseconds: 20) { _ in
+            probe.recordInvocation()
+            blocker.wait()
+            return "late"
+        }
+        defer { blocker.signal() }
+
+        let first = Task { await lookup.title(for: 42) }
+        for _ in 0..<20 where probe.invocationCount == 0 {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        XCTAssertEqual(probe.invocationCount, 1)
+        let firstResult = await first.value
+        XCTAssertTrue(firstResult.timedOut)
+
+        let started = ContinuousClock.now
+        let second = await lookup.title(for: 43)
+
+        XCTAssertTrue(second.timedOut)
+        XCTAssertLessThan(started.duration(to: .now), .milliseconds(20))
+        XCTAssertEqual(probe.invocationCount, 1)
+    }
+
+    func testScreenshotWindowFocusValidationFailsClosedOnTimeoutOrChange() {
+        XCTAssertTrue(ScreenshotWindowFocusValidation.matches(
+            expectedTitle: "Résumé",
+            current: .init(title: "resume", timedOut: false)))
+        XCTAssertTrue(ScreenshotWindowFocusValidation.matches(
+            expectedTitle: "",
+            current: .init(title: nil, timedOut: false)))
+        XCTAssertFalse(ScreenshotWindowFocusValidation.matches(
+            expectedTitle: "Report",
+            current: .timeout))
+        XCTAssertFalse(ScreenshotWindowFocusValidation.matches(
+            expectedTitle: "Report",
+            current: .init(title: "Chat", timedOut: false)))
+    }
+
+    func testActivitySamplerRemovesTerminationObserverWhenStopped() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ActivityStoreTests-\(UUID().uuidString).sqlite")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let sampler = ActivitySampler(
+            store: ActivityStore(databaseURL: url),
+            notificationCenter: NotificationCenter())
+
+        XCTAssertFalse(sampler.hasTerminationObserver)
+        sampler.start()
+        XCTAssertTrue(sampler.hasTerminationObserver)
+        sampler.stop()
+        XCTAssertFalse(sampler.hasTerminationObserver)
+    }
+
     func testClearOCRTextRemovesOnlyRowsOlderThanCutoff() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("ActivityStoreTests-\(UUID().uuidString).sqlite")
@@ -158,10 +333,10 @@ final class ActivityStoreTests: XCTestCase {
         let store = ActivityStore(databaseURL: url)
 
         let old = Date(timeIntervalSinceNow: -3 * 86_400)
-        store.insertScreenshot(ts: old, path: "/tmp/old.heic.enc", app: "Safari",
-                               ocr: "ancient invoice number")
-        store.insertScreenshot(ts: Date(), path: "/tmp/new.heic.enc", app: "Xcode",
-                               ocr: "fresh build log")
+        try store.insertScreenshot(ts: old, path: "/tmp/old.heic.enc", app: "Safari",
+                                   ocr: "ancient invoice number")
+        try store.insertScreenshot(ts: Date(), path: "/tmp/new.heic.enc", app: "Xcode",
+                                   ocr: "fresh build log")
 
         store.clearOCRText(olderThan: Date(timeIntervalSinceNow: -86_400))
 
@@ -169,5 +344,22 @@ final class ActivityStoreTests: XCTestCase {
         XCTAssertEqual(store.searchOCR("fresh").count, 1)
         // Pixel bookkeeping untouched: text pruning is independent of paths.
         XCTAssertEqual(store.screenshotPaths(olderThan: Date()).count, 2)
+    }
+}
+
+private final class ActivityResolverInvocationProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var invocationCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func recordInvocation() {
+        lock.lock()
+        count += 1
+        lock.unlock()
     }
 }

--- a/LokalBotTests/AgentAccessGateTests.swift
+++ b/LokalBotTests/AgentAccessGateTests.swift
@@ -51,4 +51,30 @@ final class AgentAccessGateTests: XCTestCase {
         }
         XCTAssertEqual(AgentAccessGate().root.path, root.path)
     }
+
+    func testScopedCapabilityAuthorizesOnlyWhilePresentAndUnexpired() throws {
+        let (gate, root) = makeGate()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let capability = try gate.issueScopedCapability(validFor: 120)
+        let environment = [AgentAccessGate.capabilityEnvironmentKey: capability.token]
+
+        XCTAssertTrue(gate.isAuthorized(environment: environment))
+        XCTAssertFalse(gate.isAuthorized(
+            environment: environment,
+            now: Date().addingTimeInterval(121)))
+        XCTAssertFalse(gate.isAuthorized(environment: [
+            AgentAccessGate.capabilityEnvironmentKey: capability.token + "tampered",
+        ]))
+
+        gate.revoke(capability)
+        XCTAssertFalse(gate.isAuthorized(environment: environment))
+    }
+
+    func testGlobalToggleAuthorizesWithoutCapability() throws {
+        let (gate, root) = makeGate()
+        defer { try? FileManager.default.removeItem(at: root) }
+        XCTAssertFalse(gate.isAuthorized(environment: [:]))
+        try gate.enable()
+        XCTAssertTrue(gate.isAuthorized(environment: [:]))
+    }
 }

--- a/LokalBotTests/AgentAccessManagerTests.swift
+++ b/LokalBotTests/AgentAccessManagerTests.swift
@@ -174,14 +174,17 @@ final class AgentAccessManagerTests: XCTestCase {
     }
 
     func testDisableDuringWakeReleasesLeaseAcquiredAfterDisable() async throws {
-        let entry = try XCTUnwrap(
-            ModelCatalog.entry(id: ModelCatalog.recommendedSummarizationID))
+        let entry = ModelCatalog.Entry(
+            id: "wake-fixture", displayName: "Wake Fixture",
+            fileName: "wake-fixture.gguf", url: "", sizeGB: 0,
+            blurb: "", disablesThinking: false)
         let models = root.appendingPathComponent("models", isDirectory: true)
         try FileManager.default.createDirectory(at: models, withIntermediateDirectories: true)
         try Data("GGUF".utf8).write(to: models.appendingPathComponent(entry.fileName))
         var settings = AppSettings()
         settings.summarizerBackend = .builtIn
         settings.builtInModelID = entry.id
+        settings.customBuiltInModels = [entry]
 
         let blocker = BlockingEnsure()
         let ensureStarted = expectation(description: "broker ensure started")

--- a/LokalBotTests/AgentApprovalPolicyTests.swift
+++ b/LokalBotTests/AgentApprovalPolicyTests.swift
@@ -3,37 +3,117 @@ import XCTest
 
 final class AgentApprovalPolicyTests: XCTestCase {
 
-    func testGatedToolAsksByDefault() {
-        let policy = AgentApprovalPolicy()
-        XCTAssertEqual(policy.verdict(tool: "bash"), .ask)
-        XCTAssertEqual(policy.verdict(tool: "write"), .ask)
-        XCTAssertEqual(policy.verdict(tool: "edit"), .ask)
+    private let workspace = URL(fileURLWithPath: "/tmp/lokalbot-agent-policy-workspace")
+
+    private func verdict(_ policy: AgentApprovalPolicy, tool: String, path: String? = nil,
+                         requestWorkspace: String? = nil) -> AgentApprovalPolicy.Verdict {
+        policy.verdict(
+            tool: tool,
+            path: path,
+            requestWorkspace: requestWorkspace,
+            selectedWorkspace: workspace)
     }
 
-    func testAutoApproveAllAllowsEverything() {
+    func testGatedToolAsksByDefault() {
+        let policy = AgentApprovalPolicy()
+        XCTAssertEqual(verdict(policy, tool: "bash"), .ask)
+        XCTAssertEqual(verdict(policy, tool: "write"), .ask)
+        XCTAssertEqual(verdict(policy, tool: "edit"), .ask)
+    }
+
+    func testAutoApproveAllowsOnlyFileChanges() {
         var policy = AgentApprovalPolicy()
-        policy.autoApproveAll = true
-        XCTAssertEqual(policy.verdict(tool: "bash"), .allow)
+        policy.autoApproveFileChanges = true
+        let root = workspace.path
+        XCTAssertEqual(verdict(policy, tool: "bash", path: "\(root)/script.sh",
+                               requestWorkspace: root), .ask)
+        XCTAssertEqual(verdict(policy, tool: "write", path: "\(root)/note.txt",
+                               requestWorkspace: root), .allow)
+        XCTAssertEqual(verdict(policy, tool: "edit", path: "\(root)/nested/note.txt",
+                               requestWorkspace: root), .allow)
+        XCTAssertEqual(verdict(policy, tool: "unknown", path: "\(root)/note.txt",
+                               requestWorkspace: root), .ask)
+    }
+
+    func testPrivacySensitiveToolsAlwaysAsk() {
+        var policy = AgentApprovalPolicy()
+        policy.autoApproveFileChanges = true
+        let root = workspace.path
+        policy.allowForSession(
+            tool: "read", path: "/private/notes.txt", requestWorkspace: root,
+            selectedWorkspace: workspace)
+        policy.allowForSession(
+            tool: "bash", path: nil, requestWorkspace: root,
+            selectedWorkspace: workspace)
+        XCTAssertEqual(verdict(policy, tool: "read", path: "/private/notes.txt",
+                               requestWorkspace: root), .ask)
+        XCTAssertEqual(verdict(policy, tool: "bash", requestWorkspace: root), .ask)
+        XCTAssertEqual(verdict(policy, tool: "BASH", requestWorkspace: root), .ask)
     }
 
     func testSessionAllowanceIsPerTool() {
         var policy = AgentApprovalPolicy()
-        policy.allowForSession(tool: "bash")
-        XCTAssertEqual(policy.verdict(tool: "bash"), .allow)
-        XCTAssertEqual(policy.verdict(tool: "write"), .ask)
+        let root = workspace.path
+        policy.allowForSession(
+            tool: "write", path: "\(root)/one.txt", requestWorkspace: root,
+            selectedWorkspace: workspace)
+        XCTAssertEqual(verdict(policy, tool: "write", path: "\(root)/two.txt",
+                               requestWorkspace: root), .allow)
+        XCTAssertEqual(verdict(policy, tool: "edit", path: "\(root)/two.txt",
+                               requestWorkspace: root), .ask)
     }
 
     func testResetSessionClearsAllowances() {
         var policy = AgentApprovalPolicy()
-        policy.allowForSession(tool: "bash")
+        let root = workspace.path
+        policy.allowForSession(
+            tool: "write", path: "\(root)/one.txt", requestWorkspace: root,
+            selectedWorkspace: workspace)
         policy.resetSession()
-        XCTAssertEqual(policy.verdict(tool: "bash"), .ask)
+        XCTAssertEqual(verdict(policy, tool: "write", path: "\(root)/two.txt",
+                               requestWorkspace: root), .ask)
     }
 
     func testResetSessionKeepsAutoApproveToggle() {
         var policy = AgentApprovalPolicy()
-        policy.autoApproveAll = true
+        policy.autoApproveFileChanges = true
         policy.resetSession()
-        XCTAssertEqual(policy.verdict(tool: "bash"), .allow)
+        let root = workspace.path
+        XCTAssertEqual(verdict(policy, tool: "write", path: "\(root)/note.txt",
+                               requestWorkspace: root), .allow)
+    }
+
+    func testOutsideMissingAndMismatchedPathsNeverInheritApproval() {
+        var policy = AgentApprovalPolicy()
+        policy.autoApproveFileChanges = true
+        let root = workspace.path
+        XCTAssertEqual(verdict(policy, tool: "write", requestWorkspace: root), .ask)
+        XCTAssertEqual(verdict(policy, tool: "write", path: "/private/outside.txt",
+                               requestWorkspace: root), .ask)
+        XCTAssertEqual(verdict(policy, tool: "edit", path: "\(root)/note.txt",
+                               requestWorkspace: "/private/other-workspace"), .ask)
+    }
+
+    func testSymlinkEscapedWriteNeverInheritsApproval() throws {
+        let parent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-policy-symlink-\(UUID().uuidString)", isDirectory: true)
+        let root = parent.appendingPathComponent("workspace", isDirectory: true)
+        let outside = parent.appendingPathComponent("outside", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("escape", isDirectory: true),
+            withDestinationURL: outside)
+        defer { try? FileManager.default.removeItem(at: parent) }
+
+        var policy = AgentApprovalPolicy()
+        policy.autoApproveFileChanges = true
+        XCTAssertEqual(
+            policy.verdict(
+                tool: "write",
+                path: root.appendingPathComponent("escape/private.txt").path,
+                requestWorkspace: root.path,
+                selectedWorkspace: root),
+            .ask)
     }
 }

--- a/LokalBotTests/AgentRuntimeInstallerTests.swift
+++ b/LokalBotTests/AgentRuntimeInstallerTests.swift
@@ -4,6 +4,15 @@ import XCTest
 @MainActor
 final class AgentRuntimeInstallerTests: XCTestCase {
 
+    private actor VerificationProbe {
+        private(set) var calls = 0
+
+        func verify() -> Bool {
+            calls += 1
+            return false
+        }
+    }
+
     private var sandbox: URL!
 
     override func setUp() async throws {
@@ -36,10 +45,16 @@ final class AgentRuntimeInstallerTests: XCTestCase {
     }
 
     private var fakePackageInstaller: AgentRuntimeInstaller.PackageInstaller {
-        { _, _, destination in
+        { _, template, destination in
             let cliDir = destination.appendingPathComponent(
                 "node_modules/@earendil-works/pi-coding-agent/dist", isDirectory: true)
             try FileManager.default.createDirectory(at: cliDir, withIntermediateDirectories: true)
+            try FileManager.default.copyItem(
+                at: template.appendingPathComponent("package.json"),
+                to: destination.appendingPathComponent("package.json"))
+            try FileManager.default.copyItem(
+                at: template.appendingPathComponent("bun.lock"),
+                to: destination.appendingPathComponent("bun.lock"))
             try Data("// cli".utf8).write(to: cliDir.appendingPathComponent("cli.js"))
         }
     }
@@ -54,31 +69,61 @@ final class AgentRuntimeInstallerTests: XCTestCase {
         XCTAssertEqual(process.terminationStatus, 0, "\(tool) failed")
     }
 
-    private func manifest(bunZip: URL, corruptBunSHA: Bool = false) throws -> AgentRuntimeManifest {
+    private func manifest(
+        bunZip: URL,
+        corruptBunSHA: Bool = false,
+        runtimeTreeSHA256: String? = nil
+    ) throws -> AgentRuntimeManifest {
         AgentRuntimeManifest(
             bun: AgentRuntimeArtifact(
                 name: "Bun test", url: bunZip,
                 sha256: corruptBunSHA ? String(repeating: "0", count: 64)
                                       : try SHA256Verifier.hexDigest(of: bunZip),
-                archiveKind: .zip))
+                archiveKind: .zip),
+            piRuntimeTreeSHA256: runtimeTreeSHA256)
     }
 
     func testInstallsVerifiedArtifactsIntoLayout() async throws {
         let root = sandbox.appendingPathComponent("agent-runtime", isDirectory: true)
+        let testManifest = try manifest(bunZip: makeBunFixture())
         let installer = AgentRuntimeInstaller(
             root: root,
             runtimeTemplate: try makeRuntimeTemplate(),
             packageInstaller: fakePackageInstaller)
-        await installer.installIfNeeded(manifest: try manifest(bunZip: makeBunFixture()))
+        await installer.installIfNeeded(manifest: testManifest)
         XCTAssertEqual(installer.phase, .installed)
-        XCTAssertTrue(AgentRuntimeLayout.isInstalled(under: root))
+        XCTAssertTrue(AgentRuntimeLayout.isInstalled(under: root, manifest: testManifest))
         XCTAssertTrue(FileManager.default.isExecutableFile(
             atPath: AgentRuntimeLayout.bunBinary(under: root).path))
         let markerData = try Data(contentsOf: AgentRuntimeLayout.versionMarker(under: root))
-        let versions = try XCTUnwrap(
-            JSONSerialization.jsonObject(with: markerData) as? [String: String])
-        XCTAssertEqual(versions, ["bun": AgentRuntimeManifest.bunVersion,
-                                  "pi": AgentRuntimeManifest.piVersion])
+        let marker = try JSONDecoder().decode(AgentRuntimeVersionMarker.self, from: markerData)
+        XCTAssertEqual(marker.bunVersion, AgentRuntimeManifest.bunVersion)
+        XCTAssertEqual(marker.piVersion, AgentRuntimeManifest.piVersion)
+        XCTAssertEqual(marker.bunArchiveSHA256, testManifest.bun.sha256)
+        XCTAssertEqual(marker.bunBinarySHA256.count, 64)
+        XCTAssertEqual(marker.piCLISHA256.count, 64)
+        XCTAssertEqual(marker.piRuntimeTreeSHA256.count, 64)
+        let attributes = try FileManager.default.attributesOfItem(
+            atPath: AgentRuntimeLayout.versionMarker(under: root).path)
+        XCTAssertEqual(attributes[.posixPermissions] as? NSNumber, NSNumber(value: 0o600))
+    }
+
+    func testInitializationDefersRuntimeVerificationUntilRefresh() async throws {
+        let probe = VerificationProbe()
+        let installer = AgentRuntimeInstaller(
+            root: sandbox.appendingPathComponent("agent-runtime", isDirectory: true),
+            runtimeTemplate: try makeRuntimeTemplate(),
+            packageInstaller: fakePackageInstaller,
+            runtimeVerifier: { _, _ in await probe.verify() })
+
+        XCTAssertEqual(installer.phase, .checking)
+        var calls = await probe.calls
+        XCTAssertEqual(calls, 0)
+
+        await installer.refreshInstalledState()
+        calls = await probe.calls
+        XCTAssertEqual(calls, 1)
+        XCTAssertEqual(installer.phase, .idle)
     }
 
     func testChecksumMismatchFailsAndInstallsNothing() async throws {
@@ -94,6 +139,43 @@ final class AgentRuntimeInstallerTests: XCTestCase {
         }
         XCTAssertTrue(message.contains("checksum"), message)
         XCTAssertFalse(AgentRuntimeLayout.isInstalled(under: root))
+    }
+
+    func testRuntimeTreeChecksumMismatchFailsAndInstallsNothing() async throws {
+        let root = sandbox.appendingPathComponent("agent-runtime", isDirectory: true)
+        let installer = AgentRuntimeInstaller(
+            root: root,
+            runtimeTemplate: try makeRuntimeTemplate(),
+            packageInstaller: fakePackageInstaller)
+        await installer.installIfNeeded(manifest: try manifest(
+            bunZip: makeBunFixture(),
+            runtimeTreeSHA256: String(repeating: "0", count: 64)))
+        guard case .failed(let message) = installer.phase else {
+            return XCTFail("expected failure, got \(installer.phase)")
+        }
+        XCTAssertTrue(message.contains("checksum"), message)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.path))
+    }
+
+    func testRuntimeTreeChecksumMatchInstallsVerifiedTree() async throws {
+        let root = sandbox.appendingPathComponent("agent-runtime", isDirectory: true)
+        let template = try makeRuntimeTemplate()
+        let expectedTree = sandbox.appendingPathComponent("expected-pi", isDirectory: true)
+        try await fakePackageInstaller(
+            URL(fileURLWithPath: "/unused/fake-bun"), template, expectedTree)
+        let expectedDigest = try SHA256Verifier.treeHexDigest(of: expectedTree)
+        try FileManager.default.removeItem(at: expectedTree)
+
+        let testManifest = try manifest(
+            bunZip: makeBunFixture(), runtimeTreeSHA256: expectedDigest)
+        let installer = AgentRuntimeInstaller(
+            root: root,
+            runtimeTemplate: template,
+            packageInstaller: fakePackageInstaller)
+        await installer.installIfNeeded(manifest: testManifest)
+
+        XCTAssertEqual(installer.phase, .installed)
+        XCTAssertTrue(AgentRuntimeLayout.isInstalled(under: root, manifest: testManifest))
     }
 
     func testFrozenPackageInstallerCopiesManifestAndRunsExpectedCommand() async throws {
@@ -133,14 +215,11 @@ final class AgentRuntimeInstallerTests: XCTestCase {
             root: root,
             runtimeTemplate: try makeRuntimeTemplate(),
             packageInstaller: fakePackageInstaller)
-        await installer.installIfNeeded(manifest: try manifest(bunZip: makeBunFixture()))
+        let testManifest = try manifest(bunZip: makeBunFixture())
+        await installer.installIfNeeded(manifest: testManifest)
         XCTAssertEqual(installer.phase, .installed)
-        // Second call must short-circuit without downloading: this manifest
-        // points at nonexistent files, so any fetch attempt would fail.
-        let bogus = AgentRuntimeManifest(
-            bun: AgentRuntimeArtifact(name: "Bun", url: URL(fileURLWithPath: "/nonexistent.zip"),
-                                      sha256: String(repeating: "0", count: 64), archiveKind: .zip))
-        await installer.installIfNeeded(manifest: bogus)
+        try FileManager.default.removeItem(at: testManifest.bun.url)
+        await installer.installIfNeeded(manifest: testManifest)
         XCTAssertEqual(installer.phase, .installed)
     }
 }

--- a/LokalBotTests/AgentRuntimeTests.swift
+++ b/LokalBotTests/AgentRuntimeTests.swift
@@ -40,7 +40,69 @@ final class AgentRuntimeTests: XCTestCase {
         XCTAssertFalse(AgentRuntimeLayout.isInstalled(under: root), "bun not yet executable")
 
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: bun.path)
-        XCTAssertTrue(AgentRuntimeLayout.isInstalled(under: root))
+        try Data("{}".utf8).write(to: root.appendingPathComponent("pi/package.json"))
+        try Data("lock".utf8).write(to: root.appendingPathComponent("pi/bun.lock"))
+        let importedModule = cli.deletingLastPathComponent().appendingPathComponent("main.js")
+        try Data("// imported runtime code".utf8).write(to: importedModule)
+        let manifest = AgentRuntimeManifest(bun: AgentRuntimeArtifact(
+            name: "test", url: URL(fileURLWithPath: "/test.zip"),
+            sha256: String(repeating: "a", count: 64), archiveKind: .zip))
+        let marker = AgentRuntimeVersionMarker(
+            bunVersion: AgentRuntimeManifest.bunVersion,
+            piVersion: AgentRuntimeManifest.piVersion,
+            bunArchiveSHA256: manifest.bun.sha256,
+            bunBinarySHA256: try SHA256Verifier.hexDigest(of: bun),
+            piCLISHA256: try SHA256Verifier.hexDigest(of: cli),
+            packageJSONSHA256: try SHA256Verifier.hexDigest(
+                of: root.appendingPathComponent("pi/package.json")),
+            lockfileSHA256: try SHA256Verifier.hexDigest(
+                of: root.appendingPathComponent("pi/bun.lock")),
+            piRuntimeTreeSHA256: try SHA256Verifier.treeHexDigest(
+                of: root.appendingPathComponent("pi", isDirectory: true)))
+        try JSONEncoder().encode(marker).write(
+            to: AgentRuntimeLayout.versionMarker(under: root))
+        XCTAssertTrue(AgentRuntimeLayout.isInstalled(under: root, manifest: manifest))
+
+        // cli.js is unchanged: imported/runtime dependency code must be covered
+        // by the whole-tree digest too.
+        try Data("// tampered imported code".utf8).write(to: importedModule)
+        XCTAssertFalse(AgentRuntimeLayout.isInstalled(under: root, manifest: manifest))
+    }
+
+    func testTreeDigestIsDeterministicAndCoversSymlinksAndHiddenFiles() throws {
+        let parent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tree-digest-\(UUID().uuidString)", isDirectory: true)
+        let first = parent.appendingPathComponent("first", isDirectory: true)
+        let second = parent.appendingPathComponent("second", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+
+        func populate(_ root: URL, reverseCreationOrder: Bool) throws {
+            let package = root.appendingPathComponent("node_modules/pkg", isDirectory: true)
+            let bin = root.appendingPathComponent("node_modules/.bin", isDirectory: true)
+            let directories = reverseCreationOrder ? [bin, package] : [package, bin]
+            for directory in directories {
+                try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            }
+            try Data("export default 1".utf8).write(
+                to: package.appendingPathComponent("main.js"))
+            try Data("hidden".utf8).write(
+                to: package.appendingPathComponent(".metadata"))
+            try FileManager.default.createSymbolicLink(
+                atPath: bin.appendingPathComponent("pkg").path,
+                withDestinationPath: "../pkg/main.js")
+        }
+
+        try populate(first, reverseCreationOrder: false)
+        try populate(second, reverseCreationOrder: true)
+        let firstDigest = try SHA256Verifier.treeHexDigest(of: first)
+        XCTAssertEqual(firstDigest, try SHA256Verifier.treeHexDigest(of: second))
+
+        try FileManager.default.removeItem(
+            at: second.appendingPathComponent("node_modules/.bin/pkg"))
+        try FileManager.default.createSymbolicLink(
+            atPath: second.appendingPathComponent("node_modules/.bin/pkg").path,
+            withDestinationPath: "../pkg/.metadata")
+        XCTAssertNotEqual(firstDigest, try SHA256Verifier.treeHexDigest(of: second))
     }
 
     func testManifestPinsExpectedVersions() {
@@ -50,5 +112,20 @@ final class AgentRuntimeTests: XCTestCase {
         XCTAssertTrue(manifest.bun.url.absoluteString.contains("bun-v1.3.14/bun-darwin-aarch64.zip"))
         XCTAssertEqual(manifest.bun.sha256.count, 64)
         XCTAssertEqual(manifest.bun.archiveKind, .zip)
+        XCTAssertEqual(manifest.piRuntimeTreeSHA256?.count, 64)
+        XCTAssertNotEqual(manifest.piRuntimeTreeSHA256, String(repeating: "0", count: 64))
+    }
+
+    /// Maintainers can point this at a fresh frozen-lockfile install when
+    /// updating the pinned pi runtime. It deliberately skips in ordinary CI,
+    /// which must not depend on npm or a preinstalled package tree.
+    func testCurrentManifestMatchesProvidedPinnedRuntimeTree() throws {
+        guard let path = ProcessInfo.processInfo.environment["LOKALBOT_PINNED_RUNTIME_TREE"],
+              !path.isEmpty else {
+            throw XCTSkip("Set LOKALBOT_PINNED_RUNTIME_TREE to verify a fresh pinned install")
+        }
+        let digest = try SHA256Verifier.treeHexDigest(
+            of: URL(fileURLWithPath: path, isDirectory: true))
+        XCTAssertEqual(digest, AgentRuntimeManifest.current.piRuntimeTreeSHA256)
     }
 }

--- a/LokalBotTests/AgentSessionControllerTests.swift
+++ b/LokalBotTests/AgentSessionControllerTests.swift
@@ -102,13 +102,16 @@ final class AgentSessionControllerTests: XCTestCase {
             withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        let entry = try XCTUnwrap(
-            ModelCatalog.entry(id: ModelCatalog.recommendedSummarizationID))
+        let entry = ModelCatalog.Entry(
+            id: "agent-lease-fixture", displayName: "Agent Lease Fixture",
+            fileName: "agent-lease-fixture.gguf", url: "", sizeGB: 0,
+            blurb: "", disablesThinking: false)
         try Data("GGUF".utf8).write(
             to: root.appendingPathComponent("models/\(entry.fileName)"))
         var settings = AppSettings()
         settings.summarizerBackend = .builtIn
         settings.builtInModelID = entry.id
+        settings.customBuiltInModels = [entry]
 
         let blocker = BlockingBrokerEnsure()
         var hooks: [InferenceRole: InferenceBroker.RuntimeHooks] = [:]

--- a/LokalBotTests/AgentSessionControllerTests.swift
+++ b/LokalBotTests/AgentSessionControllerTests.swift
@@ -53,6 +53,31 @@ final class AgentSessionControllerTests: XCTestCase {
         try await Task.sleep(for: .milliseconds(150))
     }
 
+    private func approvalEvent(
+        id: String,
+        tool: String,
+        workspace: String,
+        path: String?,
+        content: String
+    ) throws -> String {
+        var payload: [String: Any] = [
+            "tool": tool,
+            "workspace": workspace,
+            "content": content,
+        ]
+        if let path { payload["path"] = path }
+        let payloadData = try JSONSerialization.data(withJSONObject: payload)
+        let payloadString = String(decoding: payloadData, as: UTF8.self)
+        let event: [String: Any] = [
+            "type": "extension_ui_request",
+            "id": id,
+            "method": "confirm",
+            "title": "lokalbot_tool_approval",
+            "message": payloadString,
+        ]
+        return String(decoding: try JSONSerialization.data(withJSONObject: event), as: UTF8.self)
+    }
+
     func testStartReachesReady() async throws {
         let controller = makeController()
         await controller.start()
@@ -225,16 +250,107 @@ final class AgentSessionControllerTests: XCTestCase {
     func testSessionScopeAutoApprovesRepeats() async throws {
         let controller = makeController()
         await controller.start()
-        transport.inject(#"{"type":"extension_ui_request","id":"u1","method":"confirm","title":"lokalbot_tool_approval","message":"{\"tool\":\"bash\",\"summary\":\"ls\"}"}"#)
+        let root = controller.workspace.path
+        transport.inject(try approvalEvent(
+            id: "u1", tool: "write", workspace: root,
+            path: root + "/one.txt", content: "one"))
         try await pump()
         await controller.respondToApproval(id: "u1", approved: true, scope: .session)
-        transport.inject(#"{"type":"extension_ui_request","id":"u2","method":"confirm","title":"lokalbot_tool_approval","message":"{\"tool\":\"bash\",\"summary\":\"pwd\"}"}"#)
+        transport.inject(try approvalEvent(
+            id: "u2", tool: "write", workspace: root,
+            path: root + "/nested/two.txt", content: "two"))
         try await pump()
         XCTAssertTrue(transport.sentLines.contains {
             $0.contains(#""id":"u2""#) && $0.contains(#""confirmed":true"#)
-        }, "second bash auto-approved for the session")
+        }, "second write auto-approved for the session")
         XCTAssertFalse(controller.items.contains {
             if case .approval(let request) = $0 { return request.id == "u2" } else { return false }
+        })
+    }
+
+    func testOutsideAndMissingWritePathsNeverInheritSessionApproval() async throws {
+        let controller = makeController()
+        await controller.start()
+        controller.autoApproveSession = true
+        let root = controller.workspace.path
+
+        transport.inject(try approvalEvent(
+            id: "outside", tool: "write", workspace: root,
+            path: "/private/lokalbot-outside.txt", content: "outside"))
+        transport.inject(try approvalEvent(
+            id: "missing", tool: "edit", workspace: root,
+            path: nil, content: "missing"))
+        transport.inject(try approvalEvent(
+            id: "mismatch", tool: "write", workspace: "/private/other-workspace",
+            path: root + "/inside.txt", content: "mismatch"))
+        try await pump()
+
+        for id in ["outside", "missing", "mismatch"] {
+            XCTAssertTrue(controller.items.contains {
+                if case .approval(let request) = $0 { return request.id == id }
+                return false
+            })
+            XCTAssertFalse(transport.sentLines.contains {
+                $0.contains("\"id\":\"\(id)\"") && $0.contains(#""confirmed":true"#)
+            })
+        }
+    }
+
+    func testBashAlwaysRequiresOneTimeApproval() async throws {
+        let controller = makeController()
+        await controller.start()
+        controller.autoApproveSession = true
+
+        transport.inject(#"{"type":"extension_ui_request","id":"bash1","method":"confirm","title":"lokalbot_tool_approval","message":"{\"tool\":\"bash\",\"workspace\":\"/tmp/project\",\"command\":\"cat ~/.ssh/config\"}"}"#)
+        try await pump()
+        XCTAssertTrue(controller.items.contains {
+            if case .approval(let request) = $0 { return request.id == "bash1" }
+            return false
+        })
+        XCTAssertFalse(transport.sentLines.contains {
+            $0.contains(#""id":"bash1""#) && $0.contains(#""confirmed":true"#)
+        })
+
+        // A caller cannot persist shell permission even if it requests session
+        // scope; the next command must surface independently.
+        await controller.respondToApproval(id: "bash1", approved: true, scope: .session)
+        transport.inject(#"{"type":"extension_ui_request","id":"bash2","method":"confirm","title":"lokalbot_tool_approval","message":"{\"tool\":\"bash\",\"workspace\":\"/tmp/project\",\"command\":\"env\"}"}"#)
+        try await pump()
+        XCTAssertTrue(controller.items.contains {
+            if case .approval(let request) = $0 { return request.id == "bash2" }
+            return false
+        })
+        XCTAssertFalse(transport.sentLines.contains {
+            $0.contains(#""id":"bash2""#) && $0.contains(#""confirmed":true"#)
+        })
+    }
+
+    func testOutsideWorkspaceReadAlwaysRequiresOneTimeApproval() async throws {
+        let controller = makeController()
+        await controller.start()
+        controller.autoApproveSession = true
+
+        transport.inject(#"{"type":"extension_ui_request","id":"read1","method":"confirm","title":"lokalbot_tool_approval","message":"{\"tool\":\"read\",\"workspace\":\"/tmp/project\",\"path\":\"/private/notes.txt\"}"}"#)
+        try await pump()
+        XCTAssertTrue(controller.items.contains {
+            if case .approval(let request) = $0 { return request.id == "read1" }
+            return false
+        })
+        XCTAssertFalse(transport.sentLines.contains {
+            $0.contains(#""id":"read1""#) && $0.contains(#""confirmed":true"#)
+        })
+
+        // Even if a caller attempts session scope, reads outside the selected
+        // workspace remain one-request capabilities.
+        await controller.respondToApproval(id: "read1", approved: true, scope: .session)
+        transport.inject(#"{"type":"extension_ui_request","id":"read2","method":"confirm","title":"lokalbot_tool_approval","message":"{\"tool\":\"read\",\"workspace\":\"/tmp/project\",\"path\":\"/private/other.txt\"}"}"#)
+        try await pump()
+        XCTAssertTrue(controller.items.contains {
+            if case .approval(let request) = $0 { return request.id == "read2" }
+            return false
+        })
+        XCTAssertFalse(transport.sentLines.contains {
+            $0.contains(#""id":"read2""#) && $0.contains(#""confirmed":true"#)
         })
     }
 
@@ -262,6 +378,44 @@ final class AgentSessionControllerTests: XCTestCase {
             return XCTFail("expected transport failure notice, got \(controller.items)")
         }
         XCTAssertTrue(isError)
+    }
+
+    func testRequestFailureTearsDownOldEventLoopBeforeRestart() async throws {
+        var settings = AppSettings()
+        settings.summarizerBackend = .openAICompatible
+        settings.openAIBaseURL = "http://127.0.0.1:1234/v1"
+        settings.openAIModel = "test-model"
+        var transports: [FakeTransport] = []
+        let controller = AgentSessionController(
+            settings: { settings },
+            storage: StorageManager(),
+            makeTransport: { _ in
+                let transport = FakeTransport()
+                transports.append(transport)
+                return transport
+            })
+
+        await controller.start()
+        let first = try XCTUnwrap(transports.first)
+        first.failFutureSends()
+        await controller.send(prompt: "trigger transport failure")
+        guard case .failed = controller.state else {
+            return XCTFail("expected failed state, got \(controller.state)")
+        }
+
+        await controller.start()
+        XCTAssertEqual(controller.state, .ready)
+        XCTAssertEqual(transports.count, 2)
+
+        // The first stream is deliberately still open. A late event from it
+        // must not mutate the replacement session.
+        first.inject(#"{"type":"agent_start"}"#)
+        try await pump()
+        XCTAssertEqual(controller.state, .ready)
+
+        transports[1].inject(#"{"type":"agent_start"}"#)
+        try await pump()
+        XCTAssertEqual(controller.state, .running)
     }
 
     func testFirstPromptNamesSessionAndDraftRequiresCloseConfirmation() async throws {

--- a/LokalBotTests/AgentSessionTabsTests.swift
+++ b/LokalBotTests/AgentSessionTabsTests.swift
@@ -99,6 +99,16 @@ final class AgentSessionTabsTests: XCTestCase {
         XCTAssertEqual(second.controller.state, .idle)
     }
 
+    func testLiveSessionCountIsBounded() {
+        let factory = Factory(root: root)
+        let sessions = AgentSessionTabs { factory.makeController() }
+        for _ in 0..<(AgentSessionTabs.maximumLiveSessions + 3) {
+            _ = sessions.addSession()
+        }
+        XCTAssertEqual(sessions.tabs.count, AgentSessionTabs.maximumLiveSessions)
+        XCTAssertEqual(factory.transports.count, AgentSessionTabs.maximumLiveSessions)
+    }
+
     func testClearSavedHistoryStopsSessionsRemovesFilesAndCreatesFreshTab() async throws {
         let factory = Factory(root: root)
         try FileManager.default.createDirectory(

--- a/LokalBotTests/AgentTranscriptTests.swift
+++ b/LokalBotTests/AgentTranscriptTests.swift
@@ -119,6 +119,77 @@ final class AgentTranscriptTests: XCTestCase {
         }
     }
 
+    func testEveryMessageInsertionPathIsBounded() {
+        let oversized = String(repeating: "x", count: AgentTranscriptFolder.maximumMessageCharacters + 1)
+        var folder = AgentTranscriptFolder()
+        folder.noteUserPrompt(oversized)
+        folder.appendAssistantMessage(oversized)
+        folder.appendNotice(oversized)
+        folder.fold(.messageEnd(role: "assistant", text: oversized))
+
+        XCTAssertEqual(folder.items.count, 4)
+        for item in folder.items {
+            let text: String
+            switch item {
+            case .user(_, let value), .assistant(_, let value, _), .notice(_, let value, _):
+                text = value
+            default:
+                return XCTFail("unexpected item \(item)")
+            }
+            XCTAssertEqual(text.count, AgentTranscriptFolder.maximumMessageCharacters)
+        }
+    }
+
+    func testResourceLimitEvictsOldestTextUntilWithinTotalBudget() {
+        var folder = AgentTranscriptFolder()
+        for index in 0..<10 {
+            folder.noteUserPrompt(
+                "\(index)" + String(
+                    repeating: "x",
+                    count: AgentTranscriptFolder.maximumMessageCharacters - 1))
+        }
+        folder.enforceResourceLimits()
+
+        XCTAssertLessThan(folder.items.count, 10)
+        let retainedCharacters = folder.items.reduce(0) { total, item in
+            if case .user(_, let text) = item { return total + text.count }
+            return total
+        }
+        XCTAssertLessThanOrEqual(
+            retainedCharacters, AgentTranscriptFolder.maximumTotalCharacters)
+        XCTAssertFalse(folder.items.contains {
+            if case .user(_, let text) = $0 { return text.first == "0" }
+            return false
+        })
+    }
+
+    func testApprovalsHaveIndependentCountAndPreviewBounds() {
+        var folder = AgentTranscriptFolder()
+        let oversizedCommand = String(
+            repeating: "x", count: AgentTranscriptFolder.maximumToolCharacters + 1)
+        for index in 0..<AgentTranscriptFolder.maximumPendingApprovals {
+            XCTAssertTrue(folder.addApproval(
+                approvalRequest(id: "approval-\(index)", command: oversizedCommand)))
+        }
+        XCTAssertFalse(folder.addApproval(
+            approvalRequest(id: "overflow", command: "must be rejected")))
+        XCTAssertEqual(folder.pendingApprovalIDs.count, AgentTranscriptFolder.maximumPendingApprovals)
+        guard case .approval(let first) = folder.items.first else {
+            return XCTFail("expected bounded approval")
+        }
+        XCTAssertEqual(
+            (first.workspace?.count ?? 0) + (first.command?.count ?? 0),
+            AgentTranscriptFolder.maximumToolCharacters)
+        XCTAssertTrue(first.isTruncated)
+
+        var freshFolder = AgentTranscriptFolder()
+        XCTAssertFalse(freshFolder.addApproval(approvalRequest(
+            id: String(
+                repeating: "i",
+                count: AgentTranscriptFolder.maximumApprovalIdentifierCharacters + 1),
+            command: "oversized id")))
+    }
+
     private func approvalRequest(id: String, command: String) -> AgentApprovalRequest {
         AgentApprovalRequest(
             id: id,

--- a/LokalBotTests/AppIdentifiersTests.swift
+++ b/LokalBotTests/AppIdentifiersTests.swift
@@ -3,6 +3,21 @@ import XCTest
 @testable import LokalBot
 
 final class AppIdentifiersTests: XCTestCase {
+    func testHostedUnitTestsUseProcessScopedLibraryAndDefaults() throws {
+        guard UITestRuntime.isUnitTesting else {
+            throw XCTSkip("requires the hosted LokalBot unit-test process")
+        }
+        let processID = String(ProcessInfo.processInfo.processIdentifier)
+        let storageRoot = try XCTUnwrap(UITestRuntime.storageRoot)
+        let defaultsSuite = try XCTUnwrap(UITestRuntime.defaultsSuiteName)
+
+        XCTAssertTrue(storageRoot.hasSuffix("lokalbot-unit-tests-\(processID)"))
+        XCTAssertEqual(defaultsSuite, "me.dotenv.LokalBot.unit-tests.\(processID)")
+        XCTAssertNotEqual(
+            URL(fileURLWithPath: storageRoot).standardizedFileURL,
+            AppDirectories.applicationSupport.standardizedFileURL)
+    }
+
     @MainActor
     func testUITestRuntimeFlagDoesNotSelectDeterministicEncryptionKeyInProductionTarget() throws {
         guard ProcessInfo.processInfo.environment["LOKALBOT_RUN_KEYCHAIN_TESTS"] == "1" else {

--- a/LokalBotTests/AskLibraryContextTests.swift
+++ b/LokalBotTests/AskLibraryContextTests.swift
@@ -103,6 +103,37 @@ final class AskLibraryContextTests: XCTestCase {
         XCTAssertEqual(summaryLines.count, 1)
     }
 
+    func testTitleSummaryMatchesAreRankedCappedAndBudgeted() throws {
+        try MeetingFixture.write((0..<10).map { index in
+            .init(
+                title: "Portfolio review",
+                startedAt: Date(timeIntervalSince1970: 1_790_000_000 + Double(index)),
+                summary: "rank-\(index)\n" + String(
+                    repeating: "🧠",
+                    count: AskLibraryContext.maxSummaryUTF8Bytes),
+                transcriptLines: [])
+        }, under: root)
+
+        let meetings = try SessionLookup.loadAllMeetings()
+        let bundle = AskLibraryContext.build(
+            question: "Please summarize the Portfolio review meeting",
+            meetings: meetings)
+
+        XCTAssertLessThanOrEqual(
+            bundle.contextText.utf8.count,
+            AskLibraryContext.maxContextUTF8Bytes)
+        XCTAssertEqual(
+            bundle.contextText.components(separatedBy: "— full summary").count - 1,
+            AskLibraryContext.maxTitleSummaryMatches)
+        XCTAssertTrue(bundle.contextText.contains("[… summary truncated …]"))
+        for index in 6..<10 {
+            XCTAssertTrue(bundle.contextText.contains("rank-\(index)"), "missing newest rank \(index)")
+        }
+        for index in 0..<6 {
+            XCTAssertFalse(bundle.contextText.contains("rank-\(index)"), "included older rank \(index)")
+        }
+    }
+
     func testEmptyBundleWhenNothingMatches() throws {
         let meetings = try SessionLookup.loadAllMeetings()
         let bundle = AskLibraryContext.build(

--- a/LokalBotTests/AskLibraryEngineTests.swift
+++ b/LokalBotTests/AskLibraryEngineTests.swift
@@ -153,4 +153,10 @@ final class AskLibraryEngineTests: XCTestCase {
             "\(URLSessionLlamaChatClient.mainServerBaseURL)/v1",
             "\(LlamaServer.shared.baseURL)")
     }
+
+    func testLocalServerAuthenticationAddsBearerHeader() throws {
+        var request = URLRequest(url: try XCTUnwrap(URL(string: "http://127.0.0.1:17872/health")))
+        LocalLlamaServerAuthentication.apply(to: &request, token: "secret")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer secret")
+    }
 }

--- a/LokalBotTests/AudioSourceMonitorTests.swift
+++ b/LokalBotTests/AudioSourceMonitorTests.swift
@@ -84,6 +84,27 @@ final class AudioSourceMonitorTests: XCTestCase {
                        helper.id)
     }
 
+    func testZoomCaptureMapsCptHostAndPrefersItOverTheHost() {
+        let host = AudioProcess(id: 100,
+                                name: "zoom.us",
+                                bundleID: "us.zoom.xos",
+                                objectID: AudioObjectID(100),
+                                isRunningOutput: true)
+        let helper = AudioProcess(id: 200,
+                                  name: "CptHost",
+                                  bundleID: "us.zoom.CptHost",
+                                  objectID: AudioObjectID(200),
+                                  isRunningOutput: true)
+        let app = MeetingDetector.DetectedApp(
+            name: "Zoom", bundleID: "us.zoom.xos", pid: host.id)
+
+        XCTAssertTrue(MeetingDetector.audioBundleID(
+            "us.zoom.CptHost", belongsTo: "us.zoom.xos"))
+        XCTAssertEqual(
+            MeetingDetector.bestOutputAudioProcess(for: app, in: [host, helper])?.id,
+            helper.id)
+    }
+
     /// Unknown apps stay eligible so a genuinely-new meeting tool is still
     /// surfaced via the monitor's fallback candidate path.
     func testUnknownAppIsNotExcluded() {

--- a/LokalBotTests/ChatAgentTests.swift
+++ b/LokalBotTests/ChatAgentTests.swift
@@ -384,7 +384,7 @@ final class ChatAgentTests: XCTestCase {
         try FileManager.default.createDirectory(at: storage.rootURL, withIntermediateDirectories: true)
         let activityStore = ActivityStore(databaseURL: sqlite)
 
-        activityStore.insertScreenshot(
+        try activityStore.insertScreenshot(
             ts: Date(), path: "/tmp/x.heic.enc", app: "Safari",
             windowTitle: "Stripe invoicing docs", trigger: "app_switch",
             ocr: "How to issue a refund for an invoice in the Stripe dashboard")

--- a/LokalBotTests/CotypingFocusPollBackoffTests.swift
+++ b/LokalBotTests/CotypingFocusPollBackoffTests.swift
@@ -2,6 +2,24 @@ import AppKit
 import XCTest
 @testable import LokalBot
 
+private final class LockedTestBox<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: Value
+
+    init(_ value: Value) {
+        storage = value
+    }
+
+    var value: Value {
+        lock.withLock { storage }
+    }
+
+    @discardableResult
+    func update<Result>(_ body: (inout Value) -> Result) -> Result {
+        lock.withLock { body(&storage) }
+    }
+}
+
 // MARK: - Focus poll backoff
 
 final class CotypingFocusPollBackoffTests: XCTestCase {
@@ -92,5 +110,153 @@ final class CotypingFocusPollBackoffTests: XCTestCase {
             lastCaptureUptimeNanoseconds: 10_000_000,
             nowUptimeNanoseconds: 25_000_000,
             maxAgeMilliseconds: 30))
+    }
+
+    func testSnapshotExecutorEnforcesOneWholeCaptureDeadline() async {
+        let executor = CotypingAXSnapshotExecutor(deadlineMilliseconds: 25) { _ in
+            Thread.sleep(forTimeInterval: 0.2)
+            return .none
+        }
+        let started = ContinuousClock.now
+
+        let result = await executor.capture()
+
+        let elapsed = started.duration(to: .now)
+        XCTAssertTrue(result.timedOut)
+        XCTAssertNil(result.focus)
+        XCTAssertLessThan(elapsed, .milliseconds(150),
+                          "many bounded AX reads must not multiply into a UI-visible stall")
+    }
+
+    func testSnapshotExecutorRunsResolverOffMainThread() async {
+        let resolverWasOnMainThread = LockedTestBox(true)
+        let executor = CotypingAXSnapshotExecutor { _ in
+            resolverWasOnMainThread.update { $0 = Thread.isMainThread }
+            return .none
+        }
+
+        let result = await executor.capture()
+
+        XCTAssertFalse(result.timedOut)
+        XCTAssertFalse(resolverWasOnMainThread.value)
+    }
+
+    func testSnapshotExecutorSharesCompatibleInFlightCapture() async {
+        let resolverStarted = expectation(description: "resolver started")
+        let releaseResolver = DispatchSemaphore(value: 0)
+        let invocationCount = LockedTestBox(0)
+        let executor = CotypingAXSnapshotExecutor(deadlineMilliseconds: 1_000) { _ in
+            invocationCount.update { $0 += 1 }
+            resolverStarted.fulfill()
+            releaseResolver.wait()
+            return .none
+        }
+
+        let first = Task { await executor.capture(options: [.surface, .style]) }
+        await fulfillment(of: [resolverStarted], timeout: 1)
+        let second = Task { await executor.capture(options: [.style]) }
+        try? await Task.sleep(for: .milliseconds(20))
+        releaseResolver.signal()
+
+        let firstResult = await first.value
+        let secondResult = await second.value
+        XCTAssertFalse(firstResult.timedOut)
+        XCTAssertFalse(secondResult.timedOut)
+        XCTAssertEqual(invocationCount.value, 1)
+    }
+
+    func testSnapshotExecutorKeepsOnlyOneMergedPendingBatch() async {
+        let firstResolverStarted = expectation(description: "first resolver started")
+        let releaseFirstResolver = DispatchSemaphore(value: 0)
+        let capturedOptions = LockedTestBox<[CotypingAXCaptureOptions]>([])
+        let executor = CotypingAXSnapshotExecutor(deadlineMilliseconds: 1_000) { options in
+            let invocation = capturedOptions.update { values in
+                values.append(options)
+                return values.count
+            }
+            if invocation == 1 {
+                firstResolverStarted.fulfill()
+                releaseFirstResolver.wait()
+            }
+            return .none
+        }
+
+        let active = Task { await executor.capture() }
+        await fulfillment(of: [firstResolverStarted], timeout: 1)
+        let pendingSurface = Task { await executor.capture(options: [.surface]) }
+        let pendingURL = Task { await executor.capture(options: [.url]) }
+        let pendingStyle = Task { await executor.capture(options: [.style]) }
+        try? await Task.sleep(for: .milliseconds(30))
+        releaseFirstResolver.signal()
+
+        _ = await active.value
+        _ = await pendingSurface.value
+        _ = await pendingURL.value
+        _ = await pendingStyle.value
+        let finalOptions = capturedOptions.value
+        XCTAssertEqual(finalOptions.count, 2,
+                       "polls that arrive during a capture must collapse into one pending snapshot")
+        XCTAssertEqual(finalOptions.last, [.surface, .url, .style])
+    }
+
+    func testSlowSurfaceCaptureDoesNotHoldCacheLockAndSameKeyCoalesces() async {
+        let store = CotypingSurfaceCaptureSingleFlight()
+        let seeded = CotypingSurfaceCapture(
+            windowTitle: "Seeded",
+            fieldPlaceholder: nil,
+            urlString: nil)
+        _ = store.capture(forKey: "seed") { seeded }
+
+        let slowCaptureStarted = expectation(description: "slow surface capture started")
+        let releaseSlowCapture = DispatchSemaphore(value: 0)
+        let slowResolveCount = LockedTestBox(0)
+        let slowValue = CotypingSurfaceCapture(
+            windowTitle: "Resolved",
+            fieldPlaceholder: "Message",
+            urlString: nil)
+        let resolveSlow: @Sendable () -> CotypingSurfaceCapture = {
+            slowResolveCount.update { $0 += 1 }
+            slowCaptureStarted.fulfill()
+            releaseSlowCapture.wait()
+            return slowValue
+        }
+
+        let first = Task.detached {
+            store.capture(forKey: "slow") { resolveSlow() }
+        }
+        await fulfillment(of: [slowCaptureStarted], timeout: 1)
+
+        let readStarted = ContinuousClock.now
+        let cachedWhileResolving = store.cachedValue(forKey: "seed")
+        let readElapsed = readStarted.duration(to: .now)
+        XCTAssertEqual(cachedWhileResolving, seeded)
+        XCTAssertLessThan(readElapsed, .milliseconds(50),
+                          "a slow AX resolver must run outside the cache lock")
+
+        let second = Task.detached {
+            store.capture(forKey: "slow") { resolveSlow() }
+        }
+        try? await Task.sleep(for: .milliseconds(20))
+        releaseSlowCapture.signal()
+
+        let firstValue = await first.value
+        let secondValue = await second.value
+        XCTAssertEqual(firstValue, slowValue)
+        XCTAssertEqual(secondValue, slowValue)
+        XCTAssertEqual(slowResolveCount.value, 1,
+                       "same-key callers must share the active surface capture")
+    }
+
+    @MainActor
+    func testValidationCaptureFailsClosedOnTimeout() async {
+        let executor = CotypingAXSnapshotExecutor(deadlineMilliseconds: 20) { _ in
+            Thread.sleep(forTimeInterval: 0.15)
+            return .none
+        }
+        let tracker = CotypingFocusTracker(snapshotExecutor: executor)
+
+        let focus = await tracker.refreshForValidation()
+
+        XCTAssertNil(focus)
     }
 }

--- a/LokalBotTests/DownloadIntegrityTests.swift
+++ b/LokalBotTests/DownloadIntegrityTests.swift
@@ -38,3 +38,81 @@ final class DownloadIntegrityTests: XCTestCase {
         XCTAssertFalse(acceptsTruncatedFile)
     }
 }
+
+@MainActor
+final class ModelDownloadManagerCancellationTests: XCTestCase {
+    func testCancellationDuringSHA256VerificationRemovesOnlyCompletedStagedFile() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("model-cancel-\(UUID().uuidString)", isDirectory: true)
+        let storage = StorageManager(rootURL: root)
+        let sourceURL = try XCTUnwrap(URL(string: "https://example.com/model.gguf"))
+        let staged = root.appendingPathComponent("completed-whole-file.tmp")
+        let stashDirectory = root.appendingPathComponent("models/.partial", isDirectory: true)
+        let resumable = ParallelRangeDownloader.stashPartialURL(
+            for: sourceURL, in: stashDirectory)
+        let resumeManifest = stashDirectory.appendingPathComponent(
+            "LokalBot-resume-\(ParallelRangeDownloader.stashName(for: sourceURL)).json")
+        let gate = SHA256VerificationGate()
+        let expectedDigest = String(repeating: "a", count: 64)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let manager = ModelDownloadManager(
+            stagedDownloader: { _, _, passedStashDirectory, _ in
+                XCTAssertEqual(passedStashDirectory, stashDirectory)
+                try FileManager.default.createDirectory(
+                    at: stashDirectory, withIntermediateDirectories: true)
+                try Data("whole file".utf8).write(to: staged)
+                try Data("resumable bytes".utf8).write(to: resumable)
+                try Data("resume manifest".utf8).write(to: resumeManifest)
+                return staged
+            },
+            sha256Digest: { _ in
+                await gate.suspendUntilReleased()
+                return expectedDigest
+            })
+
+        manager.download(
+            url: sourceURL.absoluteString,
+            fileName: "model.gguf",
+            id: "cancel-during-verification",
+            expectedSHA256: expectedDigest,
+            storage: storage)
+        await gate.waitUntilSuspended()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: staged.path))
+
+        manager.cancel(id: "cancel-during-verification")
+        await gate.release()
+        for _ in 0..<100 where FileManager.default.fileExists(atPath: staged.path) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: staged.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: resumable.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: resumeManifest.path))
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: root.appendingPathComponent("models/model.gguf").path))
+    }
+}
+
+private actor SHA256VerificationGate {
+    private var suspended = false
+    private var suspensionWaiter: CheckedContinuation<Void, Never>?
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+
+    func suspendUntilReleased() async {
+        suspended = true
+        suspensionWaiter?.resume()
+        suspensionWaiter = nil
+        await withCheckedContinuation { releaseWaiter = $0 }
+    }
+
+    func waitUntilSuspended() async {
+        guard !suspended else { return }
+        await withCheckedContinuation { suspensionWaiter = $0 }
+    }
+
+    func release() {
+        releaseWaiter?.resume()
+        releaseWaiter = nil
+    }
+}

--- a/LokalBotTests/DownloadIntegrityTests.swift
+++ b/LokalBotTests/DownloadIntegrityTests.swift
@@ -41,6 +41,57 @@ final class DownloadIntegrityTests: XCTestCase {
 
 @MainActor
 final class ModelDownloadManagerCancellationTests: XCTestCase {
+    func testLegacyCatalogModelIsHashedAndMarkedBeforeReuse() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("legacy-model-\(UUID().uuidString)", isDirectory: true)
+        let storage = StorageManager(rootURL: root)
+        let models = root.appendingPathComponent("models", isDirectory: true)
+        try FileManager.default.createDirectory(at: models, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let data = Data("GGUFlegacy-model".utf8)
+        let model = models.appendingPathComponent("legacy.gguf")
+        try data.write(to: model)
+        let digest = try SHA256Verifier.hexDigest(of: model)
+        let entry = ModelCatalog.Entry(
+            id: "legacy", displayName: "Legacy", fileName: model.lastPathComponent,
+            url: "https://example.com/legacy.gguf", sha256: digest,
+            sizeBytes: Int64(data.count), sizeGB: Double(data.count) / 1_000_000_000,
+            blurb: "", disablesThinking: false)
+
+        let resolved = await ModelDownloadManager().verifiedExistingURL(entry, storage: storage)
+
+        XCTAssertEqual(resolved, model)
+        XCTAssertEqual(
+            try String(contentsOf: model.appendingPathExtension("sha256"), encoding: .utf8),
+            digest)
+    }
+
+    func testMismatchedLegacyCatalogModelIsRemoved() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("corrupt-model-\(UUID().uuidString)", isDirectory: true)
+        let storage = StorageManager(rootURL: root)
+        let models = root.appendingPathComponent("models", isDirectory: true)
+        try FileManager.default.createDirectory(at: models, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let model = models.appendingPathComponent("corrupt.gguf")
+        try Data("GGUFbad!".utf8).write(to: model)
+        let expectedFile = root.appendingPathComponent("expected.gguf")
+        try Data("GGUFgood".utf8).write(to: expectedFile)
+        let expectedDigest = try SHA256Verifier.hexDigest(of: expectedFile)
+        let entry = ModelCatalog.Entry(
+            id: "corrupt", displayName: "Corrupt", fileName: model.lastPathComponent,
+            url: "https://example.com/corrupt.gguf", sha256: expectedDigest,
+            sizeBytes: 8, sizeGB: 0.000_000_008,
+            blurb: "", disablesThinking: false)
+
+        let resolved = await ModelDownloadManager().verifiedExistingURL(entry, storage: storage)
+
+        XCTAssertNil(resolved)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: model.path))
+    }
+
     func testCancellationDuringSHA256VerificationRemovesOnlyCompletedStagedFile() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("model-cancel-\(UUID().uuidString)", isDirectory: true)

--- a/LokalBotTests/EmbeddingModelPreparationCoordinatorTests.swift
+++ b/LokalBotTests/EmbeddingModelPreparationCoordinatorTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import LokalBot
+
+final class EmbeddingPreparationTests: XCTestCase {
+    private actor OperationGate {
+        private(set) var invocationCount = 0
+        private var started = false
+        private var released = false
+        private var startWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func run(result: URL) async throws -> URL {
+            invocationCount += 1
+            started = true
+            let waitingForStart = startWaiters
+            startWaiters.removeAll()
+            for waiter in waitingForStart { waiter.resume() }
+            if !released {
+                await withCheckedContinuation { releaseWaiters.append($0) }
+            }
+            try Task.checkCancellation()
+            return result
+        }
+
+        func waitUntilStarted() async {
+            if started { return }
+            await withCheckedContinuation { startWaiters.append($0) }
+        }
+
+        func release() {
+            released = true
+            let waiting = releaseWaiters
+            releaseWaiters.removeAll()
+            for waiter in waiting { waiter.resume() }
+        }
+    }
+
+    func testConcurrentWaitersSharePreparationAndCancelIndependently() async throws {
+        let coordinator = EmbeddingModelPreparationCoordinator()
+        let gate = OperationGate()
+        let key = "/tmp/embedding-model.gguf"
+        let expected = URL(fileURLWithPath: key)
+
+        let first = Task {
+            try await coordinator.prepare(key: key) {
+                try await gate.run(result: expected)
+            }
+        }
+        await gate.waitUntilStarted()
+        first.cancel()
+        do {
+            _ = try await first.value
+            XCTFail("the canceled waiter should return without canceling shared work")
+        } catch is CancellationError {
+            // expected
+        }
+        let waitersAfterCancellation = await coordinator.waiterCount(for: key)
+        XCTAssertEqual(waitersAfterCancellation, 0)
+
+        let second = Task {
+            try await coordinator.prepare(key: key) {
+                return URL(fileURLWithPath: "/tmp/unexpected.gguf")
+            }
+        }
+        while await coordinator.waiterCount(for: key) < 1 {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        let countWhileSecondWaits = await gate.invocationCount
+        XCTAssertEqual(countWhileSecondWaits, 1)
+
+        await gate.release()
+        let secondValue = try await second.value
+        XCTAssertEqual(secondValue, expected)
+        let finalCount = await gate.invocationCount
+        XCTAssertEqual(finalCount, 1)
+    }
+}

--- a/LokalBotTests/FileLibraryToolProviderTests.swift
+++ b/LokalBotTests/FileLibraryToolProviderTests.swift
@@ -99,6 +99,12 @@ final class FileLibraryToolProviderTests: XCTestCase {
             arguments: ["limit": 1])
         XCTAssertTrue(capped.text.contains("Cache planning"))
         XCTAssertFalse(capped.text.contains("Old sync"))
+
+        for invalid: JSONValue in [0, -1, .number(1.5), 1_001] {
+            let result = await provider.call(
+                name: "list_meetings", arguments: ["limit": invalid])
+            XCTAssertTrue(result.text.hasPrefix("[invalid_arguments]"), "\(invalid)")
+        }
     }
 
     func testGetMeetingLatestReturnsMarkdownSections() async {
@@ -141,6 +147,10 @@ final class FileLibraryToolProviderTests: XCTestCase {
 
         let missing = await provider.call(name: "search_meetings", arguments: nil)
         XCTAssertTrue(missing.text.hasPrefix("[invalid_arguments]"))
+
+        let badLimit = await provider.call(
+            name: "search_meetings", arguments: ["query": "redis", "limit": -4])
+        XCTAssertTrue(badLimit.text.hasPrefix("[invalid_arguments]"))
     }
 
     func testAskLibraryDelegatesToClosure() async {

--- a/LokalBotTests/Helpers/FakeTransport.swift
+++ b/LokalBotTests/Helpers/FakeTransport.swift
@@ -6,6 +6,7 @@ import Foundation
 final class FakeTransport: PiLineTransport, @unchecked Sendable {
     private(set) var sent: [String] = []
     private let lock = NSLock()
+    private var sendFailure: Error?
     let incoming: AsyncStream<String>
     private let continuation: AsyncStream<String>.Continuation
 
@@ -16,10 +17,18 @@ final class FakeTransport: PiLineTransport, @unchecked Sendable {
     }
 
     func send(line: String) async throws {
-        lock.lock(); sent.append(line); lock.unlock()
+        let failure = lock.withLock {
+            let failure = sendFailure
+            if failure == nil { sent.append(line) }
+            return failure
+        }
+        if let failure { throw failure }
     }
 
     func inject(_ line: String) { continuation.yield(line) }
     func close() { continuation.finish() }
-    var sentLines: [String] { lock.lock(); defer { lock.unlock() }; return sent }
+    func failFutureSends(_ error: Error = URLError(.cannotConnectToHost)) {
+        lock.withLock { sendFailure = error }
+    }
+    var sentLines: [String] { lock.withLock { sent } }
 }

--- a/LokalBotTests/HuggingFaceAPIClientTests.swift
+++ b/LokalBotTests/HuggingFaceAPIClientTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import XCTest
+@testable import LokalBot
+
+final class HuggingFaceAPIClientTests: XCTestCase {
+    override func tearDown() {
+        HuggingFaceURLProtocolStub.reset()
+        super.tearDown()
+    }
+
+    func testFilesRequestsBlobMetadataAndDecodesLFSChecksum() async throws {
+        let checksum = String(repeating: "a", count: 64)
+        HuggingFaceURLProtocolStub.responseData = Data(
+            """
+            {
+              "sha": "0123456789abcdef",
+              "siblings": [
+                {
+                  "rfilename": "models/example-Q4_K_M.gguf",
+                  "lfs": { "sha256": "\(checksum)", "size": 123456 }
+                },
+                { "rfilename": "README.md" }
+              ]
+            }
+            """.utf8)
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [HuggingFaceURLProtocolStub.self]
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+
+        let files = try await HuggingFaceAPIClient(session: session)
+            .files(modelID: "owner/repository")
+
+        let request = try XCTUnwrap(HuggingFaceURLProtocolStub.lastRequest)
+        let components = try XCTUnwrap(
+            URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false))
+        XCTAssertEqual(components.path, "/api/models/owner/repository")
+        XCTAssertEqual(
+            components.queryItems?.first(where: { $0.name == "blobs" })?.value,
+            "true")
+
+        let file = try XCTUnwrap(files.first)
+        XCTAssertEqual(files.count, 1)
+        XCTAssertEqual(file.id, "models/example-Q4_K_M.gguf")
+        XCTAssertEqual(file.sizeBytes, 123456)
+        XCTAssertEqual(file.revision, "0123456789abcdef")
+        XCTAssertEqual(file.sha256, checksum)
+        XCTAssertTrue(file.downloadURL.absoluteString.contains("/0123456789abcdef/"))
+    }
+}
+
+private final class HuggingFaceURLProtocolStub: URLProtocol {
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var storedResponseData = Data()
+    nonisolated(unsafe) private static var storedLastRequest: URLRequest?
+
+    static var responseData: Data {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return storedResponseData
+        }
+        set {
+            lock.lock()
+            storedResponseData = newValue
+            lock.unlock()
+        }
+    }
+
+    static var lastRequest: URLRequest? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedLastRequest
+    }
+
+    static func reset() {
+        lock.lock()
+        storedResponseData = Data()
+        storedLastRequest = nil
+        lock.unlock()
+    }
+
+    override static func canInit(with request: URLRequest) -> Bool { true }
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let data: Data
+        Self.lock.lock()
+        Self.storedLastRequest = request
+        data = Self.storedResponseData
+        Self.lock.unlock()
+
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: 200,
+                  httpVersion: "HTTP/1.1",
+                  headerFields: ["Content-Type": "application/json"]) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/LokalBotTests/IndexPersistenceTests.swift
+++ b/LokalBotTests/IndexPersistenceTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SQLite3
 @testable import LokalBot
 
 @MainActor
@@ -39,6 +40,36 @@ final class IndexPersistenceTests: XCTestCase {
 
         XCTAssertTrue(committed)
         XCTAssertEqual(database.firstDouble("SELECT COUNT(*) FROM values_table"), 3)
+    }
+
+    func testCheckedQueriesDistinguishEmptyResultsFromSQLiteFailures() throws {
+        let database = try XCTUnwrap(SQLiteDatabase(
+            url: root.appendingPathComponent("checked-errors.sqlite")))
+        try database.execute("CREATE TABLE values_table (value INTEGER NOT NULL)")
+
+        let empty: [Int64] = try database.queryChecked(
+            "SELECT value FROM values_table") { sqlite3_column_int64($0, 0) }
+        XCTAssertEqual(empty, [])
+
+        let failingQuery: () throws -> [Int64] = {
+            try database.queryChecked("SELECT value FROM table_that_does_not_exist") {
+                sqlite3_column_int64($0, 0)
+            }
+        }
+        XCTAssertThrowsError(try failingQuery())
+        XCTAssertNotNil(database.lastError)
+    }
+
+    func testDatabaseConnectionsEnableWALAndBusyTimeout() throws {
+        let database = try XCTUnwrap(SQLiteDatabase(
+            url: root.appendingPathComponent("connection-policy.sqlite")))
+        let journalModes: [String] = try database.queryChecked("PRAGMA journal_mode") {
+            String(cString: sqlite3_column_text($0, 0))
+        }
+        let timeout = try database.firstDoubleChecked("PRAGMA busy_timeout")
+
+        XCTAssertEqual(journalModes, ["wal"])
+        XCTAssertEqual(timeout, 5_000)
     }
 
     func testSearchIndexBackfillsLegacyRowMappingAndRemovesOnlyTargetMeeting() throws {
@@ -154,6 +185,204 @@ final class IndexPersistenceTests: XCTestCase {
         XCTAssertEqual(database.firstDouble(
             "SELECT COUNT(*) FROM search_document_rows WHERE meeting_id = ?1",
             bind: [meeting.id.uuidString]), 2)
+    }
+
+    func testDeletedMeetingTombstonePreventsLateSearchReindex() throws {
+        let storage = StorageManager(
+            rootURL: root.appendingPathComponent("deleted-library", isDirectory: true))
+        let meeting = Meeting(
+            id: UUID(),
+            title: "Deleted meeting",
+            appName: "Tests",
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            endedAt: Date(timeIntervalSince1970: 1_700_000_100),
+            relativePath: "meetings/deleted",
+            hasSystemTrack: false)
+        let folder = meeting.folderURL(in: storage)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let transcriptURL = folder.appendingPathComponent("transcript.json")
+        try writeTranscript(text: "originalneedle", to: transcriptURL,
+                            modificationDate: Date(timeIntervalSince1970: 1_700_000_200))
+
+        let databaseURL = storage.rootURL.appendingPathComponent("lokalbotv3.sqlite")
+        let index = SearchIndex(databaseURL: databaseURL)
+        index.reindex(meeting, storage: storage)
+        XCTAssertEqual(index.search("originalneedle").map(\.meetingID), [meeting.id])
+
+        XCTAssertTrue(index.remove(meeting.id))
+        try writeTranscript(text: "latenotification", to: transcriptURL,
+                            modificationDate: Date(timeIntervalSince1970: 1_700_000_300))
+        index.reindex(meeting, storage: storage)
+
+        let database = try XCTUnwrap(SQLiteDatabase(url: databaseURL))
+        XCTAssertTrue(database.hasRow(
+            "SELECT 1 FROM deleted_meetings WHERE meeting_id = ?1",
+            bind: [meeting.id.uuidString]))
+        XCTAssertTrue(index.search("originalneedle").isEmpty)
+        XCTAssertTrue(index.search("latenotification").isEmpty)
+        XCTAssertFalse(database.hasRow(
+            "SELECT 1 FROM indexed_meetings WHERE meeting_id = ?1",
+            bind: [meeting.id.uuidString]))
+    }
+
+    func testOlderSearchSnapshotCannotOverwriteNewerIndependentCommit() throws {
+        let storage = StorageManager(
+            rootURL: root.appendingPathComponent("freshness-library", isDirectory: true))
+        let meeting = Meeting(
+            id: UUID(),
+            title: "Freshness race",
+            appName: "Tests",
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            endedAt: Date(timeIntervalSince1970: 1_700_000_100),
+            relativePath: "meetings/freshness",
+            hasSystemTrack: false)
+        let folder = meeting.folderURL(in: storage)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let transcriptURL = folder.appendingPathComponent("transcript.json")
+        try writeTranscript(text: "stalesnapshotneedle", to: transcriptURL,
+                            modificationDate: Date(timeIntervalSince1970: 1_700_000_200))
+
+        let databaseURL = storage.rootURL.appendingPathComponent("lokalbotv3.sqlite")
+        let olderWorker = SearchIndex(databaseURL: databaseURL)
+        var injectionError: Error?
+        olderWorker.reindex(meeting, storage: storage) {
+            do {
+                try self.writeTranscript(
+                    text: "freshsnapshotneedle", to: transcriptURL,
+                    modificationDate: Date(timeIntervalSince1970: 1_700_000_300))
+                SearchIndex(databaseURL: databaseURL).reindex(meeting, storage: storage)
+            } catch {
+                injectionError = error
+            }
+        }
+
+        XCTAssertNil(injectionError)
+        XCTAssertTrue(olderWorker.search("stalesnapshotneedle").isEmpty)
+        XCTAssertEqual(olderWorker.search("freshsnapshotneedle").map(\.meetingID), [meeting.id])
+        let database = try XCTUnwrap(SQLiteDatabase(url: databaseURL))
+        XCTAssertEqual(database.firstDouble(
+            "SELECT source_mtime FROM indexed_meetings WHERE meeting_id = ?1",
+            bind: [meeting.id.uuidString]), 1_700_000_300)
+    }
+
+    func testFailedCleanupKeepsTombstoneVisibleAndStartupReconcilesStaleRows() throws {
+        let storage = StorageManager(
+            rootURL: root.appendingPathComponent("cleanup-library", isDirectory: true))
+        let removed = Meeting(
+            id: UUID(), title: "Removed", appName: "Tests",
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            endedAt: Date(timeIntervalSince1970: 1_700_000_100),
+            relativePath: "meetings/removed", hasSystemTrack: false)
+        let retained = Meeting(
+            id: UUID(), title: "Retained", appName: "Tests",
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            endedAt: Date(timeIntervalSince1970: 1_700_000_100),
+            relativePath: "meetings/retained", hasSystemTrack: false)
+        for (meeting, text) in [(removed, "ghostneedle removed"),
+                                (retained, "ghostneedle retained")] {
+            let folder = meeting.folderURL(in: storage)
+            try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+            try writeTranscript(
+                text: text, to: folder.appendingPathComponent("transcript.json"),
+                modificationDate: Date(timeIntervalSince1970: 1_700_000_200))
+        }
+
+        let databaseURL = storage.rootURL.appendingPathComponent("lokalbotv3.sqlite")
+        let index = SearchIndex(databaseURL: databaseURL)
+        index.reindex(removed, storage: storage)
+        index.reindex(retained, storage: storage)
+        let database = try XCTUnwrap(SQLiteDatabase(url: databaseURL))
+        XCTAssertTrue(database.exec("""
+            CREATE TRIGGER fail_removed_search_cleanup
+            BEFORE DELETE ON search_document_rows
+            WHEN OLD.meeting_id = '\(removed.id.uuidString)'
+            BEGIN
+                SELECT RAISE(ABORT, 'forced cleanup failure');
+            END;
+            """))
+
+        XCTAssertFalse(index.remove(removed.id))
+        XCTAssertTrue(database.hasRow(
+            "SELECT 1 FROM deleted_meetings WHERE meeting_id = ?1",
+            bind: [removed.id.uuidString]))
+        XCTAssertGreaterThan(database.firstDouble(
+            "SELECT COUNT(*) FROM docs WHERE meeting_id = ?1",
+            bind: [removed.id.uuidString]) ?? 0, 0)
+        XCTAssertEqual(index.search("ghostneedle").map(\.meetingID), [retained.id])
+
+        let embedding = EmbeddingIndex(databaseURL: databaseURL, storage: storage)
+        XCTAssertTrue(database.run(
+            "INSERT INTO embeddings (meeting_id, start, text, vec) VALUES (?1, ?2, ?3, ?4)",
+            bind: [removed.id.uuidString, 12.0, "stale semantic row",
+                   Data(repeating: 1, count: MemoryLayout<Float>.stride)]))
+        XCTAssertTrue(database.run("""
+            INSERT INTO embedded_meetings (meeting_id, source_mtime, model_id)
+            VALUES (?1, ?2, ?3)
+            """, bind: [removed.id.uuidString, 1_700_000_200.0,
+                         "qwen3-embedding-0.6b-q8"]))
+        XCTAssertFalse(embedding.hasEmbeddings)
+        let staleHit = EmbeddingIndex.Hit(
+            meetingID: removed.id, start: 12, text: "stale semantic row", score: 0.9)
+        XCTAssertTrue(embedding.liveHits(from: [staleHit]).isEmpty)
+
+        XCTAssertTrue(database.exec("DROP TRIGGER fail_removed_search_cleanup"))
+        _ = SearchIndex(databaseURL: databaseURL)
+        _ = EmbeddingIndex(databaseURL: databaseURL, storage: storage)
+
+        XCTAssertEqual(database.firstDouble(
+            "SELECT COUNT(*) FROM docs WHERE meeting_id = ?1",
+            bind: [removed.id.uuidString]), 0)
+        XCTAssertEqual(database.firstDouble(
+            "SELECT COUNT(*) FROM search_document_rows WHERE meeting_id = ?1",
+            bind: [removed.id.uuidString]), 0)
+        XCTAssertEqual(database.firstDouble(
+            "SELECT COUNT(*) FROM embeddings WHERE meeting_id = ?1",
+            bind: [removed.id.uuidString]), 0)
+        XCTAssertEqual(index.search("ghostneedle").map(\.meetingID), [retained.id])
+    }
+
+    func testSearchWorkQueueCoalescesPendingMeetingAndStopRejectsNewWork() async throws {
+        let storage = StorageManager(
+            rootURL: root.appendingPathComponent("queue-library", isDirectory: true))
+        var older = Meeting(
+            id: UUID(), title: "oldcoalescedtitle", appName: "Tests",
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            endedAt: Date(timeIntervalSince1970: 1_700_000_100),
+            relativePath: "meetings/coalesced", hasSystemTrack: false)
+        let folder = older.folderURL(in: storage)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        try writeTranscript(
+            text: "queue transcript", to: folder.appendingPathComponent("transcript.json"),
+            modificationDate: Date(timeIntervalSince1970: 1_700_000_200))
+        var newer = older
+        newer.title = "newcoalescedtitle"
+
+        let databaseURL = storage.rootURL.appendingPathComponent("lokalbotv3.sqlite")
+        let queue = SearchIndexWorkQueue(databaseURL: databaseURL, rootURL: storage.rootURL)
+        await queue.enqueue([older, newer])
+        await queue.waitUntilIdle()
+
+        let index = SearchIndex(databaseURL: databaseURL)
+        XCTAssertTrue(index.search("oldcoalescedtitle").isEmpty)
+        XCTAssertEqual(index.search("newcoalescedtitle").map(\.meetingID), [newer.id])
+
+        older = Meeting(
+            id: UUID(), title: "stoppedqueuetitle", appName: "Tests",
+            startedAt: Date(timeIntervalSince1970: 1_700_000_300),
+            endedAt: Date(timeIntervalSince1970: 1_700_000_400),
+            relativePath: "meetings/stopped", hasSystemTrack: false)
+        let stoppedFolder = older.folderURL(in: storage)
+        try FileManager.default.createDirectory(
+            at: stoppedFolder, withIntermediateDirectories: true)
+        try writeTranscript(
+            text: "must not be indexed",
+            to: stoppedFolder.appendingPathComponent("transcript.json"),
+            modificationDate: Date(timeIntervalSince1970: 1_700_000_500))
+
+        await queue.stop()
+        await queue.enqueue(older)
+        await queue.waitUntilIdle()
+        XCTAssertTrue(index.search("stoppedqueuetitle").isEmpty)
     }
 
     func testEmbeddingIndexAddsMeetingIDIndexWithoutDiscardingCurrentRows() throws {

--- a/LokalBotTests/InferenceBrokerTests.swift
+++ b/LokalBotTests/InferenceBrokerTests.swift
@@ -24,6 +24,34 @@ final class InferenceBrokerTests: XCTestCase {
 
     private struct TestFailure: Error {}
 
+    private actor EnsureGate {
+        private var started = false
+        private var released = false
+        private var startWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func wait() async {
+            started = true
+            let waiters = startWaiters
+            startWaiters.removeAll()
+            for waiter in waiters { waiter.resume() }
+            guard !released else { return }
+            await withCheckedContinuation { releaseWaiters.append($0) }
+        }
+
+        func waitUntilStarted() async {
+            if started { return }
+            await withCheckedContinuation { startWaiters.append($0) }
+        }
+
+        func release() {
+            released = true
+            let waiters = releaseWaiters
+            releaseWaiters.removeAll()
+            for waiter in waiters { waiter.resume() }
+        }
+    }
+
     private let modelURL = FileManager.default.temporaryDirectory
         .appendingPathComponent("broker-test-fake.gguf")
 
@@ -126,6 +154,49 @@ final class InferenceBrokerTests: XCTestCase {
         XCTAssertEqual(active, 0)
     }
 
+    func testCancellationAfterEnsureSchedulesIdleStop() async throws {
+        let recorder = HookRecorder()
+        let sink = SinkRecorder()
+        let gate = EnsureGate()
+        var hooks: [InferenceRole: InferenceBroker.RuntimeHooks] = [:]
+        for role in InferenceRole.allCases {
+            hooks[role] = InferenceBroker.RuntimeHooks(
+                ensure: { _ in
+                    await recorder.record("ensure:\(role.rawValue)")
+                    if role == .mainLLM { await gate.wait() }
+                },
+                stop: { await recorder.record("stop:\(role.rawValue)") })
+        }
+        let broker = InferenceBroker(
+            hooks: hooks,
+            lingerSeconds: [.mainLLM: 0.01],
+            leaseStateSink: { pinned, descriptions in
+                sink.record(pinned: pinned, descriptions: descriptions)
+            })
+
+        let acquiring = Task {
+            try await broker.lease(
+                .mainLLM, model: modelURL, priority: .interactive, purpose: "cancelled")
+        }
+        await gate.waitUntilStarted()
+        acquiring.cancel()
+        await gate.release()
+        do {
+            _ = try await acquiring.value
+            XCTFail("expected cancellation after ensure returned")
+        } catch is CancellationError {
+            // expected
+        }
+
+        let active = await broker.activeLeaseCount(.mainLLM)
+        XCTAssertEqual(active, 0)
+        XCTAssertEqual(sink.lastPinned, [])
+        let stopped = await waitUntil {
+            await recorder.count(of: "stop:mainLLM") == 1
+        }
+        XCTAssertTrue(stopped)
+    }
+
     func testWithLeaseReleasesOnSuccessAndOnThrow() async throws {
         let recorder = HookRecorder()
         let sink = SinkRecorder()
@@ -188,5 +259,58 @@ final class InferenceBrokerTests: XCTestCase {
         await broker.release(summary)
         let stopped = await waitUntil { await recorder.count(of: "stop:mainLLM") == 1 }
         XCTAssertTrue(stopped)
+    }
+
+    func testConflictingModelWaitsUntilExistingLeaseReleases() async throws {
+        let recorder = HookRecorder()
+        let sink = SinkRecorder()
+        let broker = makeBroker(recorder: recorder, sink: sink)
+        let firstURL = modelURL.appendingPathExtension("first")
+        let secondURL = modelURL.appendingPathExtension("second")
+        let first = try await broker.lease(
+            .mainLLM, model: firstURL, priority: .background, purpose: "first")
+
+        let waiting = Task {
+            try await broker.lease(
+                .mainLLM, model: secondURL, priority: .interactive, purpose: "second")
+        }
+        try await Task.sleep(for: .milliseconds(100))
+        let ensuresBeforeRelease = await recorder.count(of: "ensure:mainLLM")
+        let pathBeforeRelease = await broker.activeModelPath(.mainLLM)
+        XCTAssertEqual(ensuresBeforeRelease, 1)
+        XCTAssertEqual(pathBeforeRelease,
+                       firstURL.standardizedFileURL.resolvingSymlinksInPath().path)
+
+        await broker.release(first)
+        let second = try await waiting.value
+        let ensuresAfterRelease = await recorder.count(of: "ensure:mainLLM")
+        XCTAssertEqual(ensuresAfterRelease, 2)
+        XCTAssertEqual(second.modelPath,
+                       secondURL.standardizedFileURL.resolvingSymlinksInPath().path)
+        await broker.release(second)
+    }
+
+    func testCancellingConflictingWaiterDoesNotAcquireOrLeak() async throws {
+        let recorder = HookRecorder()
+        let sink = SinkRecorder()
+        let broker = makeBroker(recorder: recorder, sink: sink)
+        let first = try await broker.lease(
+            .mainLLM, model: modelURL, priority: .background, purpose: "first")
+        let waiting = Task {
+            try await broker.lease(
+                .mainLLM, model: modelURL.appendingPathExtension("other"),
+                priority: .interactive, purpose: "cancelled")
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        waiting.cancel()
+        do {
+            _ = try await waiting.value
+            XCTFail("expected cancellation")
+        } catch is CancellationError {
+            // expected
+        }
+        let active = await broker.activeLeaseCount(.mainLLM)
+        XCTAssertEqual(active, 1)
+        await broker.release(first)
     }
 }

--- a/LokalBotTests/InferenceEndpointPolicyTests.swift
+++ b/LokalBotTests/InferenceEndpointPolicyTests.swift
@@ -3,10 +3,25 @@ import XCTest
 
 final class InferenceEndpointPolicyTests: XCTestCase {
     func testLoopbackEndpointsDoNotRequireApproval() throws {
-        for value in ["http://localhost:11434", "http://127.0.0.1:8080", "http://[::1]:9000"] {
+        for value in [
+            "http://localhost:11434",
+            "http://127.0.0.1:8080",
+            "http://127.42.10.8:8080",
+            "http://[::1]:9000",
+        ] {
             let url = try XCTUnwrap(URL(string: value))
             XCTAssertTrue(InferenceEndpointPolicy.isAllowed(url, approvedOrigins: []), value)
             XCTAssertNoThrow(try InferenceEndpointPolicy.validate(url, approvedOrigins: []), value)
+        }
+    }
+
+    func testHostnameBeginningWith127IsNotMistakenForLoopback() throws {
+        let url = try XCTUnwrap(URL(string: "http://127.attacker.example/v1"))
+        XCTAssertFalse(InferenceEndpointPolicy.isLoopback(url))
+        XCTAssertThrowsError(try InferenceEndpointPolicy.validate(url, approvedOrigins: [])) {
+            XCTAssertEqual(
+                $0 as? InferenceEndpointPolicy.PolicyError,
+                .insecureRemoteEndpoint("http://127.attacker.example"))
         }
     }
 
@@ -18,6 +33,19 @@ final class InferenceEndpointPolicyTests: XCTestCase {
             url, approvedOrigins: ["https://inference.example.com"]))
         XCTAssertThrowsError(try InferenceEndpointPolicy.validate(
             url, approvedOrigins: ["https://other.example.com"]))
+    }
+
+    func testRemoteHTTPIsRejectedEvenWhenApproved() throws {
+        let url = try XCTUnwrap(URL(string: "http://inference.example.com/v1"))
+
+        XCTAssertFalse(InferenceEndpointPolicy.isAllowed(
+            url, approvedOrigins: ["http://inference.example.com"]))
+        XCTAssertThrowsError(try InferenceEndpointPolicy.validate(
+            url, approvedOrigins: ["http://inference.example.com"])) { error in
+            XCTAssertEqual(
+                error as? InferenceEndpointPolicy.PolicyError,
+                .insecureRemoteEndpoint("http://inference.example.com"))
+        }
     }
 
     func testOnlyHTTPInferenceURLsAreAccepted() throws {

--- a/LokalBotTests/LeasedTextEngineTests.swift
+++ b/LokalBotTests/LeasedTextEngineTests.swift
@@ -4,6 +4,19 @@ import XCTest
 @MainActor
 final class LeasedTextEngineTests: XCTestCase {
 
+    private final class PartialRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [String] = []
+
+        func append(_ partial: String) {
+            lock.withLock { storage.append(partial) }
+        }
+
+        var values: [String] {
+            lock.withLock { storage }
+        }
+    }
+
     private actor CallRecorder {
         private(set) var events: [String] = []
         func record(_ event: String) { events.append(event) }
@@ -99,10 +112,10 @@ final class LeasedTextEngineTests: XCTestCase {
         let completion = try await engine.complete(completionRequest)
         XCTAssertEqual(completion, "complete:the-prompt")
 
-        var partials: [String] = []
+        let partials = PartialRecorder()
         let streamed = try await engine.completeStreaming(completionRequest) { partials.append($0) }
         XCTAssertEqual(streamed, "stream:the-prompt")
-        XCTAssertEqual(partials, ["partial-chunk"])
+        XCTAssertEqual(partials.values, ["partial-chunk"])
 
         let ensures = await recorder.count(of: "ensure:mainLLM")
         XCTAssertEqual(ensures, 3)

--- a/LokalBotTests/LiveMeetingTranscriberTests.swift
+++ b/LokalBotTests/LiveMeetingTranscriberTests.swift
@@ -110,7 +110,7 @@ final class LiveMeetingTranscriberTests: XCTestCase {
         addBurst(to: &samples, at: 1.0, duration: 0.4, sampleRate: sampleRate)
         addBurst(to: &samples, at: 3.0, duration: 0.4, sampleRate: sampleRate)
         let source = root.appendingPathComponent(AudioPreviewTee.micFileName)
-        try writeCAF(samples: samples, to: source, sampleRate: sampleRate)
+        let liveWriter = try writeCAF(samples: samples, to: source, sampleRate: sampleRate)
         let worker = LiveMeetingAudioPreparationWorker(storageRoot: root)
 
         let result = try await worker.prepareNextChunk(source: source, processedFrames: 0)
@@ -126,6 +126,8 @@ final class LiveMeetingTranscriberTests: XCTestCase {
         XCTAssertEqual(
             contents.first?.resolvingSymlinksInPath(),
             prepared.url.resolvingSymlinksInPath())
+        XCTAssertGreaterThan(liveWriter.length, 0,
+                             "suffix preparation must work while the append-only writer remains open")
 
         let reader = try AVAudioFile(forReading: prepared.url)
         XCTAssertEqual(reader.length, prepared.processedFrames)

--- a/LokalBotTests/MCPProtocolTests.swift
+++ b/LokalBotTests/MCPProtocolTests.swift
@@ -69,4 +69,20 @@ final class MCPProtocolTests: XCTestCase {
         let encoded = try JSONEncoder().encode(value)
         XCTAssertEqual(String(decoding: encoded, as: UTF8.self), #"{"limit":12}"#)
     }
+
+    func testFractionalAndOutOfRangeNumbersAreNotIntegers() {
+        XCTAssertNil(JSONValue.number(1.5).intValue)
+        XCTAssertNil(JSONValue.number(.infinity).intValue)
+        XCTAssertNil(JSONValue.number(Double.greatestFiniteMagnitude).intValue)
+    }
+
+    func testOversizedRequestIsRejectedBeforeJSONDecoding() {
+        let line = #"{"jsonrpc":"2.0","id":1,"method":"ping","padding":""#
+            + String(repeating: "x", count: 1_048_576) + #""}"#
+        guard case .failure(let code, let message, _) = MCPRequest.parse(line) else {
+            return XCTFail("expected an oversized request failure")
+        }
+        XCTAssertEqual(code, -32600)
+        XCTAssertTrue(message.contains("1 MiB"))
+    }
 }

--- a/LokalBotTests/MCPServerIntegrationTests.swift
+++ b/LokalBotTests/MCPServerIntegrationTests.swift
@@ -86,4 +86,67 @@ final class MCPServerIntegrationTests: XCTestCase {
         XCTAssertTrue(output[1].contains("[access_disabled]"))
         XCTAssertTrue(output[1].contains(#""isError":true"#))
     }
+
+    func testUnterminatedOversizedRecordIsRejectedBeforeEOF() throws {
+        let process = Process()
+        process.executableURL = helperURL
+        process.arguments = ["mcp"]
+        var environment = ProcessInfo.processInfo.environment
+        environment["LOKALBOT_STORAGE_ROOT"] = root.path
+        process.environment = environment
+
+        let stdin = Pipe()
+        let stdout = Pipe()
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        process.standardError = FileHandle.nullDevice
+        let responseArrived = expectation(description: "oversized record rejected before EOF")
+        let output = MCPOutputProbe(expectation: responseArrived)
+        stdout.fileHandleForReading.readabilityHandler = { handle in
+            output.append(handle.availableData)
+        }
+
+        try process.run()
+        let payload = Data(
+            repeating: 0x78,
+            count: MCPRequest.maximumLineBytes + 2 * 1_024 * 1_024)
+        stdin.fileHandleForWriting.write(payload)
+
+        let result = XCTWaiter.wait(for: [responseArrived], timeout: 2)
+        stdin.fileHandleForWriting.closeFile()
+        process.waitUntilExit()
+        stdout.fileHandleForReading.readabilityHandler = nil
+
+        XCTAssertEqual(result, .completed)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertTrue(output.text.contains(#""code":-32600"#))
+        XCTAssertTrue(output.text.contains("1 MiB"))
+    }
+}
+
+private final class MCPOutputProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let expectation: XCTestExpectation
+    private var data = Data()
+    private var fulfilled = false
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func append(_ chunk: Data) {
+        guard !chunk.isEmpty else { return }
+        lock.lock()
+        data.append(chunk)
+        let shouldFulfill = !fulfilled && data.contains(0x0A)
+        if shouldFulfill { fulfilled = true }
+        lock.unlock()
+        if shouldFulfill { expectation.fulfill() }
+    }
+
+    var text: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return String(decoding: data, as: UTF8.self)
+    }
 }

--- a/LokalBotTests/ModelResidencyTests.swift
+++ b/LokalBotTests/ModelResidencyTests.swift
@@ -198,4 +198,24 @@ final class ModelResidencyTests: XCTestCase {
         residency.unregister(id: "server", ifGenerationMatches: replacementGeneration)
         XCTAssertTrue(residency.residents.isEmpty)
     }
+
+    func testPendingLoadsReserveBudgetUntilCancelledOrRegistered() async {
+        let residency = ModelResidency(budgetBytes: 10)
+        final class Unloads { var ids: [String] = [] }
+        let unloads = Unloads()
+        residency.register(id: "old", label: "Old", bytes: 4) {
+            unloads.ids.append("old")
+        }
+
+        let first = await residency.willLoad(id: "first", bytes: 4)
+        XCTAssertEqual(residency.pendingLoadBytes, 4)
+        _ = await residency.willLoad(id: "second", bytes: 4)
+        XCTAssertEqual(unloads.ids, ["old"], "the second admission must count the first pending load")
+        XCTAssertEqual(residency.pendingLoadBytes, 8)
+
+        residency.cancelLoad(first)
+        XCTAssertEqual(residency.pendingLoadBytes, 4)
+        residency.register(id: "second", label: "Second", bytes: 4, unload: {})
+        XCTAssertEqual(residency.pendingLoadBytes, 0)
+    }
 }

--- a/LokalBotTests/PiJSONLFrameSplitterTests.swift
+++ b/LokalBotTests/PiJSONLFrameSplitterTests.swift
@@ -47,4 +47,18 @@ final class PiJSONLFrameSplitterTests: XCTestCase {
         var splitter = PiJSONLFrameSplitter()
         XCTAssertEqual(splitter.append(Data("\n\n{\"a\":1}\n\n".utf8)), ["{\"a\":1}"])
     }
+
+    func testOversizedFrameIsDiscardedAndFollowingFrameSurvives() {
+        var splitter = PiJSONLFrameSplitter(maximumFrameBytes: 1_024)
+        let oversized = String(repeating: "x", count: 2_000)
+        let lines = splitter.append(Data((oversized + "\n{\"ok\":true}\n").utf8))
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertTrue(lines[0].contains("safety limit"))
+        XCTAssertEqual(lines[1], #"{"ok":true}"#)
+    }
+
+    func testInvalidUTF8BecomesProtocolErrorFrame() {
+        var splitter = PiJSONLFrameSplitter()
+        XCTAssertTrue(splitter.append(Data([0xFF, 0x0A])).first?.contains("valid UTF-8") == true)
+    }
 }

--- a/LokalBotTests/PiLaunchPlannerTests.swift
+++ b/LokalBotTests/PiLaunchPlannerTests.swift
@@ -12,6 +12,7 @@ final class PiLaunchPlannerTests: XCTestCase {
     private func makePlan(apiKey: String? = nil,
                           skill: URL? = URL(fileURLWithPath: "/app/Resources/pi/lokalbot-cli-skill"),
                           helpers: URL? = URL(fileURLWithPath: "/app/Contents/Helpers"),
+                          capability: String? = nil,
                           continuePrevious: Bool = false) -> PiLaunchPlan {
         PiLaunchPlanner.plan(
             bun: URL(fileURLWithPath: "/rt/bun/bun"),
@@ -23,6 +24,7 @@ final class PiLaunchPlannerTests: XCTestCase {
             endpoint: AgentLLMEndpoint(baseURL: endpoint.baseURL, model: endpoint.model,
                                        contextTokens: endpoint.contextTokens, apiKey: apiKey),
             helpersDirectory: helpers,
+            agentAccessCapability: capability,
             continuePreviousSession: continuePrevious,
             baseEnvironment: ["PATH": "/usr/bin:/bin", "HOME": "/Users/x"])
     }
@@ -36,6 +38,7 @@ final class PiLaunchPlannerTests: XCTestCase {
             "--no-extensions", "-e", "/app/Resources/pi/lokalbot-extension",
             "--no-skills", "--skill", "/app/Resources/pi/lokalbot-cli-skill",
             "--no-prompt-templates",
+            "--no-context-files",
             "--no-approve",
             "--session-dir", "/store/agent/sessions",
             "--offline",
@@ -71,9 +74,15 @@ final class PiLaunchPlannerTests: XCTestCase {
         XCTAssertEqual(plan.workingDirectory.path, "/work")
     }
 
-    func testNoContextFilesFlagIsDeliberatelyAbsent() {
-        XCTAssertFalse(makePlan().arguments.contains("--no-context-files"),
-                       "project AGENTS.md/CLAUDE.md context stays enabled by design")
+    func testAutomaticContextDiscoveryIsDisabledToPreventParentDirectoryReads() {
+        XCTAssertTrue(makePlan().arguments.contains("--no-context-files"))
+    }
+
+    func testScopedAgentCapabilityIsPassedOnlyWhenIssued() {
+        XCTAssertNil(makePlan().environment[AgentAccessGate.capabilityEnvironmentKey])
+        XCTAssertEqual(
+            makePlan(capability: "id.secret").environment[AgentAccessGate.capabilityEnvironmentKey],
+            "id.secret")
     }
 
     func testContinueFlagOnlyAppearsForResumeLaunches() {

--- a/LokalBotTests/PiProcessTests.swift
+++ b/LokalBotTests/PiProcessTests.swift
@@ -73,4 +73,36 @@ final class PiProcessTests: XCTestCase {
         let running = await process.isRunning
         XCTAssertFalse(running)
     }
+
+    func testStopIsBoundedWhenChildDoesNotDrainStdin() async throws {
+        // `sleep` deliberately never reads stdin. A full-size RPC frame fills
+        // the pipe and keeps the dedicated writer busy until stop closes it.
+        let process = PiProcess(plan: plan("/bin/sh", ["-c", "exec /bin/sleep 3"]))
+        try await process.start()
+        let line = String(
+            repeating: "x",
+            count: PiJSONLFrameSplitter.defaultMaximumFrameBytes - 1)
+        let blockedSend = Task { try await process.send(line: line) }
+        try await Task.sleep(for: .milliseconds(100))
+
+        do {
+            try await process.send(line: "second command")
+            XCTFail("expected bounded input backpressure")
+        } catch PiProcessError.inputBackpressure {
+            // expected: the first frame owns the bounded 4 MiB budget
+        }
+
+        let started = ContinuousClock.now
+        await process.stop()
+        XCTAssertLessThan(started.duration(to: .now), .seconds(1))
+
+        do {
+            try await blockedSend.value
+            XCTFail("expected the blocked write to fail when stdin closes")
+        } catch PiProcessError.inputClosed {
+            // expected
+        } catch PiProcessError.inputWriteFailed {
+            // The kernel may report EPIPE before DispatchIO observes close.
+        }
+    }
 }

--- a/LokalBotTests/PiRPCClientTests.swift
+++ b/LokalBotTests/PiRPCClientTests.swift
@@ -64,4 +64,126 @@ final class PiRPCClientTests: XCTestCase {
         try await client.sendResponse(.uiConfirmResponse(requestID: "u1", confirmed: true))
         XCTAssertTrue(transport.sentLines.contains { $0.contains(#""id":"u1""#) && $0.contains(#""confirmed":true"#) })
     }
+
+    func testRequestTimesOutAndIgnoresLateResponse() async throws {
+        let transport = FakeTransport()
+        let client = PiRPCClient(transport: transport, requestTimeout: .milliseconds(40))
+        await client.run()
+        do {
+            _ = try await client.request(.getState(id: "timeout"))
+            XCTFail("expected timeout")
+        } catch PiRPCError.requestTimedOut(let id) {
+            XCTAssertEqual(id, "timeout")
+        }
+        transport.inject(#"{"type":"response","id":"timeout","command":"get_state","success":true}"#)
+    }
+
+    func testCancellationRemovesPendingRequest() async throws {
+        let transport = FakeTransport()
+        let client = PiRPCClient(transport: transport, requestTimeout: .seconds(10))
+        await client.run()
+        let task = Task { try await client.request(.getState(id: "cancelled")) }
+        try await Task.sleep(for: .milliseconds(30))
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("expected cancellation")
+        } catch is CancellationError {
+            // expected
+        }
+    }
+
+    func testMalformedFrameBecomesVisibleProtocolError() async {
+        let transport = FakeTransport()
+        let client = PiRPCClient(transport: transport)
+        await client.run()
+        var iterator = (await client.events).makeAsyncIterator()
+        transport.inject("not-json")
+        guard let event = await iterator.next(),
+              case .extensionError(let message) = event else {
+            return XCTFail("expected protocol error")
+        }
+        XCTAssertTrue(message.contains("malformed"))
+    }
+
+    func testTextDeltaOverflowDoesNotEvictApproval() async throws {
+        let transport = FakeTransport()
+        let client = PiRPCClient(
+            transport: transport,
+            requestTimeout: .seconds(1),
+            eventBufferCapacity: 1)
+        await client.run()
+
+        async let responseTask = client.request(.getState(id: "overflow-barrier"))
+        for _ in 0..<20 where !transport.sentLines.contains(where: { $0.contains("overflow-barrier") }) {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        XCTAssertTrue(transport.sentLines.contains { $0.contains("overflow-barrier") })
+
+        transport.inject(
+            #"{"type":"extension_ui_request","id":"approval-1","method":"confirm"}"#)
+        for _ in 0..<4 {
+            transport.inject(
+                #"{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"x"}}"#)
+        }
+        transport.inject(
+            #"{"type":"response","id":"overflow-barrier","command":"get_state","success":true}"#)
+        _ = try await responseTask
+
+        var iterator = (await client.events).makeAsyncIterator()
+        guard case .extensionUIRequest(let request) = await iterator.next() else {
+            return XCTFail("expected the buffered approval to survive text overflow")
+        }
+        XCTAssertEqual(request.id, "approval-1")
+
+        transport.inject(#"{"type":"agent_end"}"#)
+        let eventAfterOverflow = await iterator.next()
+        XCTAssertEqual(eventAfterOverflow, .agentEnd)
+        transport.close()
+        let streamEnd = await iterator.next()
+        XCTAssertNil(streamEnd)
+    }
+
+    func testApprovalOverflowFailsPendingRequestAndTerminatesStream() async throws {
+        let transport = FakeTransport()
+        let client = PiRPCClient(
+            transport: transport,
+            requestTimeout: .seconds(1),
+            eventBufferCapacity: 1)
+        await client.run()
+
+        let responseTask = Task { try await client.request(.getState(id: "structural-overflow")) }
+        for _ in 0..<20 where !transport.sentLines.contains(where: { $0.contains("structural-overflow") }) {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        XCTAssertTrue(transport.sentLines.contains { $0.contains("structural-overflow") })
+
+        transport.inject(#"{"type":"agent_start"}"#)
+        transport.inject(
+            #"{"type":"extension_ui_request","id":"approval-dropped","method":"confirm"}"#)
+
+        do {
+            _ = try await responseTask.value
+            XCTFail("expected structural event overflow")
+        } catch PiRPCError.eventBufferOverflow {
+            // Expected: the approval could not be queued, so the client failed closed.
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+
+        var iterator = (await client.events).makeAsyncIterator()
+        let bufferedEvent = await iterator.next()
+        XCTAssertEqual(bufferedEvent, .agentStart)
+        let streamEnd = await iterator.next()
+        XCTAssertNil(streamEnd)
+
+        do {
+            _ = try await client.request(.getState(id: "after-overflow"))
+            XCTFail("expected the client to remain terminal")
+        } catch PiRPCError.eventBufferOverflow {
+            // Expected: later callers observe the same deterministic failure.
+        } catch {
+            XCTFail("unexpected terminal error: \(error)")
+        }
+    }
 }

--- a/LokalBotTests/PipelineJobStoreTests.swift
+++ b/LokalBotTests/PipelineJobStoreTests.swift
@@ -109,4 +109,15 @@ final class PipelineJobStoreTests: XCTestCase {
 
         XCTAssertEqual(makeStore().pendingJobs().first?.meetingID, id)
     }
+
+    func testEnqueueReportsUnavailableDatabaseInsteadOfSilentlyDroppingJob() {
+        let missingParent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-\(UUID().uuidString)", isDirectory: true)
+        let store = PipelineJobStore(
+            databaseURL: missingParent.appendingPathComponent("test.sqlite"))
+
+        XCTAssertFalse(store.enqueue(
+            meetingID: UUID(), transcribe: true, summarize: true))
+        XCTAssertTrue(store.pendingJobs().isEmpty)
+    }
 }

--- a/LokalBotTests/ProcessingPipelineModelPreparationTests.swift
+++ b/LokalBotTests/ProcessingPipelineModelPreparationTests.swift
@@ -54,8 +54,9 @@ final class ProcessingPipelineModelPreparationTests: XCTestCase {
             storage: storage,
             settings: { settings },
             builtInModelPreparer: { entry, storage in
-                preparationCount += 1
                 let url = storage.rootURL.appendingPathComponent("models/\(entry.fileName)")
+                if ModelFileValidator.looksLikeGGUF(url) { return url }
+                preparationCount += 1
                 try FileManager.default.createDirectory(
                     at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
                 try Data("GGUF".utf8).write(to: url)

--- a/LokalBotTests/ProcessingPipelineModelPreparationTests.swift
+++ b/LokalBotTests/ProcessingPipelineModelPreparationTests.swift
@@ -3,6 +3,42 @@ import XCTest
 
 @MainActor
 final class ProcessingPipelineModelPreparationTests: XCTestCase {
+    private actor CancellationInsensitiveWork {
+        private var started = false
+        private var released = false
+        private var completed = false
+        private var cleanupReturned = false
+        private var startWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func run() async {
+            started = true
+            let waiters = startWaiters
+            startWaiters.removeAll()
+            for waiter in waiters { waiter.resume() }
+            if !released {
+                await withCheckedContinuation { releaseWaiters.append($0) }
+            }
+            completed = true
+        }
+
+        func waitUntilStarted() async {
+            if started { return }
+            await withCheckedContinuation { startWaiters.append($0) }
+        }
+
+        func release() {
+            released = true
+            let waiters = releaseWaiters
+            releaseWaiters.removeAll()
+            for waiter in waiters { waiter.resume() }
+        }
+
+        func isCompleted() -> Bool { completed }
+        func markCleanupReturned() { cleanupReturned = true }
+        func didCleanupReturn() -> Bool { cleanupReturned }
+    }
+
     func testFirstBuiltInSummaryPreparesMissingSelectedModel() async throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -33,5 +69,28 @@ final class ProcessingPipelineModelPreparationTests: XCTestCase {
                        "first use downloads once; later summaries reuse the validated model")
         let entry = try XCTUnwrap(ModelCatalog.entry(id: settings.builtInModelID))
         XCTAssertNotNil(ModelCatalog.localURL(for: entry, storage: storage))
+    }
+
+    func testCancelOutcomesWaitsForCancellationInsensitiveWork() async throws {
+        let work = CancellationInsensitiveWork()
+        let outcomesTask = Task { await work.run() }
+        await work.waitUntilStarted()
+
+        let cleanup = Task {
+            await ProcessingPipeline.cancelAndWaitForOutcomes(outcomesTask)
+            await work.markCleanupReturned()
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        let completedBeforeRelease = await work.isCompleted()
+        XCTAssertFalse(completedBeforeRelease)
+        let cleanupReturnedBeforeRelease = await work.didCleanupReturn()
+        XCTAssertFalse(cleanupReturnedBeforeRelease)
+
+        await work.release()
+        await cleanup.value
+        let completedAfterCleanup = await work.isCompleted()
+        XCTAssertTrue(completedAfterCleanup)
+        let cleanupReturnedAfterRelease = await work.didCleanupReturn()
+        XCTAssertTrue(cleanupReturnedAfterRelease)
     }
 }

--- a/LokalBotTests/RecordingNotifierTests.swift
+++ b/LokalBotTests/RecordingNotifierTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import LokalBot
+
+@MainActor
+final class RecordingPromptRegistryTests: XCTestCase {
+    func testInvalidationRemovesStaleRecordActionBeforeReplacement() {
+        var registry = RecordingPromptRegistry()
+        var recorded: [String] = []
+        let now = Date()
+
+        registry.insert(identifier: "old", expiresAt: now.addingTimeInterval(120)) {
+            recorded.append("old")
+        }
+        XCTAssertEqual(Set(registry.removeAll()), ["old"])
+
+        registry.insert(identifier: "current", expiresAt: now.addingTimeInterval(120)) {
+            recorded.append("current")
+        }
+        XCTAssertNil(registry.remove("old"))
+        registry.remove("current")?.record()
+
+        XCTAssertEqual(recorded, ["current"])
+    }
+
+    func testExpiredPromptIsRemovedWithoutInvalidatingCurrentPrompt() {
+        var registry = RecordingPromptRegistry()
+        var didRecordCurrent = false
+        let now = Date()
+
+        registry.insert(identifier: "expired", expiresAt: now.addingTimeInterval(-1)) {}
+        registry.insert(identifier: "current", expiresAt: now.addingTimeInterval(60)) {
+            didRecordCurrent = true
+        }
+
+        XCTAssertEqual(Set(registry.removeExpired(now: now)), ["expired"])
+        XCTAssertNil(registry.remove("expired"))
+        registry.remove("current")?.record()
+        XCTAssertTrue(didRecordCurrent)
+    }
+}

--- a/LokalBotTests/ReuseSubsystemsTests.swift
+++ b/LokalBotTests/ReuseSubsystemsTests.swift
@@ -5,6 +5,68 @@ import XCTest
 /// Everything here is deterministic and runs off the main actor.
 final class ReuseSubsystemsTests: XCTestCase {
 
+    private final class ResolverThreadProbe: @unchecked Sendable {
+        private let lock = NSLock()
+        private var resolverWasOnMainThread = true
+
+        func recordCurrentThread() {
+            lock.withLock {
+                resolverWasOnMainThread = Thread.isMainThread
+            }
+        }
+
+        var wasOnMainThread: Bool {
+            lock.withLock { resolverWasOnMainThread }
+        }
+    }
+
+    func testMicrophoneReconfigurationRetryPolicyIsFinite() {
+        let delays = (1...MicRecorder.maximumReconfigurationAttempts).compactMap {
+            MicRecorder.reconfigurationRetryDelay(forAttempt: $0)
+        }
+
+        XCTAssertEqual(delays, [1, 2, 3, 4])
+        XCTAssertNil(MicRecorder.reconfigurationRetryDelay(forAttempt: 0))
+        XCTAssertNil(MicRecorder.reconfigurationRetryDelay(
+            forAttempt: MicRecorder.maximumReconfigurationAttempts + 1))
+    }
+
+    func testAudioRecoverySilencePlannerRejectsTinyAndInvalidGaps() {
+        XCTAssertNil(AudioRecoverySilencePlanner.plan(forElapsed: -1))
+        XCTAssertNil(AudioRecoverySilencePlanner.plan(forElapsed: .nan))
+        XCTAssertNil(AudioRecoverySilencePlanner.plan(
+            forElapsed: AudioRecoverySilencePlanner.minimumDuration - 0.001))
+    }
+
+    func testAudioRecoverySilencePlannerPreservesOrdinaryMonotonicGap() {
+        XCTAssertEqual(
+            AudioRecoverySilencePlanner.plan(forElapsed: Duration.seconds(4)),
+            AudioRecoverySilencePlan(duration: 4, wasCapped: false))
+    }
+
+    func testAudioRecoverySilencePlannerCapsSleepSizedGap() {
+        XCTAssertEqual(
+            AudioRecoverySilencePlanner.plan(forElapsed: 3_600),
+            AudioRecoverySilencePlan(
+                duration: AudioRecoverySilencePlanner.maximumDuration,
+                wasCapped: true))
+    }
+
+    func testSystemAudioRetryBudgetIsFiniteAndResetsForNewTarget() {
+        var budget = SystemAudioSamePIDRetryBudget()
+
+        XCTAssertTrue(budget.canRetry)
+        budget.recordRetry()
+        budget.recordRetry()
+        budget.recordRetry()
+        XCTAssertEqual(budget.attempts, SystemAudioSamePIDRetryBudget.maximumAttempts)
+        XCTAssertFalse(budget.canRetry)
+
+        budget.reset()
+        XCTAssertEqual(budget.attempts, 0)
+        XCTAssertTrue(budget.canRetry)
+    }
+
     // MARK: - SettingsSearchRanker
 
     func testSearchEmptyQueryMatchesEverything() {
@@ -113,6 +175,79 @@ final class ReuseSubsystemsTests: XCTestCase {
                 previous: "We should ship the fix today",
                 incoming: "the fix today"),
             "We should ship the fix today")
+    }
+
+    func testDictationDeliveryTargetRejectsAnotherAppOrField() {
+        let target = DictationDeliveryTarget(
+            processID: 42,
+            bundleID: "com.example.Editor",
+            focusIdentityKey: "field-a")
+
+        XCTAssertTrue(target.matches(
+            processID: 42,
+            bundleID: "com.example.Editor",
+            focusIdentityKey: "field-a"))
+        XCTAssertFalse(target.matches(
+            processID: 43,
+            bundleID: "com.example.Chat",
+            focusIdentityKey: "field-a"))
+        XCTAssertFalse(target.matches(
+            processID: 42,
+            bundleID: "com.example.Editor",
+            focusIdentityKey: "field-b"))
+    }
+
+    func testDictationDeliveryTargetCanBindToAnAppWhenAXFieldIdentityIsUnavailable() {
+        let target = DictationDeliveryTarget(
+            processID: 42,
+            bundleID: "com.example.Editor",
+            focusIdentityKey: nil)
+
+        XCTAssertTrue(target.matches(
+            processID: 42,
+            bundleID: "com.example.Editor",
+            focusIdentityKey: nil))
+        XCTAssertFalse(target.matches(
+            processID: 7,
+            bundleID: "com.example.Editor",
+            focusIdentityKey: nil))
+    }
+
+    func testAppOnlyDictationTargetRejectsSameAppSecureFocus() {
+        let target = DictationDeliveryTarget(
+            processID: 42,
+            bundleID: "com.example.Editor",
+            focusIdentityKey: nil)
+        let secureFocus = DictationFocusSnapshot(
+            processID: 42,
+            bundleID: "com.example.Editor",
+            focusIdentityKey: "password-field",
+            isSecureOrBlocked: true)
+
+        XCTAssertFalse(target.matches(secureFocus))
+        XCTAssertNil(DictationDeliveryTarget.captured(from: secureFocus))
+    }
+
+    func testDictationFocusSnapshotExecutorFailsClosedWithoutBlockingMainActor() async {
+        let threadProbe = ResolverThreadProbe()
+        let executor = DictationFocusSnapshotExecutor(deadlineMilliseconds: 20) {
+            threadProbe.recordCurrentThread()
+            Thread.sleep(forTimeInterval: 0.15)
+            return DictationFocusSnapshot(
+                processID: 42,
+                bundleID: "com.example.Editor",
+                focusIdentityKey: "late-field",
+                isSecureOrBlocked: false)
+        }
+        let started = ContinuousClock.now
+
+        let capture = await executor.capture()
+
+        let elapsed = started.duration(to: .now)
+        XCTAssertTrue(capture.timedOut)
+        XCTAssertNil(capture.snapshot)
+        XCTAssertLessThan(elapsed, .milliseconds(100))
+        XCTAssertFalse(threadProbe.wasOnMainThread)
     }
 
     // MARK: - ModelFit
@@ -225,6 +360,26 @@ final class ReuseSubsystemsTests: XCTestCase {
             ParallelRangeDownloader.ResumeState.self, from: JSONEncoder().encode(state))
 
         XCTAssertEqual(decoded, state)
+    }
+
+    func testHuggingFaceFileUsesPinnedRevisionIntegrityHintAndNamespacedName() throws {
+        let digest = String(repeating: "a", count: 64)
+        let revision = String(repeating: "b", count: 40)
+        let file = HFFile(
+            id: "gguf/model.gguf",
+            modelID: "owner/repo",
+            sizeBytes: 123,
+            revision: revision,
+            sha256: digest)
+        XCTAssertTrue(file.downloadURL.path.contains("/resolve/\(revision)/"))
+        XCTAssertEqual(file.downloadURL.fragment, "sha256=\(digest)")
+        XCTAssertTrue(file.fileName.hasPrefix("hf-"))
+        XCTAssertTrue(file.fileName.hasSuffix("-model.gguf"))
+
+        let sameLeafElsewhere = HFFile(
+            id: "model.gguf", modelID: "other/repo", sizeBytes: 123,
+            revision: revision, sha256: digest)
+        XCTAssertNotEqual(file.fileName, sameLeafElsewhere.fileName)
     }
 
     // MARK: - DiskSpacePrecheck

--- a/LokalBotTests/ScreenshotProcessingWorkerTests.swift
+++ b/LokalBotTests/ScreenshotProcessingWorkerTests.swift
@@ -53,6 +53,43 @@ final class ScreenshotProcessingWorkerTests: XCTestCase {
         XCTAssertEqual(try Self.decrypt(manualURL, key: key), rawHEIC)
     }
 
+    func testDiscardedPersistenceAllowsIdenticalAutomaticCaptureToRetry() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ScreenshotProcessingWorkerTests-\(UUID().uuidString)",
+                                    isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let image = try XCTUnwrap(Self.onePixelImage())
+        let contentHash = Data(repeating: 0x44, count: 32)
+        let key = SymmetricKey(data: Data(repeating: 0x55, count: 32))
+        let worker = ScreenshotProcessingWorker(dependencies: ScreenshotProcessingDependencies(
+            contentHash: { _ in contentHash },
+            heicData: { _ in Data("image".utf8) },
+            recognizeText: { _ in "retry me" },
+            write: { data, url in
+                try FileManager.default.createDirectory(
+                    at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try data.write(to: url, options: .atomic)
+            }))
+
+        let first = try await worker.process(.init(
+            image: image, trigger: .interval, key: key,
+            fileURL: root.appendingPathComponent("first.heic.enc")))
+        guard case .stored(let storedHash, _) = first else {
+            return XCTFail("The initial capture should store")
+        }
+
+        // ScreenshotService calls this after its SQLite transaction fails and
+        // removes the encrypted file. The same screen must be allowed to retry.
+        await worker.discardStored(contentHash: storedHash)
+        let retry = try await worker.process(.init(
+            image: image, trigger: .interval, key: key,
+            fileURL: root.appendingPathComponent("retry.heic.enc")))
+
+        guard case .stored = retry else {
+            return XCTFail("A rolled-back capture must not poison dedup state")
+        }
+    }
+
     private static func onePixelImage() -> CGImage? {
         guard let context = CGContext(
             data: nil, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4,

--- a/LokalBotTests/StorageManagerTests.swift
+++ b/LokalBotTests/StorageManagerTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import LokalBot
+
+final class StorageManagerTests: XCTestCase {
+    func testDeleteMeetingRemovesDurableFolder() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StorageManagerTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let storage = StorageManager(rootURL: root)
+        let meeting = try storage.createMeetingFolder(title: "Delete me", appName: "Tests")
+        let folder = meeting.folderURL(in: storage)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: folder.path))
+
+        try storage.deleteMeeting(meeting)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: folder.path))
+    }
+
+    func testDeleteMeetingSurfacesFilesystemFailure() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StorageManagerTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let storage = StorageManager(rootURL: root)
+        let missing = Meeting(
+            id: UUID(), title: "Already gone", appName: "Tests",
+            startedAt: Date(), endedAt: Date(), relativePath: "meetings/missing")
+
+        XCTAssertThrowsError(try storage.deleteMeeting(missing))
+    }
+}

--- a/LokalBotTests/SystemAudioRecorderCopyTests.swift
+++ b/LokalBotTests/SystemAudioRecorderCopyTests.swift
@@ -185,6 +185,61 @@ final class SystemAudioRecorderCopyTests: XCTestCase {
         try assertLosslessMicrophoneCopy(interleaved: false)
     }
 
+    func testMicrophoneBufferPoolIsBoundedAndReusesReturnedBuffer() throws {
+        let format = makeFormat(interleaved: false)
+        let source = makeBuffer(format: format, frames: frameCount)
+        let pool = try XCTUnwrap(MicAudioBufferPool(
+            format: format,
+            bufferCount: 2,
+            frameCapacity: frameCount))
+
+        let first = try XCTUnwrap(pool.borrow(for: source))
+        let second = try XCTUnwrap(pool.borrow(for: source))
+        XCTAssertEqual(pool.availableBufferCount, 0)
+        XCTAssertNil(pool.borrow(for: source))
+
+        pool.returnBuffer(first)
+        XCTAssertEqual(pool.availableBufferCount, 1)
+        let reused = try XCTUnwrap(pool.borrow(for: source))
+        XCTAssertTrue(reused === first)
+        pool.returnBuffer(reused)
+        pool.returnBuffer(second)
+        XCTAssertEqual(pool.availableBufferCount, 2)
+    }
+
+    func testMicrophoneBufferPoolRejectsOversizedOrMismatchedInput() throws {
+        let format = makeFormat(interleaved: false)
+        let pool = try XCTUnwrap(MicAudioBufferPool(
+            format: format,
+            bufferCount: 1,
+            frameCapacity: frameCount))
+        let oversized = makeBuffer(format: format, frames: frameCount + 1)
+        let mismatchedFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 44_100,
+            channels: 2,
+            interleaved: false)!
+        let mismatched = makeBuffer(format: mismatchedFormat, frames: frameCount)
+
+        XCTAssertNil(pool.borrow(for: oversized))
+        XCTAssertNil(pool.borrow(for: mismatched))
+        XCTAssertEqual(pool.availableBufferCount, 1)
+    }
+
+    func testMicrophoneDropCounterNeverWaitsForContendedHealthLock() {
+        let lock = NSLock()
+        let counter = MicRealtimeDropCounter(lock: lock)
+        lock.lock()
+        XCTAssertFalse(counter.recordDrop())
+        lock.unlock()
+
+        XCTAssertEqual(counter.snapshot(), 0)
+        XCTAssertTrue(counter.recordDrop())
+        XCTAssertEqual(counter.snapshot(), 1)
+        counter.reset()
+        XCTAssertEqual(counter.snapshot(), 0)
+    }
+
     private func assertLosslessMicrophoneCopy(
         interleaved: Bool,
         file: StaticString = #filePath,
@@ -194,7 +249,12 @@ final class SystemAudioRecorderCopyTests: XCTestCase {
         let source = makeBuffer(format: format, frames: frameCount)
         fillDeterministicRamp(source)
 
-        let destination = try XCTUnwrap(MicRecorder.copyBuffer(source), file: file, line: line)
+        let pool = try XCTUnwrap(MicAudioBufferPool(
+            format: format,
+            bufferCount: 1,
+            frameCapacity: frameCount), file: file, line: line)
+        let destination = try XCTUnwrap(pool.borrow(for: source), file: file, line: line)
+        XCTAssertTrue(MicRecorder.copyBuffer(source, into: destination), file: file, line: line)
         XCTAssertEqual(destination.frameLength, source.frameLength, file: file, line: line)
         let sourceList = UnsafeMutableAudioBufferListPointer(
             UnsafeMutablePointer(mutating: source.audioBufferList))
@@ -206,6 +266,7 @@ final class SystemAudioRecorderCopyTests: XCTestCase {
             XCTAssertEqual(memcmp(src.mData!, dst.mData!, Int(src.mDataByteSize)), 0,
                            file: file, line: line)
         }
+        pool.returnBuffer(destination)
     }
 
     // MARK: - RMS

--- a/LokalBotTests/SystemResourceSamplerTests.swift
+++ b/LokalBotTests/SystemResourceSamplerTests.swift
@@ -79,6 +79,45 @@ final class SystemResourceSamplerTests: XCTestCase {
     }
 }
 
+final class MediaPlaybackProcessControllerTests: XCTestCase {
+    func testCancellationKillsTermIgnoringHelperWithinBound() async throws {
+        let process = Process()
+        let readyPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "trap '' TERM; echo ready; exec /bin/sleep 30"]
+        process.standardOutput = readyPipe
+        process.standardError = FileHandle.nullDevice
+
+        let controller = ScriptProcessController(terminationGraceSeconds: 0.05)
+        XCTAssertTrue(controller.attach(process))
+        try process.run()
+        controller.processDidStart(process)
+        defer {
+            controller.detach(process)
+            if process.isRunning { _ = kill(process.processIdentifier, SIGKILL) }
+            process.waitUntilExit()
+        }
+
+        let ready = readyPipe.fileHandleForReading.readData(ofLength: 6)
+        XCTAssertEqual(String(decoding: ready, as: UTF8.self), "ready\n")
+        XCTAssertNotNil(
+            SystemResourceSampler.processUsage(for: process.processIdentifier)?.startTime)
+
+        controller.cancel()
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while process.isRunning, clock.now < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+
+        XCTAssertFalse(process.isRunning, "TERM-ignoring helper exceeded the hard bound")
+        guard !process.isRunning else { return }
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationReason, .uncaughtSignal)
+        XCTAssertEqual(process.terminationStatus, SIGKILL)
+    }
+}
+
 @MainActor
 final class ResourceMonitorPresentationTests: XCTestCase {
     private typealias Usage = SystemResourceSampler.ProcessUsage

--- a/project.yml
+++ b/project.yml
@@ -138,8 +138,8 @@ targetTemplates:
       properties:
         CFBundleDisplayName: LokalBot
         CFBundleIconFile: AppIcon
-        CFBundleShortVersionString: "0.2.0"
-        CFBundleVersion: "7"
+        CFBundleShortVersionString: "0.2.1"
+        CFBundleVersion: "8"
         NSMicrophoneUsageDescription: >-
           LokalBot records your side of meetings from the microphone.
           Audio stays on this Mac; transcript text is sent off-device only if


### PR DESCRIPTION
## Summary

- enforce workspace and privacy boundaries for Agent Mode and CLI access, authenticate local inference, require approved HTTPS for remote endpoints, and pin and hash the complete Agent runtime and model artifacts
- make recording, dictation, audio recovery, subprocess I/O, and media handoff lifecycles race-safe, bounded, and off realtime and main threads
- serialize and coalesce model and index preparation, make search, deletion, and storage durable, and bound MCP, Ask, and Agent context memory and input
- harden screenshot focus and exclusion handling plus CI native-vendor caches

## Validation

- `xcodegen generate`
- `swiftlint lint --strict --quiet --config .swiftlint.yml`
- `bun build LokalBot/Resources/pi/lokalbot-extension/index.ts --target=bun --outfile=/tmp/lokalbot-extension.js`
- `xcodebuild -quiet -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' test CODE_SIGNING_ALLOWED=NO`
  - 1,136 tests: 1,125 passed, 0 failed, 11 environment or model-gated skips
- two independent Bun 1.3.14 frozen-lockfile installs produced the same pinned Pi runtime tree digest
