### PR TITLE
Fix SwiftLint line length and digest Tasks UI tests

### DIFF
--- a/LokalBot/Views/DayDigestView.swift
+++ b/LokalBot/Views/DayDigestView.swift
@@ -69,6 +69,8 @@ struct DayDigestView: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier("dayDigest.tasks")
             }
 
             if mode.showsOtherActivity, !presentation.otherActivityBlocks.isEmpty {

--- a/LokalBot/Views/DayDigestView.swift
+++ b/LokalBot/Views/DayDigestView.swift
@@ -44,10 +44,14 @@ struct DayDigestView: View {
 
             if !presentation.focusBlocks.isEmpty {
                 VStack(alignment: .leading, spacing: 12) {
-                    Label("Tasks", systemImage: "briefcase")
-                        .font(DayDigestTaskType.sectionTitle)
-                        .foregroundStyle(.primary)
-                        .accessibilityAddTraits(.isHeader)
+                    HStack(spacing: 6) {
+                        Image(systemName: "briefcase")
+                            .accessibilityHidden(true)
+                        Text("Tasks")
+                            .font(DayDigestTaskType.sectionTitle)
+                            .accessibilityIdentifier("dayDigest.tasks")
+                    }
+                    .foregroundStyle(.primary)
                     VStack(alignment: .leading, spacing: 8) {
                         sessionList(presentation.initialFocusBlocks, prominent: true)
                         let additional = presentation.collapsibleFocusBlocks
@@ -69,8 +73,6 @@ struct DayDigestView: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .accessibilityElement(children: .contain)
-                .accessibilityIdentifier("dayDigest.tasks")
             }
 
             if mode.showsOtherActivity, !presentation.otherActivityBlocks.isEmpty {

--- a/LokalBot/Views/QuickRecallView.swift
+++ b/LokalBot/Views/QuickRecallView.swift
@@ -296,8 +296,13 @@ private struct QuickRecallContent: View {
 
     private var noMatchesState: some View {
         VStack(spacing: 8) {
-            Label("No local matches", systemImage: "magnifyingglass")
-                .font(.headline)
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass")
+                    .accessibilityHidden(true)
+                Text("No local matches")
+                    .font(.headline)
+                    .accessibilityIdentifier("quickRecall.noMatches")
+            }
             Text("Nothing in saved moments, captured screens, or meetings matches this search.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
@@ -312,7 +317,6 @@ private struct QuickRecallContent: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 28)
         .padding(.horizontal, 20)
-        .accessibilityIdentifier("quickRecall.noMatches")
     }
 
     private func search() {

--- a/LokalBotTests/DayDigestEvidenceTests.swift
+++ b/LokalBotTests/DayDigestEvidenceTests.swift
@@ -730,7 +730,12 @@ final class DayDigestEvidenceTests: XCTestCase {
     func testJournalKeepsLongTaskTitlesAndCompleteSummaries() async throws {
         let title = "Oracle price-quote and price-floor logic in AggregatorSwapAdapter (PR #230)"
         let summary = """
-            Implemented decimal-scaled price conversion in AggregatorSwapAdapter.sol, using Math.tryMul to adjust tokenOutPrice by the tokenIn/tokenOut decimal difference before deriving oracle amount-out values for a WETH/USDC quote in a fork test. The changes, including the oracle price floor logic and related test files, remain open as PR #230; it is unclear whether the tests fully cover the new floor.
+            Implemented decimal-scaled price conversion in AggregatorSwapAdapter.sol, \
+            using Math.tryMul to adjust tokenOutPrice by the tokenIn/tokenOut decimal \
+            difference before deriving oracle amount-out values for a WETH/USDC quote \
+            in a fork test. The changes, including the oracle price floor logic and \
+            related test files, remain open as PR #230; it is unclear whether the \
+            tests fully cover the new floor.
             """.trimmingCharacters(in: .whitespacesAndNewlines)
         XCTAssertGreaterThan(title.count, 72)
         XCTAssertGreaterThan(summary.split(whereSeparator: \.isWhitespace).count, 52)

--- a/LokalBotUITests/MainWindowUITests.swift
+++ b/LokalBotUITests/MainWindowUITests.swift
@@ -48,7 +48,7 @@ final class MainWindowUITests: XCTestCase {
                        "Today should not hide its daily memory behind More local context")
         XCTAssertTrue(textWithContent("Highlights").firstMatch.exists,
                       "digest highlights hierarchy is missing")
-        XCTAssertTrue(identified("dayDigest.tasks").waitForExistence(timeout: 5),
+        XCTAssertTrue(digestTasksVisible(),
                       "digest task hierarchy is missing")
         XCTAssertTrue(textWithContent("Updated the Timeline UI").firstMatch.exists,
                       "human-facing focus summary is missing")
@@ -386,7 +386,7 @@ final class MainWindowUITests: XCTestCase {
                       "compact time allocation missing — seeded activity did not load")
         XCTAssertTrue(textWithContent("Xcode").firstMatch.exists,
                       "seeded activity app 'Xcode' missing from Timeline")
-        XCTAssertTrue(identified("dayDigest.tasks").waitForExistence(timeout: 5),
+        XCTAssertTrue(digestTasksVisible(),
                       "digest task hierarchy is missing")
         XCTAssertTrue(textWithContent("Updated the Timeline UI").firstMatch.exists,
                       "human-facing focus summary is missing")
@@ -903,6 +903,13 @@ final class MainWindowUITests: XCTestCase {
     private func identified(_ identifier: String) -> XCUIElement {
         app.descendants(matching: .any).matching(
             NSPredicate(format: "identifier == %@", identifier)).firstMatch
+    }
+
+    /// Prefer the stable identifier; fall back to visible copy if AX role differs.
+    private func digestTasksVisible() -> Bool {
+        let identifiedHeader = app.descendants(matching: .any)["dayDigest.tasks"]
+        if identifiedHeader.waitForExistence(timeout: 5) { return true }
+        return textWithContent("Tasks").firstMatch.exists
     }
 
     private func switchToKeywordSearch() {

--- a/LokalBotUITests/MainWindowUITests.swift
+++ b/LokalBotUITests/MainWindowUITests.swift
@@ -48,7 +48,7 @@ final class MainWindowUITests: XCTestCase {
                        "Today should not hide its daily memory behind More local context")
         XCTAssertTrue(textWithContent("Highlights").firstMatch.exists,
                       "digest highlights hierarchy is missing")
-        XCTAssertTrue(textWithContent("Tasks").firstMatch.exists,
+        XCTAssertTrue(identified("dayDigest.tasks").waitForExistence(timeout: 5),
                       "digest task hierarchy is missing")
         XCTAssertTrue(textWithContent("Updated the Timeline UI").firstMatch.exists,
                       "human-facing focus summary is missing")
@@ -386,7 +386,7 @@ final class MainWindowUITests: XCTestCase {
                       "compact time allocation missing — seeded activity did not load")
         XCTAssertTrue(textWithContent("Xcode").firstMatch.exists,
                       "seeded activity app 'Xcode' missing from Timeline")
-        XCTAssertTrue(textWithContent("Tasks").firstMatch.exists,
+        XCTAssertTrue(identified("dayDigest.tasks").waitForExistence(timeout: 5),
                       "digest task hierarchy is missing")
         XCTAssertTrue(textWithContent("Updated the Timeline UI").firstMatch.exists,
                       "human-facing focus summary is missing")

--- a/LokalBotUITests/QuickRecallUITests.swift
+++ b/LokalBotUITests/QuickRecallUITests.swift
@@ -69,8 +69,11 @@ final class QuickRecallUITests: XCTestCase {
         XCTAssertTrue(ask.waitForExistence(timeout: 4),
                       "inline assistant action missing for an unmatched query")
         XCTAssertEqual(ask.value as? String, "Answer from your meetings and screen")
-        XCTAssertTrue(text(containing: "No local matches").waitForExistence(timeout: 4),
-                      "Quick Recall did not distinguish a completed empty search")
+        XCTAssertTrue(
+            app.descendants(matching: .any)["quickRecall.noMatches"]
+                .waitForExistence(timeout: 8)
+                || text(containing: "Nothing in saved moments").exists,
+            "Quick Recall did not distinguish a completed empty search")
         // SwiftUI propagates the enclosing no-match state's accessibility ID
         // to descendants on macOS, so select this button by visible content.
         let askInstead = app.buttons.matching(NSPredicate(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the CI failures that landed with the day-digest expand-in-place work (`7b18978`) and are red on master / 0.6.1.

- **SwiftLint:** wrap the 408-character summary fixture in `DayDigestEvidenceTests` so it stays under the 400-character `--strict` warning.
- **XCUITest digest:** the Tasks heading is a `Text` with `dayDigest.tasks` (same pattern as `today.header`). Tests wait for that identifier and fall back to visible copy.
- **XCUITest Quick Recall:** hosted runs can miss `Label` copy for an empty search. Identify `No local matches` the same way.

## Validation

- SwiftLint is green on this PR.
- Digest UI tests passed on the second CI run; Quick Recall then failed once on `testClearReturnsToAskEmptyState` (it had passed on the prior run). That assertion is now identifier-based.

## Risk / rollout notes

UI tests now prefer accessibility identifiers over heading copy for Tasks and Quick Recall empty search.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1512329c-7bdf-4a03-9600-36e51c0d8cb5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1512329c-7bdf-4a03-9600-36e51c0d8cb5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

