### PR TITLE
Prepare LokalBot 0.6.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,6 +278,7 @@ jobs:
       # releases/latest/download/appcast.xml, so the appcast must live on the
       # Release next to the DMG it signs. Hyphenated tags (v1.0.0-beta) become
       # pre-releases and never become "latest" (RELEASING.md step 7).
+      # Prefer Scripts/release-notes/<tag>.md as the Release body when present.
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -286,12 +287,21 @@ jobs:
           if [[ "$GITHUB_REF_NAME" == *-* ]]; then
             prerelease_flag="--prerelease"
           fi
+          notes_file="Scripts/release-notes/${GITHUB_REF_NAME}.md"
+          notes_flag=(--generate-notes)
+          if [[ -f "$notes_file" ]]; then
+            notes_flag=(--notes-file "$notes_file")
+          fi
           if ! gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
             gh release create "$GITHUB_REF_NAME" \
               --repo "$GITHUB_REPOSITORY" \
               --title "LokalBot ${GITHUB_REF_NAME#v}" \
-              --generate-notes \
+              "${notes_flag[@]}" \
               $prerelease_flag
+          elif [[ -f "$notes_file" ]]; then
+            gh release edit "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --notes-file "$notes_file"
           fi
           gh release upload "$GITHUB_REF_NAME" \
             --repo "$GITHUB_REPOSITORY" \

--- a/LokalBot/Info.plist
+++ b/LokalBot/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>CFBundleVersion</key>
-	<string>24</string>
+	<string>25</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -278,8 +278,14 @@ gh release create v1.0.0 \
   build/LokalBot.dmg \
   build/appcast.xml \
   --title "LokalBot 1.0.0" \
-  --notes "What's new in this release."
+  --notes-file Scripts/release-notes/v1.0.0.md
 ```
+
+CI reads `Scripts/release-notes/<tag>.md` when that file exists (for example
+`Scripts/release-notes/v0.6.1.md`) and posts it as the GitHub Release body.
+Otherwise it falls back to `--generate-notes`. Write a short “What’s new”
+summary there before tagging so Sparkle’s release-notes link and the GitHub
+Release page show the same changelog.
 
 Pre-release tags (a hyphen suffix, e.g. `v1.0.0-beta`) are marked **Pre-release**
 on GitHub and won't become "Latest"; tag without a suffix for a stable release.

--- a/Scripts/release-notes/v0.6.1.md
+++ b/Scripts/release-notes/v0.6.1.md
@@ -1,0 +1,6 @@
+## What’s new
+
+- **Readable Day Digest tasks.** Long task summaries expand in place with Show more, instead of cutting off mid-sentence. Generated titles and summaries now keep complete sentences.
+- **A stable Ask composer.** Switching between Ask and Search, or changing retrieval filters, no longer shifts the query field. The query chrome stays pinned at the top with a stable size.
+
+**Full changelog:** https://github.com/stevyhacker/lokalbot/compare/v0.6.0...v0.6.1

--- a/project.yml
+++ b/project.yml
@@ -139,8 +139,8 @@ targetTemplates:
       properties:
         CFBundleDisplayName: LokalBot
         CFBundleIconFile: AppIcon
-        CFBundleShortVersionString: "0.6.0"
-        CFBundleVersion: "24"
+        CFBundleShortVersionString: "0.6.1"
+        CFBundleVersion: "25"
         NSMicrophoneUsageDescription: >-
           LokalBot records your side of meetings from the microphone.
           Audio stays on this Mac; transcript text is sent off-device only if


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ships **LokalBot 0.6.1** (build 25) with a short text changelog on the GitHub Release.

This patch covers the two fixes landed after `v0.6.0`:

- Day Digest task summaries expand in place instead of cutting off mid-sentence; generated titles and summaries keep complete sentences.
- Ask/Search retrieval chrome stays pinned at a stable size so switching modes no longer shifts the composer.

The release workflow now posts `Scripts/release-notes/<tag>.md` as the Release body when that file exists (this tag uses `Scripts/release-notes/v0.6.1.md`), falling back to `--generate-notes` otherwise.

**Published:** https://github.com/stevyhacker/lokalbot/releases/tag/v0.6.1 — `LokalBot.dmg` and `appcast.xml` are uploaded, and the notes above are the Release body.

## Validation

- Confirmed `project.yml` and `LokalBot/Info.plist` both read `0.6.1` / `25`.
- Tag `v0.6.1` triggered the Release workflow; it completed successfully and posted the notes file as the GitHub Release body.
- macOS archive/notarize ran in GitHub Actions (this environment is Linux).

## Risk / rollout notes

- Sparkle compares `CFBundleVersion`; 25 is monotonic after 0.6.0’s 24.
- Existing installs pick this up from `releases/latest/download/appcast.xml`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1512329c-7bdf-4a03-9600-36e51c0d8cb5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1512329c-7bdf-4a03-9600-36e51c0d8cb5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

