### PR TITLE
Fix release DMG packaging on managed Python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,8 +214,10 @@ jobs:
 
       - name: Build styled DMG
         run: |
-          python3 -m pip install --quiet 'dmgbuild==1.6.7'
-          python3 Scripts/build_release_dmg.py \
+          dmgbuild_venv="$RUNNER_TEMP/dmgbuild-venv"
+          python3 -m venv "$dmgbuild_venv"
+          "$dmgbuild_venv/bin/python3" -m pip install --quiet 'dmgbuild==1.6.7'
+          "$dmgbuild_venv/bin/python3" Scripts/build_release_dmg.py \
             --app build/export/LokalBot.app \
             --output build/LokalBot.dmg
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -217,11 +217,15 @@ xcrun stapler staple build/export/LokalBot.app
 ### 4. Build the styled DMG
 
 ```sh
-pip3 install dmgbuild   # once per machine; pip3 install "dmgbuild[badge_icons]" for a badged volume icon
-python3 Scripts/build_release_dmg.py \
+python3 -m venv /tmp/LokalBot-dmg-venv
+/tmp/LokalBot-dmg-venv/bin/python3 -m pip install 'dmgbuild==1.6.7'
+/tmp/LokalBot-dmg-venv/bin/python3 Scripts/build_release_dmg.py \
   --app build/export/LokalBot.app \
   --output build/LokalBot.dmg
 ```
+
+Keep `dmgbuild` inside the venv. Homebrew Python is PEP 668-managed and rejects
+system-level `pip install` calls on current macOS runners.
 
 This stages `LokalBot.app` beside an `Applications` shortcut, locks the
 drag-to-install icon layout, and reuses the bundle's `AppIcon.icns` as the


### PR DESCRIPTION
## What changed

- install the pinned `dmgbuild` release inside a runner-local virtual environment
- invoke the DMG builder with that venv's Python interpreter
- update the manual release runbook to use the same PEP 668-safe path

## Why

The `v0.3.0` release successfully archived, exported, signed, notarized, and stapled the app, then failed before DMG construction because current Homebrew Python rejects system-level `pip install` with `externally-managed-environment`.

## Verification

- built a real 0.3.0 arm64 smoke DMG using a fresh Python venv and `dmgbuild==1.6.7`
- `hdiutil verify` accepted the generated DMG
- release workflow YAML parsed successfully
- `git diff --check`
