### PR TITLE
Fix remote Think label and OpenRouter day-digest 404

### DIFF
--- a/LokalBot/Engines/TextEngine.swift
+++ b/LokalBot/Engines/TextEngine.swift
@@ -69,9 +69,10 @@ enum ChatCompletionDialect: Equatable, Sendable {
     }
 }
 
-/// OpenRouter reasoning shape. Native uses `max_tokens`/`exclude` or
-/// `effort: none`. High-effort is the fallback for models that cannot
-/// disable thinking (for example GLM-5.3).
+/// OpenRouter request shape. Native uses `max_tokens`/`exclude` or
+/// `effort: none` plus strict `json_schema`. High-effort is the fallback
+/// for models that cannot disable thinking or honor structured outputs
+/// (for example GLM-5.3): `effort: high`, no schema, no require_parameters.
 enum OpenRouterReasoningCompatibility: Equatable, Sendable {
     case native
     case highEffort
@@ -541,7 +542,9 @@ struct OpenAICompatibleEngine: TextEngine {
                          schema: [String: Any]?,
                          options: TextGenerationOptions?,
                          openRouterReasoning: OpenRouterReasoningCompatibility = .native) throws -> URLRequest {
-        if chatDialect == .openAI || chatDialect == .openRouter, let schema,
+        if chatDialect == .openAI
+            || (chatDialect == .openRouter && openRouterReasoning != .highEffort),
+           let schema,
            let issue = OpenAIStrictSchemaValidator.validationIssue(in: schema) {
             throw TextEngineError.badResponse("invalid strict JSON schema: \(issue)")
         }
@@ -560,7 +563,7 @@ struct OpenAICompatibleEngine: TextEngine {
                 ["role": "user", "content": user],
             ],
         ]
-        if let schema {
+        if let schema, !(chatDialect == .openRouter && openRouterReasoning == .highEffort) {
             body["response_format"] = [
                 "type": "json_schema",
                 "json_schema": ["name": "response", "strict": true, "schema": schema],
@@ -575,7 +578,8 @@ struct OpenAICompatibleEngine: TextEngine {
             openRouterReasoning: openRouterReasoning)
         if chatDialect == .openRouter {
             var provider: [String: Any] = ["data_collection": "deny"]
-            if schema != nil || (options?.reasoningBudgetTokens ?? 0) > 0 {
+            if openRouterReasoning != .highEffort,
+               (schema != nil || (options?.reasoningBudgetTokens ?? 0) > 0) {
                 provider["require_parameters"] = true
             }
             body["provider"] = provider

--- a/LokalBot/Engines/TextEngine.swift
+++ b/LokalBot/Engines/TextEngine.swift
@@ -69,6 +69,14 @@ enum ChatCompletionDialect: Equatable, Sendable {
     }
 }
 
+/// OpenRouter reasoning shape. Native uses `max_tokens`/`exclude` or
+/// `effort: none`. High-effort is the fallback for models that cannot
+/// disable thinking (for example GLM-5.3).
+enum OpenRouterReasoningCompatibility: Equatable, Sendable {
+    case native
+    case highEffort
+}
+
 enum TextEngineError: LocalizedError, Sendable {
     case serverUnreachable(String)
     case badResponse(String)
@@ -482,9 +490,36 @@ struct OpenAICompatibleEngine: TextEngine {
     private func chat(system: String, prompt: String, context: [String],
                       schema: [String: Any]?,
                       options: TextGenerationOptions?) async throws -> String {
+        try await chat(
+            system: system, prompt: prompt, context: context,
+            schema: schema, options: options, openRouterReasoning: .native)
+    }
+
+    private func chat(system: String, prompt: String, context: [String],
+                      schema: [String: Any]?,
+                      options: TextGenerationOptions?,
+                      openRouterReasoning: OpenRouterReasoningCompatibility) async throws -> String {
         guard !model.isEmpty else { throw TextEngineError.noModel }
         let request = try makeChatRequest(system: system, prompt: prompt, context: context,
-                                          schema: schema, options: options)
+                                          schema: schema, options: options,
+                                          openRouterReasoning: openRouterReasoning)
+        do {
+            return try await completeChat(request)
+        } catch {
+            guard Self.shouldFallbackToHighReasoning(
+                dialect: chatDialect,
+                error: error,
+                usedFallback: openRouterReasoning == .highEffort,
+                requestedReasoningBudget: options?.reasoningBudgetTokens)
+            else { throw error }
+            lokalbotLog("openrouter reasoning fallback effort=high model=\(model)")
+            return try await chat(
+                system: system, prompt: prompt, context: context,
+                schema: schema, options: options, openRouterReasoning: .highEffort)
+        }
+    }
+
+    private func completeChat(_ request: URLRequest) async throws -> String {
         let (data, response) = try await send(request, base: baseURL)
         let httpResponse = response as? HTTPURLResponse
         guard let status = httpResponse?.statusCode, (200...299).contains(status) else {
@@ -504,7 +539,8 @@ struct OpenAICompatibleEngine: TextEngine {
     /// offline tests without requiring credentials or a billable call.
     func makeChatRequest(system: String, prompt: String, context: [String],
                          schema: [String: Any]?,
-                         options: TextGenerationOptions?) throws -> URLRequest {
+                         options: TextGenerationOptions?,
+                         openRouterReasoning: OpenRouterReasoningCompatibility = .native) throws -> URLRequest {
         if chatDialect == .openAI || chatDialect == .openRouter, let schema,
            let issue = OpenAIStrictSchemaValidator.validationIssue(in: schema) {
             throw TextEngineError.badResponse("invalid strict JSON schema: \(issue)")
@@ -535,7 +571,8 @@ struct OpenAICompatibleEngine: TextEngine {
             options: options,
             defaultThinkingBudgetTokens: defaultThinkingBudgetTokens,
             dialect: chatDialect,
-            model: model)
+            model: model,
+            openRouterReasoning: openRouterReasoning)
         if chatDialect == .openRouter {
             var provider: [String: Any] = ["data_collection": "deny"]
             if schema != nil || (options?.reasoningBudgetTokens ?? 0) > 0 {
@@ -603,7 +640,8 @@ struct OpenAICompatibleEngine: TextEngine {
         options: TextGenerationOptions?,
         defaultThinkingBudgetTokens: Int?,
         dialect: ChatCompletionDialect,
-        model: String
+        model: String,
+        openRouterReasoning: OpenRouterReasoningCompatibility = .native
     ) {
         let maxTokens = options?.maxTokens.map { max(1, $0) }
         let isReasoningModel = supportsOpenAIReasoningEffort(model: model)
@@ -628,7 +666,9 @@ struct OpenAICompatibleEngine: TextEngine {
 
         case .openRouter:
             if let maxTokens { body["max_tokens"] = maxTokens }
-            if let requested = options?.reasoningBudgetTokens {
+            if openRouterReasoning == .highEffort {
+                body["reasoning"] = ["effort": "high"]
+            } else if let requested = options?.reasoningBudgetTokens {
                 let nonnegative = max(0, requested)
                 if nonnegative == 0 {
                     body["reasoning"] = ["effort": "none"]
@@ -643,8 +683,10 @@ struct OpenAICompatibleEngine: TextEngine {
             }
             // Sampling controls vary across routed reasoning providers. Keep
             // temperature only for requests that leave reasoning at the model
-            // default or explicitly disable it.
-            if (options?.reasoningBudgetTokens ?? 0) <= 0,
+            // default or explicitly disable it. High-effort fallback is
+            // always-on thinking, so omit temperature there too.
+            if openRouterReasoning != .highEffort,
+               (options?.reasoningBudgetTokens ?? 0) <= 0,
                let temperature = options?.temperature {
                 body["temperature"] = max(0, temperature)
             }
@@ -662,6 +704,24 @@ struct OpenAICompatibleEngine: TextEngine {
                 body["reasoning_effort"] = reasoningEffort(for: budget)
             }
         }
+    }
+
+    /// True when an OpenRouter 404 means the requested reasoning/schema
+    /// parameters have no matching endpoint, so one high-effort retry is allowed.
+    nonisolated static func shouldFallbackToHighReasoning(
+        dialect: ChatCompletionDialect,
+        error: Error,
+        usedFallback: Bool,
+        requestedReasoningBudget: Int?
+    ) -> Bool {
+        guard dialect == .openRouter,
+              !usedFallback,
+              requestedReasoningBudget != nil,
+              case .httpStatus(let code, let detail, _) = error as? TextEngineError,
+              code == 404
+        else { return false }
+        return detail.localizedCaseInsensitiveContains(
+            "no endpoints found that can handle the requested parameters")
     }
 
     nonisolated static func supportsOpenAIReasoningEffort(model: String) -> Bool {

--- a/LokalBot/Models/AppSettings.swift
+++ b/LokalBot/Models/AppSettings.swift
@@ -290,6 +290,26 @@ struct AppSettings: Codable, Equatable {
             && InferenceEndpointPolicy.isAllowed(
                 url, approvedOrigins: approvedRemoteInferenceOrigins)
     }
+
+    /// Name shown for the Think role. Always follows `summarizerBackend`;
+    /// leftover `builtInModelID` is ignored when Think is not the local GGUF.
+    var thinkModelDisplayName: String {
+        switch summarizerBackend {
+        case .builtIn:
+            return ModelCatalog.entry(
+                id: builtInModelID,
+                custom: customBuiltInModels)?.displayName
+                ?? summarizerBackend.displayName
+        case .appleIntelligence:
+            return summarizerBackend.displayName
+        case .ollama:
+            let model = ollamaModel.trimmingCharacters(in: .whitespacesAndNewlines)
+            return model.isEmpty ? summarizerBackend.displayName : model
+        case .openAICompatible:
+            let model = openAIModel.trimmingCharacters(in: .whitespacesAndNewlines)
+            return model.isEmpty ? summarizerBackend.displayName : model
+        }
+    }
     var openAIAPIKey: String {
         get {
             KeychainSecrets.string(account: "openai-compatible-api-key") ?? ""

--- a/LokalBot/Views/ModelStackOverviewView.swift
+++ b/LokalBot/Views/ModelStackOverviewView.swift
@@ -25,10 +25,6 @@ struct ModelStackOverviewView<Configuration: View>: View {
         self.configuration = configuration()
     }
 
-    private var mainEntry: ModelCatalog.Entry? {
-        ModelCatalog.entry(id: app.settings.builtInModelID,
-                           custom: app.settings.customBuiltInModels)
-    }
     private var autocompleteEntry: ModelCatalog.Entry? {
         ModelCatalog.entry(id: app.settings.cotypingBuiltInModelID,
                            custom: app.settings.customBuiltInModels)
@@ -108,7 +104,7 @@ struct ModelStackOverviewView<Configuration: View>: View {
                 icon: "brain",
                 stackRole: .think,
                 role: "Think",
-                model: mainEntry?.displayName ?? app.settings.summarizerBackend.displayName,
+                model: app.settings.thinkModelDisplayName,
                 detail: "Summaries, Ask, outcomes, and Agent",
                 ready: snapshot.thinkReady,
                 result: smokeResults["Think"])
@@ -289,10 +285,7 @@ enum ModelStackPreset: String, CaseIterable, Identifiable {
 
     @MainActor
     func changeSummary(app: AppState) -> String {
-        let currentMain = ModelCatalog.entry(
-            id: app.settings.builtInModelID,
-            custom: app.settings.customBuiltInModels)?.displayName
-            ?? app.settings.builtInModelID
+        let currentMain = app.settings.thinkModelDisplayName
         let nextMain = ModelCatalog.entry(
             id: mainModelID,
             custom: app.settings.customBuiltInModels)?.displayName ?? mainModelID

--- a/LokalBot/Views/OnboardingView.swift
+++ b/LokalBot/Views/OnboardingView.swift
@@ -453,10 +453,7 @@ private extension OnboardingView {
     }
 
     private var onboardingThinkModelName: String {
-        ModelCatalog.entry(
-            id: app.settings.builtInModelID,
-            custom: app.settings.customBuiltInModels)?.displayName
-            ?? app.settings.summarizerBackend.displayName
+        app.settings.thinkModelDisplayName
     }
 
     private var onboardingAutocompleteModelName: String {

--- a/LokalBotTests/AppSettingsTests.swift
+++ b/LokalBotTests/AppSettingsTests.swift
@@ -25,6 +25,29 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertTrue(AppSettings().menuBarOnly)
     }
 
+    func testThinkModelDisplayNameFollowsSelectedBackendNotLeftoverLocalID() {
+        var settings = AppSettings()
+        settings.builtInModelID = ModelCatalog.defaultSummarizationID
+        XCTAssertEqual(settings.thinkModelDisplayName, "Qwen3.5 4B")
+
+        settings.summarizerBackend = .openAICompatible
+        settings.openAIModel = "z-ai/glm-5.3"
+        XCTAssertEqual(
+            settings.thinkModelDisplayName, "z-ai/glm-5.3",
+            "Core roles must not keep showing the leftover local Think model")
+
+        settings.openAIModel = "  "
+        XCTAssertEqual(settings.thinkModelDisplayName,
+                       AppSettings.SummarizerBackend.openAICompatible.displayName)
+
+        settings.summarizerBackend = .ollama
+        settings.ollamaModel = "llama3.1"
+        XCTAssertEqual(settings.thinkModelDisplayName, "llama3.1")
+
+        settings.summarizerBackend = .appleIntelligence
+        XCTAssertEqual(settings.thinkModelDisplayName, "Apple Intelligence")
+    }
+
     func testUsesRemoteMainLLMRequiresApprovedRemoteEndpoint() {
         var settings = AppSettings()
         XCTAssertFalse(settings.usesRemoteMainLLM, "built-in Think is local")

--- a/LokalBotTests/TextEngineTests.swift
+++ b/LokalBotTests/TextEngineTests.swift
@@ -209,6 +209,92 @@ final class TextEngineTests: XCTestCase {
         XCTAssertNil(body["reasoning"])
     }
 
+    func testOpenRouterHighReasoningFallbackUsesEffortHigh() throws {
+        let engine = OpenAICompatibleEngine(
+            baseURL: URL(string: "https://openrouter.ai/api/v1")!,
+            model: "z-ai/glm-5.3",
+            apiKey: "test-token",
+            chatDialect: .openRouter)
+        let schema: [String: Any] = [
+            "type": "object",
+            "properties": ["answer": ["type": "string"]],
+            "required": ["answer"],
+            "additionalProperties": false,
+        ]
+
+        let request = try engine.makeChatRequest(
+            system: "system",
+            prompt: "prompt",
+            context: [],
+            schema: schema,
+            options: TextGenerationOptions(
+                maxTokens: 768,
+                reasoningBudgetTokens: 256,
+                temperature: 0.2),
+            openRouterReasoning: .highEffort)
+        let data = try XCTUnwrap(request.httpBody)
+        let body = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let reasoning = try XCTUnwrap(body["reasoning"] as? [String: Any])
+
+        XCTAssertEqual(reasoning["effort"] as? String, "high")
+        XCTAssertNil(reasoning["max_tokens"])
+        XCTAssertNil(reasoning["exclude"])
+        XCTAssertEqual(body["max_tokens"] as? Int, 768)
+        XCTAssertNil(body["temperature"])
+    }
+
+    func testOpenRouterHighReasoningFallbackReplacesDisabledReasoning() {
+        var body: [String: Any] = [:]
+
+        OpenAICompatibleEngine.applyGenerationOptions(
+            to: &body,
+            options: TextGenerationOptions(
+                maxTokens: 1_600,
+                reasoningBudgetTokens: 0,
+                temperature: 0),
+            defaultThinkingBudgetTokens: nil,
+            dialect: .openRouter,
+            model: "z-ai/glm-5.3",
+            openRouterReasoning: .highEffort)
+
+        let reasoning = body["reasoning"] as? [String: Any]
+        XCTAssertEqual(reasoning?["effort"] as? String, "high")
+        XCTAssertNil(reasoning?["max_tokens"])
+        XCTAssertNil(body["temperature"])
+    }
+
+    func testOpenRouterParameterMismatchTriggersHighReasoningFallbackOnce() {
+        let mismatch = TextEngineError.httpStatus(
+            code: 404,
+            detail: "No endpoints found that can handle the requested parameters. "
+                + "To learn more about provider routing, visit: "
+                + "https://openrouter.ai/docs/guides/routing/provider-selection",
+            retryAfter: nil)
+        let missingModel = TextEngineError.httpStatus(
+            code: 404, detail: "No endpoints found for model z-ai/glm-5.3", retryAfter: nil)
+
+        XCTAssertTrue(OpenAICompatibleEngine.shouldFallbackToHighReasoning(
+            dialect: .openRouter, error: mismatch, usedFallback: false,
+            requestedReasoningBudget: 256))
+        XCTAssertTrue(OpenAICompatibleEngine.shouldFallbackToHighReasoning(
+            dialect: .openRouter, error: mismatch, usedFallback: false,
+            requestedReasoningBudget: 0),
+                       "effort:none retries also need the high-reasoning fallback")
+        XCTAssertFalse(OpenAICompatibleEngine.shouldFallbackToHighReasoning(
+            dialect: .openRouter, error: mismatch, usedFallback: true,
+            requestedReasoningBudget: 256))
+        XCTAssertFalse(OpenAICompatibleEngine.shouldFallbackToHighReasoning(
+            dialect: .openRouter, error: missingModel, usedFallback: false,
+            requestedReasoningBudget: 256))
+        XCTAssertFalse(OpenAICompatibleEngine.shouldFallbackToHighReasoning(
+            dialect: .generic, error: mismatch, usedFallback: false,
+            requestedReasoningBudget: 256))
+        XCTAssertFalse(OpenAICompatibleEngine.shouldFallbackToHighReasoning(
+            dialect: .openRouter, error: mismatch, usedFallback: false,
+            requestedReasoningBudget: nil))
+    }
+
     func testOpenRouterCanDisableReasoningForStructuredRetry() throws {
         let engine = OpenAICompatibleEngine(
             baseURL: URL(string: "https://openrouter.ai/api/v1")!,

--- a/LokalBotTests/TextEngineTests.swift
+++ b/LokalBotTests/TextEngineTests.swift
@@ -242,6 +242,11 @@ final class TextEngineTests: XCTestCase {
         XCTAssertNil(reasoning["exclude"])
         XCTAssertEqual(body["max_tokens"] as? Int, 768)
         XCTAssertNil(body["temperature"])
+        XCTAssertNil(body["response_format"],
+                     "strict json_schema is what 404s GLM-5.3 after the reasoning remap")
+        let provider = try XCTUnwrap(body["provider"] as? [String: Any])
+        XCTAssertEqual(provider["data_collection"] as? String, "deny")
+        XCTAssertNil(provider["require_parameters"])
     }
 
     func testOpenRouterHighReasoningFallbackReplacesDisabledReasoning() {


### PR DESCRIPTION
## Summary
- Core roles now show the active Think backend (for example `z-ai/glm-5.3`) instead of the leftover local GGUF.
- Day digest / structured OpenRouter calls that 404 on unsupported reasoning or `json_schema` retry once with `effort=high` and without `require_parameters`.

## Test plan
- [x] `AppSettingsTests` / `TextEngineTests` for Think display name and OpenRouter fallback request shape
- [ ] Rewrite yesterday’s day digest with OpenRouter GLM-5.3 and confirm the overview generates
- [ ] Settings → Models still shows the remote Think name and sidebar footer stays accurate


Made with [Cursor](https://cursor.com)