### PR TITLE
Prepare LokalBot 0.3.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,8 +141,11 @@ jobs:
         run: bash Scripts/fetch-llama.sh
 
       # Hardened Runtime must be ON for notarization; the project default is
-      # OFF (project.yml) so local dev builds stay fast. Overriding here is the
-      # release-time flip RELEASING.md step 2 documents.
+      # OFF (project.yml) so local dev builds stay fast. LokalBot's bundled
+      # llama.cpp/sherpa runtimes and speech stack are Apple Silicon only, so
+      # keep the archive arm64-only instead of asking SwiftPM to compile an
+      # unsupported x86_64 slice. Overriding here is the release-time setup
+      # RELEASING.md step 2 documents.
       - name: Archive (Release, Hardened Runtime ON)
         env:
           APPLE_TEAM_ID: ${{ secrets.NOTARY_APPLE_TEAM_ID }}
@@ -153,6 +156,7 @@ jobs:
             -configuration Release \
             -archivePath build/LokalBot.xcarchive \
             ENABLE_HARDENED_RUNTIME=YES \
+            ARCHS=arm64 \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
             CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Developer ID Application"

--- a/LokalBot/Dictation/DictationCoordinator.swift
+++ b/LokalBot/Dictation/DictationCoordinator.swift
@@ -79,12 +79,13 @@ final class DictationCoordinator: ObservableObject {
         onBusy: @escaping () -> Void,
         onError: @escaping (String) -> Void,
         focusSnapshotExecutor: DictationFocusSnapshotExecutor = .shared,
-        screenContextProvider: @escaping
-            (DictationScreenTarget, [String]) async -> DictationScreenContext? = {
-                target, excludedApps in
-                await DictationScreenContextCapture.shared.capture(
-                    target: target, excludedApps: excludedApps)
-            }
+        screenContextProvider: @escaping (
+            DictationScreenTarget,
+            [String]
+        ) async -> DictationScreenContext? = { target, excludedApps in
+            await DictationScreenContextCapture.shared.capture(
+                target: target, excludedApps: excludedApps)
+        }
     ) {
         self.storageRoot = storageRoot
         self.settingsProvider = settingsProvider

--- a/LokalBot/Info.plist
+++ b/LokalBot/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.1</string>
+	<string>0.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/LokalBot/Services/ScreenContextPrivacy.swift
+++ b/LokalBot/Services/ScreenContextPrivacy.swift
@@ -17,7 +17,11 @@ enum ScreenContextPrivacy {
         let replacement: String
 
         init(_ pattern: String, options: NSRegularExpression.Options = [], replacement: String) {
-            expression = try! NSRegularExpression(pattern: pattern, options: options)
+            do {
+                expression = try NSRegularExpression(pattern: pattern, options: options)
+            } catch {
+                preconditionFailure("Invalid built-in redaction pattern: \(pattern)")
+            }
             self.replacement = replacement
         }
     }

--- a/LokalBot/Services/ScreenshotService.swift
+++ b/LokalBot/Services/ScreenshotService.swift
@@ -159,7 +159,7 @@ struct ScreenshotCaptureLayout {
                 appName: window.appName, excludedApps: excludedApps)
             let excludedForPrivacy = excludePrivateWindows
                 && ScreenContextPrivacy.isPrivateWindow(title: window.title)
-            guard (excludedForApp || excludedForPrivacy),
+            guard excludedForApp || excludedForPrivacy,
                   intersectionArea(window.frame, selectedDisplay.frame) > 0 else { return nil }
             return window.id
         })

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -172,8 +172,13 @@ xcodebuild archive \
   -configuration Release \
   -archivePath build/LokalBot.xcarchive \
   -allowProvisioningUpdates \
-  ENABLE_HARDENED_RUNTIME=YES
+  ENABLE_HARDENED_RUNTIME=YES \
+  ARCHS=arm64
 ```
+
+The release is Apple Silicon only. Keep `ARCHS=arm64`: the bundled native
+runtimes and the speech package do not provide a supported `x86_64` release
+slice.
 
 Create `build/exportOptions.plist`:
 

--- a/project.yml
+++ b/project.yml
@@ -138,8 +138,8 @@ targetTemplates:
       properties:
         CFBundleDisplayName: LokalBot
         CFBundleIconFile: AppIcon
-        CFBundleShortVersionString: "0.2.1"
-        CFBundleVersion: "8"
+        CFBundleShortVersionString: "0.3.0"
+        CFBundleVersion: "9"
         NSMicrophoneUsageDescription: >-
           LokalBot records your side of meetings from the microphone.
           Audio stays on this Mac; transcript text is sent off-device only if


### PR DESCRIPTION
## What changed

- bump LokalBot to 0.3.0 (build 9)
- constrain notarized release archives to arm64, matching LokalBot's bundled native runtimes and Apple-Silicon-only distribution
- document the arm64 release requirement
- clear the five existing strict SwiftLint violations on master

## Why

The v0.2.1 release workflow failed while compiling `speech-swift` for x86_64 because Swift `Float16` is unavailable for that macOS slice. The app and its bundled llama.cpp and sherpa-onnx runtimes are already arm64-only, so the release archive should not request an unsupported x86_64 slice.

## Verification

- `xcodegen generate`
- `swiftlint lint --strict` (0 violations)
- focused `ScreenContextPrivacyTests` and `ScreenshotProcessingWorkerTests`
- clean Release build with Hardened Runtime enabled and `ARCHS=arm64` on Xcode 26.6
- release workflow YAML parse
- version/build alignment check for 0.3.0 (9)
- `git diff --check`
