### PR TITLE
Prepare LokalBot 0.6.2 release

### DIFF
--- a/LokalBot/Info.plist
+++ b/LokalBot/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.1</string>
+	<string>0.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>25</string>
+	<string>26</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Scripts/release-notes/v0.6.2.md
+++ b/Scripts/release-notes/v0.6.2.md
@@ -1,0 +1,7 @@
+## What’s new
+
+- **Meeting summaries that recover automatically.** Long recordings and model output limits are handled with token-aware splitting, bounded retries, and saved partial progress. Noisy transcript artifacts are cleaned before summarization, and Retry resumes from an existing transcript instead of repeating completed transcription.
+- **Self-healing Day Digests.** Transient model failures now get a bounded retry, an interrupted managed local model can restart, and truncated or invalid output gets a compact recovery pass. A readable fallback stays available while LokalBot quietly repairs an incomplete digest later.
+- **More dependable hosted UI checks.** Day Digest Tasks and empty Quick Recall results now expose stable accessibility anchors, keeping release coverage reliable.
+
+**Full changelog:** https://github.com/stevyhacker/lokalbot/compare/v0.6.1...v0.6.2

--- a/project.yml
+++ b/project.yml
@@ -139,8 +139,8 @@ targetTemplates:
       properties:
         CFBundleDisplayName: LokalBot
         CFBundleIconFile: AppIcon
-        CFBundleShortVersionString: "0.6.1"
-        CFBundleVersion: "25"
+        CFBundleShortVersionString: "0.6.2"
+        CFBundleVersion: "26"
         NSMicrophoneUsageDescription: >-
           LokalBot records your side of meetings from the microphone.
           Audio stays on this Mac; transcript text is sent off-device only if


### PR DESCRIPTION
## Summary

- bump LokalBot to 0.6.2 (build 26)
- add a human-readable What’s new summary for all changes since v0.6.1
- keep the release metadata sources aligned

## Validation

- xcodegen generate
- plutil -lint LokalBot/Info.plist
- swiftlint lint --strict
- hosted XcodeGen, Lint, Build, Tests, and UI Tests required before merge and tagging