### PR TITLE
Deepen LokalBot core architecture

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,51 @@
+# LokalBot
+
+LokalBot is a local-first macOS work-memory app. It captures conversations,
+turns them into useful memory, and helps people retrieve or act on that memory
+without making remote data sharing the default.
+
+## Language
+
+**Work Memory**
+
+The durable, searchable record LokalBot builds from meetings, transcripts,
+notes, outcomes, and related context.
+
+_Avoid_: knowledge base, second brain
+
+**Day Digest**
+
+An evidence-backed daily journal assembled from a person's Work Memory. It
+should reflect what happened that day rather than inventing a generic recap.
+
+_Avoid_: daily summary, daily recap
+
+**Model Role**
+
+A distinct responsibility in LokalBot's on-device intelligence stack. A role
+has one selected engine and one understandable lifecycle, even when several
+features use it.
+
+_Avoid_: model slot, model tier
+
+**Transcribe**
+
+The Model Role that turns recorded speech into timestamped text and speaker
+evidence.
+
+_Avoid_: speech model, STT slot
+
+**Think**
+
+The Model Role that turns Work Memory into summaries, answers, outcomes,
+briefs, drafts, and agent responses. It stays on-device by default; using a
+remote engine requires explicit approval.
+
+_Avoid_: summarizer, main LLM slot
+
+**Autocomplete**
+
+The Model Role that offers short, immediate continuations while a person is
+writing. It is optimized for responsiveness rather than deeper synthesis.
+
+_Avoid_: small LLM, fast model slot

--- a/LokalBot/Agent/AgentLLMEndpoint.swift
+++ b/LokalBot/Agent/AgentLLMEndpoint.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A resolved OpenAI-compatible endpoint the agent's provider will talk to.
-struct AgentLLMEndpoint: Equatable {
+struct AgentLLMEndpoint: Equatable, Sendable {
     let baseURL: URL
     let model: String
     let contextTokens: Int
@@ -13,81 +13,10 @@ struct AgentLLMEndpoint: Equatable {
     static let defaultContextTokens = MainLLMRuntimePolicy.contextTokens
 }
 
-enum AgentLLMResolution: Equatable {
+enum AgentLLMResolution: Equatable, Sendable {
     /// Caller resolves the model URL and holds an `InferenceBroker` Main LLM
     /// lease before building the endpoint from the shared base URL + model id.
     case builtIn(modelID: String)
     case ready(AgentLLMEndpoint)
     case unsupported(reason: String)
-}
-
-/// Pure settings → endpoint resolution for Agent Mode. Mirrors the backend
-/// switch in ProcessingPipeline.makeTextEngine, with deliberate differences:
-/// no async work here (runtime acquisition is the caller's job); Ollama and the
-/// OpenAI-compatible server each require an explicit model because pi
-/// registers the model id statically at launch; and an empty API key
-/// resolves to nil.
-enum AgentLLMEndpointResolver {
-
-    static func resolve(settings: AppSettings) -> AgentLLMResolution {
-        switch settings.summarizerBackend {
-        case .builtIn:
-            guard let entry = ModelCatalog.entry(id: settings.builtInModelID,
-                                                 custom: settings.customBuiltInModels)
-                    ?? ModelCatalog.entry(id: ModelCatalog.recommendedSummarizationID) else {
-                return .unsupported(reason: "No built-in model is configured. Pick one under Settings → Models.")
-            }
-            return .builtIn(modelID: entry.id)
-
-        case .appleIntelligence:
-            return .unsupported(reason: "Apple Intelligence doesn't expose a local endpoint Agent Mode can use. Switch the Main LLM engine to Built-in (on-device), Ollama, or an OpenAI-compatible server under Settings → Models.")
-
-        case .ollama:
-            guard let base = URL(string: settings.ollamaBaseURL) else {
-                return .unsupported(reason: "The Ollama server URL under Settings → Models isn't a valid URL.")
-            }
-            guard InferenceEndpointPolicy.isAllowed(
-                base, approvedOrigins: settings.approvedRemoteInferenceOrigins) else {
-                return .unsupported(
-                    reason: "Approve this remote Ollama server under Settings → Models before Agent Mode sends context to it.")
-            }
-            guard InferenceEndpointPolicy.isLoopback(base)
-                    || base.scheme?.lowercased() == "https" else {
-                return .unsupported(
-                    reason: "Remote Ollama servers must use HTTPS so meeting context is encrypted in transit.")
-            }
-            guard !settings.ollamaModel.isEmpty else {
-                return .unsupported(reason: "Pick an Ollama model under Settings → Models — Agent Mode needs an explicit model.")
-            }
-            return .ready(AgentLLMEndpoint(
-                baseURL: base.appendingPathComponent("v1"),
-                model: settings.ollamaModel,
-                contextTokens: AgentLLMEndpoint.defaultContextTokens,
-                apiKey: nil))
-
-        case .openAICompatible:
-            guard let base = URL(string: settings.openAIBaseURL) else {
-                return .unsupported(reason: "The server URL under Settings → Models isn't a valid URL.")
-            }
-            guard InferenceEndpointPolicy.isAllowed(
-                base, approvedOrigins: settings.approvedRemoteInferenceOrigins) else {
-                return .unsupported(
-                    reason: "Approve this remote inference server under Settings → Models before Agent Mode sends context to it.")
-            }
-            guard InferenceEndpointPolicy.isLoopback(base)
-                    || base.scheme?.lowercased() == "https" else {
-                return .unsupported(
-                    reason: "Remote inference servers must use HTTPS; LokalBot will not send meeting context or API keys over HTTP.")
-            }
-            guard !settings.openAIModel.isEmpty else {
-                return .unsupported(reason: "Set a model name for the OpenAI-compatible server under Settings → Models.")
-            }
-            let key = settings.openAIAPIKey
-            return .ready(AgentLLMEndpoint(
-                baseURL: base,
-                model: settings.openAIModel,
-                contextTokens: AgentLLMEndpoint.defaultContextTokens,
-                apiKey: key.isEmpty ? nil : key))
-        }
-    }
 }

--- a/LokalBot/Agent/AgentSessionController.swift
+++ b/LokalBot/Agent/AgentSessionController.swift
@@ -32,6 +32,7 @@ final class AgentSessionController: ObservableObject {
     private let runtimeRoot: URL
     private let sessionsDirectory: URL
     private let broker: InferenceBroker
+    private let thinkExecution: ThinkExecution
     private let makeTransport: ((PiLaunchPlan) async throws -> PiLineTransport)?
     private let accessGate: AgentAccessGate
 
@@ -63,6 +64,7 @@ final class AgentSessionController: ObservableObject {
          runtimeRoot: URL = AgentRuntimeLayout.defaultRoot,
          sessionsDirectory: URL = AgentRuntimeLayout.sessionsDirectory,
          broker: InferenceBroker = .shared,
+         thinkExecution: ThinkExecution? = nil,
          accessGate: AgentAccessGate? = nil,
          makeTransport: ((PiLaunchPlan) async throws -> PiLineTransport)? = nil) {
         self.settings = settings
@@ -70,6 +72,7 @@ final class AgentSessionController: ObservableObject {
         self.runtimeRoot = runtimeRoot
         self.sessionsDirectory = sessionsDirectory
         self.broker = broker
+        self.thinkExecution = thinkExecution ?? ThinkExecution(storage: storage)
         self.accessGate = accessGate ?? AgentAccessGate(root: storage.rootURL)
         self.makeTransport = makeTransport
         self.workspace = storage.rootURL
@@ -321,30 +324,12 @@ final class AgentSessionController: ObservableObject {
     // MARK: - Endpoint + plan
 
     private func resolveEndpoint() async throws -> AgentLLMEndpoint {
-        switch AgentLLMEndpointResolver.resolve(settings: settings()) {
-        case .ready(let endpoint):
-            return endpoint
-        case .builtIn(let modelID):
-            guard let entry = ModelCatalog.entry(id: modelID, custom: settings().customBuiltInModels)
-                    ?? ModelCatalog.entry(id: modelID) else {
-                throw StartError.modelConfiguration("The built-in model isn't downloaded yet. Download it under Settings → Models.")
-            }
-            guard let modelURL = await ModelDownloadManager.shared.verifiedExistingURL(
-                entry, storage: storage) else {
-                throw StartError.modelConfiguration("The built-in model isn't downloaded yet. Download it under Settings → Models.")
-            }
-            releaseLLMLease()
-            llmLease = try await broker.lease(.mainLLM, model: modelURL,
-                                              priority: .interactive,
-                                              purpose: "agent session")
-            let authenticationToken = await LlamaServer.shared.authenticationToken()
-            return AgentLLMEndpoint(baseURL: LlamaServer.shared.baseURL,
-                                    model: entry.id,
-                                    contextTokens: AgentLLMEndpoint.defaultContextTokens,
-                                    apiKey: authenticationToken)
-        case .unsupported(let reason):
-            throw StartError.modelConfiguration(reason)
-        }
+        releaseLLMLease()
+        let connection = try await thinkExecution.prepareAgentConnection(
+            settings: settings(),
+            broker: broker)
+        llmLease = connection.lease
+        return connection.endpoint
     }
 
     private func makePlan(endpoint: AgentLLMEndpoint, capabilityToken: String?) -> PiLaunchPlan {
@@ -498,7 +483,7 @@ final class AgentSessionController: ObservableObject {
         revokeAccessCapability()
         releaseLLMLease()
         state = .failed(Self.message(for: error))
-        if case StartError.modelConfiguration = error {
+        if case ThinkExecutionError.agentConfiguration = error {
             recoveryAction = .openModels
         } else {
             recoveryAction = .restart
@@ -664,11 +649,9 @@ final class AgentSessionController: ObservableObject {
         }
     }
 
-    enum StartError: Error { case modelConfiguration(String) }
-
     private static func message(for error: Error) -> String {
         switch error {
-        case StartError.modelConfiguration(let reason): return reason
+        case ThinkExecutionError.agentConfiguration(let reason): return reason
         case PiProcessError.executableNotFound:
             return "The agent runtime isn't installed. Enable Agent Mode to download it."
         case PiRPCError.transportClosed:

--- a/LokalBot/Agent/AgentSessionTabs.swift
+++ b/LokalBot/Agent/AgentSessionTabs.swift
@@ -20,9 +20,17 @@ final class AgentSessionTabs: ObservableObject {
     private let makeController: @MainActor () -> AgentSessionController
     private var nextNumber: Int
 
-    convenience init(settings: @escaping () -> AppSettings, storage: StorageManager) {
+    convenience init(
+        settings: @escaping () -> AppSettings,
+        storage: StorageManager,
+        thinkExecution: ThinkExecution? = nil
+    ) {
+        let execution = thinkExecution ?? ThinkExecution(storage: storage)
         self.init {
-            AgentSessionController(settings: settings, storage: storage)
+            AgentSessionController(
+                settings: settings,
+                storage: storage,
+                thinkExecution: execution)
         }
     }
 

--- a/LokalBot/AppState.swift
+++ b/LokalBot/AppState.swift
@@ -391,10 +391,14 @@ final class AppState: ObservableObject {
     }
     private(set) lazy var pipelineJobStore = PipelineJobStore(
         databaseURL: storage.rootURL.appendingPathComponent("lokalbotv3.sqlite"))
+    /// Backend selection, preparation, privacy policy, leases, and recovery
+    /// for every feature that uses LokalBot's Think role.
+    private(set) lazy var thinkExecution = ThinkExecution(storage: storage)
     private(set) lazy var pipeline = ProcessingPipeline(
-        storage: storage, jobStore: pipelineJobStore) { [store = settingsStore] in
-        store.current
-    }
+        storage: storage,
+        jobStore: pipelineJobStore,
+        settings: { [store = settingsStore] in store.current },
+        thinkExecution: thinkExecution)
     /// Canonical state machine for Transcribe, Think, and Autocomplete.
     private(set) lazy var modelRoles = ModelRoles(
         settings: { [store = settingsStore] in store.current },
@@ -435,7 +439,7 @@ final class AppState: ObservableObject {
                 throw TextEngineError.unavailable("LokalBot is shutting down.")
             }
             let config = self.settingsStore.current.dictationCompositionTextEngineSettings
-            return try await self.pipeline.makeTextEngine(
+            return try await self.thinkExecution.makeTextEngine(
                 config,
                 priority: .interactive,
                 purpose: "dictation compose")
@@ -462,7 +466,7 @@ final class AppState: ObservableObject {
         http: CotypingEngine(
             makeEngine: { [weak self] in
                 guard let self else { throw TextEngineError.unavailable("LokalBot is shutting down.") }
-                return try await self.pipeline.makeTextEngine(
+                return try await self.thinkExecution.makeTextEngine(
                     self.settings.cotypingTextEngineSettings,
                     server: .cotyping,
                     priority: .interactive,
@@ -501,7 +505,7 @@ final class AppState: ObservableObject {
     private(set) lazy var chat = ChatViewModel(
         makeEngine: { [weak self] in
             guard let self else { throw TextEngineError.unavailable("LokalBot is shutting down.") }
-            return try await self.pipeline.makeTextEngine(
+            return try await self.thinkExecution.makeTextEngine(
                 self.settings,
                 priority: .interactive,
                 purpose: "chat")
@@ -526,7 +530,8 @@ final class AppState: ObservableObject {
     let agentInstaller = AgentRuntimeInstaller()
     private(set) lazy var agentSessions = AgentSessionTabs(
         settings: { [store = settingsStore] in store.current },
-        storage: storage)
+        storage: storage,
+        thinkExecution: thinkExecution)
     var agentController: AgentSessionController {
         agentSessions.ensureSelectedController()
     }
@@ -1297,7 +1302,7 @@ final class AppState: ObservableObject {
                             throw TextEngineError.unavailable("LokalBot is shutting down.")
                         }
                         let engineSettings = self.settings
-                        let engine = try await self.pipeline.makeTextEngine(
+                        let engine = try await self.thinkExecution.makeTextEngine(
                             engineSettings,
                             priority: .background,
                             purpose: "dreaming")

--- a/LokalBot/AppState.swift
+++ b/LokalBot/AppState.swift
@@ -11,22 +11,6 @@ import CoreGraphics
 @MainActor
 final class AppState: ObservableObject {
 
-    enum CoreModelPreparationState: Equatable {
-        case idle
-        case preparingTranscription
-        case failed(String)
-
-        var isPreparing: Bool {
-            if case .preparingTranscription = self { return true }
-            return false
-        }
-
-        var errorMessage: String? {
-            if case .failed(let message) = self { return message }
-            return nil
-        }
-    }
-
     enum NavSection: Hashable {
         case today, timeline, meetings, type, ask, agent, settings
 
@@ -109,7 +93,6 @@ final class AppState: ObservableObject {
 
     @Published private(set) var meetings: [Meeting] = []
     @Published var lastError: String?
-    @Published private(set) var coreModelPreparationState: CoreModelPreparationState = .idle
     /// A recording or dictation start was refused because microphone access
     /// is denied at the system level. Cleared when the user opens System
     /// Settings from the recovery toast or dismisses it.
@@ -125,10 +108,7 @@ final class AppState: ObservableObject {
         didSet {
             guard settings != oldValue else { return }
             settingsStore.current = settings
-            if ModelReadinessSnapshot.processingReadinessChanged(
-                from: oldValue, to: settings) {
-                processMeetingsWaitingForModels()
-            }
+            modelRoles.settingsDidChange(from: oldValue, to: settings)
             if settings.stopDebounceSeconds != oldValue.stopDebounceSeconds {
                 detector.stopDebounce = settings.stopDebounceSeconds
             }
@@ -437,6 +417,13 @@ final class AppState: ObservableObject {
         storage: storage, jobStore: pipelineJobStore) { [store = settingsStore] in
         store.current
     }
+    /// Canonical state machine for Transcribe, Think, and Autocomplete.
+    private(set) lazy var modelRoles = ModelRoles(
+        settings: { [store = settingsStore] in store.current },
+        storage: storage,
+        onReadinessChanged: { [weak self] in
+            self?.processMeetingsWaitingForModels()
+        })
     /// One Day Digest lifecycle for manual, scheduled, and headless callers.
     /// It owns evidence collection, journal state, freshness, and repair policy.
     private(set) lazy var dayDigest = DayDigestLifecycle(
@@ -574,12 +561,11 @@ final class AppState: ObservableObject {
     private var audioMonitorObserver: AnyCancellable?
     private var audioMonitorChangeForwarder: AnyCancellable?
     private var calendarObserver: AnyCancellable?
-    private var modelDownloadsObserver: AnyCancellable?
+    private var modelRolesObserver: AnyCancellable?
     /// True only on the real interactive launch path (not headless / UI test) —
     /// gates recording notifications and first-run onboarding.
     private var interactive = false
     private var terminationCleanupTask: Task<Void, Never>?
-    private var coreModelPreparationTask: (id: UUID, task: Task<Void, Never>)?
     /// Serializes cotyping model lifecycle transitions. A disable must finish
     /// unloading both runtimes before a rapid re-enable can prewarm a fresh
     /// model, otherwise the old and new routes can overlap in memory.
@@ -723,14 +709,9 @@ final class AppState: ObservableObject {
         calendarObserver = calendar.objectWillChange.sink { [weak self] in
             self?.objectWillChange.send()
         }
-        // A finished model download may unblock meetings parked as "waiting
-        // for models" — re-check whenever the active download set drains.
-        modelDownloadsObserver = ModelDownloadManager.shared.$progress
-            .map(\.isEmpty)
-            .removeDuplicates()
-            .dropFirst()
-            .filter { $0 }
-            .sink { [weak self] _ in self?.modelReadinessDidChange() }
+        modelRolesObserver = modelRoles.objectWillChange.sink { [weak self] in
+            self?.objectWillChange.send()
+        }
         pipeline.onArtifactsWritten = { [weak self] meeting in
             guard let self else { return }
             self.outcomeIndex.refresh(meeting: meeting)
@@ -1146,66 +1127,6 @@ final class AppState: ObservableObject {
     /// from this path.
     func processMeetingsWaitingForModels() {
         pipeline.retryJobsWaitingForModels()
-    }
-
-    /// A model became available outside settings persistence (for example an
-    /// engine-specific transcription download). Refresh AppState-derived UI
-    /// and give every parked processing job another readiness check.
-    func modelReadinessDidChange() {
-        objectWillChange.send()
-        processMeetingsWaitingForModels()
-    }
-
-    /// Start downloads for every missing core model of the current selection:
-    /// GGUFs (Think, Autocomplete) through the shared download manager and
-    /// the Transcribe model through its engine. Used by onboarding and the
-    /// Models presets so the first meeting processes the moment it ends
-    /// instead of parking on missing models.
-    func startCoreModelDownloads() {
-        let snapshot = settings
-        var ids = [snapshot.cotypingBuiltInModelID]
-        if snapshot.summarizerBackend == .builtIn { ids.append(snapshot.builtInModelID) }
-        for id in ids {
-            guard let entry = ModelCatalog.entry(id: id, custom: snapshot.customBuiltInModels),
-                  ModelCatalog.localURL(for: entry, storage: storage) == nil else { continue }
-            ModelDownloadManager.shared.download(entry, storage: storage)
-        }
-        guard !ModelReadinessSnapshot.transcriptionReady(snapshot) else {
-            coreModelPreparationTask?.task.cancel()
-            coreModelPreparationTask = nil
-            coreModelPreparationState = .idle
-            return
-        }
-
-        coreModelPreparationTask?.task.cancel()
-        let id = UUID()
-        coreModelPreparationState = .preparingTranscription
-        let task = Task { [weak self] in
-            guard let self else { return }
-            let failure: String?
-            do {
-                try await snapshot.transcriptionEngine().prepare()
-                failure = nil
-            } catch is CancellationError {
-                return
-            } catch {
-                failure = "Could not prepare \(snapshot.transcriptionModel.displayName): "
-                    + error.localizedDescription
-            }
-            guard self.coreModelPreparationTask?.id == id else { return }
-            self.coreModelPreparationTask = nil
-            if let failure {
-                self.coreModelPreparationState = .failed(failure)
-                self.lastError = failure
-            } else {
-                self.coreModelPreparationState = .idle
-            }
-            // GGUF completions re-check through the download observer; the
-            // Transcribe engine downloads outside the manager, so re-check
-            // here as well.
-            self.modelReadinessDidChange()
-        }
-        coreModelPreparationTask = (id, task)
     }
 
     func saveTranscript(_ transcript: Transcript, for meeting: Meeting) throws {

--- a/LokalBot/AppState.swift
+++ b/LokalBot/AppState.swift
@@ -356,7 +356,6 @@ final class AppState: ObservableObject {
         return controller
     }()
     private let dailyMemoryExportScheduler = DailyMemoryExportScheduler()
-    private let dayDigestScheduler = DayDigestScheduler()
     private(set) lazy var memoryRoutines = MemoryRoutineScheduler(
         storageRoot: storage.rootURL,
         databaseURL: storage.rootURL.appendingPathComponent("lokalbotv3.sqlite"),
@@ -438,6 +437,17 @@ final class AppState: ObservableObject {
         storage: storage, jobStore: pipelineJobStore) { [store = settingsStore] in
         store.current
     }
+    /// One Day Digest lifecycle for manual, scheduled, and headless callers.
+    /// It owns evidence collection, journal state, freshness, and repair policy.
+    private(set) lazy var dayDigest = DayDigestLifecycle(
+        storage: storage,
+        activityStore: activityStore,
+        pipeline: pipeline,
+        meetings: { [weak self] in
+            guard let self else { return [] }
+            return (self.currentMeeting.map { [$0] } ?? []) + self.meetings
+        },
+        settings: { [store = settingsStore] in store.current })
     /// Meeting-recording lifecycle: recorders, watchdog, timer tick, prewarm.
     private(set) lazy var recording = RecordingController(
         storage: storage,
@@ -1268,26 +1278,10 @@ final class AppState: ObservableObject {
 
     func applyDayDigestSetting() {
         let snapshot = settings
-        let storageRoot = storage.rootURL
-        dayDigestScheduler.configure(
+        dayDigest.configureAutomaticGeneration(
             DayDigestScheduler.Configuration(
                 enabled: snapshot.dayDigestAutoEnabled,
                 hour: snapshot.dayDigestHour),
-            digestModifiedAt: { day in
-                let name = DreamDay.key(for: day)
-                let url = storageRoot.appendingPathComponent("journal/\(name).md")
-                return DayDigestGenerationMetadataStore.completedAt(for: url)
-            },
-            latestEvidenceAt: { [weak self] day in
-                guard let self else { return nil }
-                let meetingEnd = self.meetings
-                    .filter { Calendar.current.isDate($0.startedAt, inSameDayAs: day) }
-                    .compactMap(\.endedAt)
-                    .max()
-                return [self.activityStore.latestEvidenceAt(on: day), meetingEnd]
-                    .compactMap { $0 }
-                    .max()
-            },
             canRun: { [weak self] in
                 guard let self, self.libraryReady else { return false }
                 // Scheduled background work never triggers a model download —
@@ -1307,25 +1301,6 @@ final class AppState: ObservableObject {
                     && !self.dictation.state.isWorking
                     && !cotypingGenerating
                     && !self.pipeline.hasActiveWork
-            },
-            generate: { [weak self] day in
-                guard let self else {
-                    throw TextEngineError.unavailable("LokalBot is shutting down.")
-                }
-                let blocks = self.activityStore.blocks(on: day)
-                let finished = self.meetings.filter {
-                    Calendar.current.isDate($0.startedAt, inSameDayAs: day)
-                        && $0.endedAt != nil
-                }
-                let screenContexts = self.activityStore.screenContexts(on: day)
-                guard !blocks.isEmpty || !finished.isEmpty || !screenContexts.isEmpty else {
-                    return .deferred
-                }
-                let result = try await self.pipeline.generateDayDigest(
-                    for: day, blocks: blocks, meetings: finished,
-                    screenContexts: screenContexts,
-                    config: self.settings)
-                return result.quality.needsRepair ? .needsRepair : .completed
             },
             onError: { [weak self] message in
                 self?.lastError = message

--- a/LokalBot/AppState.swift
+++ b/LokalBot/AppState.swift
@@ -49,13 +49,6 @@ final class AppState: ObservableObject {
         }
     }
 
-    struct AgentLaunchContext: Equatable {
-        var title: String
-        var prompt: String
-        var meetingID: Meeting.ID?
-        var actionID: String?
-    }
-
     /// Which tab the Settings surface shows (spec §2.5 — Settings absorbs
     /// Models as a tab strip). Session-sticky like TypeTab.
     enum SettingsTab: String, CaseIterable {
@@ -213,8 +206,7 @@ final class AppState: ObservableObject {
             || old.dreamingFirstEligibleDayKey != new.dreamingFirstEligibleDayKey
     }
 
-    // Navigation (main window): sidebar section, selected meeting, and a
-    // pending "jump to timestamp" handed from search to the detail player.
+    // Navigation (main window): sidebar section and selected meeting.
     @Published var navSection: NavSection = .today
     private static let typeTabDefaultsKey = "lokalbotv3.type.selectedTab"
     private static var navigationDefaults: UserDefaults {
@@ -233,29 +225,13 @@ final class AppState: ObservableObject {
     /// switch back to Ask before presenting their content.
     @Published var askMode: AskMode = .ask
     @Published var selectedMeetingIDs: Set<Meeting.ID> = []
-    @Published var pendingSeek: TimeInterval?
-    /// A screen-memory deep link waiting for Timeline's shared capture model.
-    /// Search, assistant citations, and Quick Recall set this before switching
-    /// sections; Timeline consumes it once its content column is mounted.
-    @Published var pendingScreenSnapshotID: Int64?
-
-    /// A query handed to the Ask section by another surface (⌘K palette).
-    /// AskView consumes and clears it on appear/change.
-    @Published var askPrefill: String?
-
-    /// True when an explicitly ask-labelled handoff should send immediately,
-    /// rather than merely placing text in Ask's search field.
-    @Published var askSubmitRequested = false
 
     /// A day handed to the Ask section (the old Timeline "Ask" tab, spec
     /// §2.2): rendered as a removable chip, and prepended to escalated
     /// queries so the assistant scopes its answer to that day.
     @Published var askDayScope: Date?
-    /// Screens explicitly attached from Timeline to the next Ask turn.
-    @Published var askScreenContextIDs: [Int64] = []
-    /// Contextual handoffs only prefill Agent. The subprocess starts after the
-    /// user reviews the prompt and explicitly chooses Send.
-    @Published var agentLaunchContext: AgentLaunchContext?
+    /// Atomic, destination-scoped payloads for cross-surface navigation.
+    private(set) lazy var navigationHandoff = NavigationHandoff()
 
     /// Navigate to the Type section with a specific tab preselected.
     func openType(_ tab: TypeTab) {
@@ -273,15 +249,16 @@ final class AppState: ObservableObject {
     /// scoping it to a day (Timeline's "Ask about this day").
     func openAsk(query: String = "", dayScope: Date? = nil,
                  screenSnapshotIDs: [Int64] = [], submit: Bool = false) {
-        askPrefill = query.isEmpty ? nil : query
-        askDayScope = dayScope
-        askScreenContextIDs = screenSnapshotIDs
-        askSubmitRequested = submit
+        navigationHandoff.stageAsk(
+            query: query,
+            dayScope: dayScope,
+            screenSnapshotIDs: screenSnapshotIDs,
+            submit: submit)
         navSection = .ask
     }
 
     func openAgent(_ context: AgentLaunchContext? = nil) {
-        agentLaunchContext = context
+        navigationHandoff.stageAgent(context)
         if let prompt = context?.prompt {
             agentSessions.ensureSelectedController().draft = prompt
         }
@@ -290,7 +267,8 @@ final class AppState: ObservableObject {
 
     /// Open one meeting in the Meetings section — the deep-link target
     /// for search hits, menu-bar recents, and palette recents.
-    func openMeeting(_ id: Meeting.ID) {
+    func openMeeting(_ id: Meeting.ID, seek: TimeInterval? = nil) {
+        navigationHandoff.stageMeeting(id, seek: seek)
         selectedMeetingIDs = [id]
         navSection = .meetings
     }
@@ -562,6 +540,7 @@ final class AppState: ObservableObject {
     private var audioMonitorChangeForwarder: AnyCancellable?
     private var calendarObserver: AnyCancellable?
     private var modelRolesObserver: AnyCancellable?
+    private var navigationHandoffObserver: AnyCancellable?
     /// True only on the real interactive launch path (not headless / UI test) —
     /// gates recording notifications and first-run onboarding.
     private var interactive = false
@@ -710,6 +689,9 @@ final class AppState: ObservableObject {
             self?.objectWillChange.send()
         }
         modelRolesObserver = modelRoles.objectWillChange.sink { [weak self] in
+            self?.objectWillChange.send()
+        }
+        navigationHandoffObserver = navigationHandoff.objectWillChange.sink { [weak self] in
             self?.objectWillChange.send()
         }
         pipeline.onArtifactsWritten = { [weak self] meeting in
@@ -1389,15 +1371,14 @@ final class AppState: ObservableObject {
 
     /// Search hit → open the meeting; transcript hits seek the player.
     func openSearchHit(_ hit: SearchIndex.Hit) {
-        if hit.kind == .segment {
-            pendingSeek = hit.start
-        }
-        openMeeting(hit.meetingID)
+        openMeeting(
+            hit.meetingID,
+            seek: hit.kind == .segment ? hit.start : nil)
     }
 
     /// Screen search/citation hit → open Timeline at the exact captured frame.
     func openScreenSnapshot(_ snapshotID: Int64) {
-        pendingScreenSnapshotID = snapshotID
+        navigationHandoff.stageScreenSnapshot(snapshotID)
         selectedMeetingIDs = []
         navSection = .timeline
     }
@@ -1405,10 +1386,7 @@ final class AppState: ObservableObject {
     /// Chat citation marker → open the cited meeting; timed markers seek the player.
     func openCitation(_ citation: ChatCitation) {
         guard let meeting = ((try? SessionLookup.find(id: citation.meetingID, in: meetings)) ?? nil) else { return }
-        if let seconds = citation.seconds {
-            pendingSeek = seconds
-        }
-        openMeeting(meeting.id)
+        openMeeting(meeting.id, seek: citation.seconds)
     }
 
     /// Permanently removes meetings: audio folder, list entry, both indexes.

--- a/LokalBot/Cotyping/CotypingEngine.swift
+++ b/LokalBot/Cotyping/CotypingEngine.swift
@@ -130,7 +130,7 @@ extension CotypingCompleting {
 @MainActor
 final class CotypingEngine: CotypingCompleting {
     /// Resolves the active `TextEngine`. In production this is
-    /// `ProcessingPipeline.makeTextEngine(settings)`, which also boots the
+    /// `ThinkExecution.makeTextEngine(settings)`, which also boots the
     /// built-in llama-server with the selected model on first use.
     private let makeEngine: () async throws -> TextEngine
     private let stopRuntime: () async -> Void

--- a/LokalBot/Engines/TextEngine.swift
+++ b/LokalBot/Engines/TextEngine.swift
@@ -517,6 +517,7 @@ struct OpenAICompatibleEngine: TextEngine {
                 dialect: chatDialect,
                 error: error,
                 usedFallback: openRouterReasoning == .highEffort,
+                requestedSchema: schema != nil,
                 requestedReasoningBudget: options?.reasoningBudgetTokens)
             else { throw error }
             lokalbotLog("openrouter reasoning fallback effort=high model=\(model)")
@@ -722,11 +723,12 @@ struct OpenAICompatibleEngine: TextEngine {
         dialect: ChatCompletionDialect,
         error: Error,
         usedFallback: Bool,
+        requestedSchema: Bool,
         requestedReasoningBudget: Int?
     ) -> Bool {
         guard dialect == .openRouter,
               !usedFallback,
-              requestedReasoningBudget != nil,
+              requestedSchema || requestedReasoningBudget != nil,
               case .httpStatus(let code, let detail, _) = error as? TextEngineError,
               code == 404
         else { return false }

--- a/LokalBot/Engines/ThinkExecution.swift
+++ b/LokalBot/Engines/ThinkExecution.swift
@@ -1,0 +1,263 @@
+import Foundation
+
+struct AgentLLMConnection: Equatable, Sendable {
+    let endpoint: AgentLLMEndpoint
+    let lease: InferenceLease?
+}
+
+enum ThinkExecutionError: LocalizedError, Sendable {
+    case invalidConfiguration
+    case agentConfiguration(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration:
+            "Invalid LLM server URL in Settings → Models."
+        case .agentConfiguration(let reason):
+            reason
+        }
+    }
+}
+
+/// The complete execution boundary for LokalBot's Think role: backend
+/// selection, local model preparation, endpoint privacy checks, runtime
+/// leases, managed recovery, and Agent Mode endpoint resolution.
+@MainActor
+final class ThinkExecution {
+    typealias BuiltInModelPreparer = (
+        ModelCatalog.Entry,
+        StorageManager
+    ) async throws -> URL
+
+    private let storage: StorageManager
+    private let builtInModelPreparer: BuiltInModelPreparer
+
+    init(
+        storage: StorageManager,
+        builtInModelPreparer: @escaping BuiltInModelPreparer = { entry, storage in
+            try await ModelDownloadManager.shared.ensureAvailable(entry, storage: storage)
+        }
+    ) {
+        self.storage = storage
+        self.builtInModelPreparer = builtInModelPreparer
+    }
+
+    func makeTextEngine(
+        _ settings: AppSettings,
+        server: LlamaServer = .shared,
+        priority: InferencePriority = .background,
+        purpose: String = "summary",
+        broker: InferenceBroker = .shared
+    ) async throws -> TextEngine {
+        switch settings.summarizerBackend {
+        case .builtIn:
+            let entry = try builtInEntry(settings)
+            let modelURL = try await prepareBuiltInModel(settings)
+            let authenticationToken = await server.authenticationToken()
+            let engine = OpenAICompatibleEngine(
+                baseURL: server.baseURL,
+                model: entry.id,
+                apiKey: authenticationToken,
+                extraBody: MainLLMRuntimePolicy.requestOverrides(for: entry.id),
+                chatDialect: .llamaServer,
+                defaultThinkingBudgetTokens:
+                    MainLLMRuntimePolicy.highReasoningBudgetTokens,
+                displayNameOverride: "Built-in — \(entry.displayName)")
+            guard let role = InferenceRole(serverPort: server.port) else {
+                try await server.ensureRunning(modelAt: modelURL)
+                return engine
+            }
+            return LeasedTextEngine(
+                base: engine,
+                broker: broker,
+                role: role,
+                modelURL: modelURL,
+                priority: priority,
+                purpose: purpose)
+
+        case .appleIntelligence:
+            if case .unavailable(let reason) = FoundationModelAvailability.current() {
+                throw TextEngineError.unavailable(reason)
+            }
+            return AppleIntelligenceEngine()
+
+        case .ollama:
+            guard let url = URL(string: settings.ollamaBaseURL) else {
+                throw ThinkExecutionError.invalidConfiguration
+            }
+            try InferenceEndpointPolicy.validate(
+                url,
+                approvedOrigins: settings.approvedRemoteInferenceOrigins)
+            var model = settings.ollamaModel
+            if model.isEmpty {
+                model = await OllamaEngine.listModels(baseURL: url).first ?? ""
+            }
+            return OllamaEngine(baseURL: url, model: model)
+
+        case .openAICompatible:
+            guard let url = URL(string: settings.openAIBaseURL) else {
+                throw ThinkExecutionError.invalidConfiguration
+            }
+            try InferenceEndpointPolicy.validate(
+                url,
+                approvedOrigins: settings.approvedRemoteInferenceOrigins)
+            return OpenAICompatibleEngine(
+                baseURL: url,
+                model: settings.openAIModel,
+                apiKey: settings.openAIAPIKey,
+                chatDialect: .inferred(from: url))
+        }
+    }
+
+    /// Ensure the selected built-in model is present before the first request.
+    /// The shared download manager coalesces callers and validates pinned model
+    /// digests before returning the local URL.
+    @discardableResult
+    func prepareBuiltInModel(_ settings: AppSettings) async throws -> URL {
+        try await builtInModelPreparer(try builtInEntry(settings), storage)
+    }
+
+    /// A built-in request already gets one managed server relaunch and replay
+    /// inside `LeasedTextEngine`; never stack the provider retry on top of it.
+    func retryDelay(
+        for error: Error,
+        settings: AppSettings,
+        attempt: Int,
+        jitter: TimeInterval = Double.random(in: 0...0.5)
+    ) -> TimeInterval? {
+        if settings.summarizerBackend == .builtIn,
+           let engineError = error as? TextEngineError,
+           case .serverUnreachable = engineError {
+            return nil
+        }
+        return TextEngineRetryPolicy.delay(
+            for: error,
+            attempt: attempt,
+            jitter: jitter)
+    }
+
+    /// Resolve and, for the built-in backend, lease the endpoint used for one
+    /// Agent Mode session. Remote endpoints pass through the same approval and
+    /// encrypted-transport policy as the rest of the Think role.
+    func prepareAgentConnection(
+        settings: AppSettings,
+        broker: InferenceBroker = .shared,
+        server: LlamaServer = .shared
+    ) async throws -> AgentLLMConnection {
+        switch Self.agentResolution(settings: settings) {
+        case .ready(let endpoint):
+            return AgentLLMConnection(endpoint: endpoint, lease: nil)
+
+        case .builtIn(let modelID):
+            guard let entry = ModelCatalog.entry(
+                id: modelID,
+                custom: settings.customBuiltInModels) ?? ModelCatalog.entry(id: modelID),
+                let modelURL = await ModelDownloadManager.shared.verifiedExistingURL(
+                    entry,
+                    storage: storage) else {
+                throw ThinkExecutionError.agentConfiguration(
+                    "The built-in model isn't downloaded yet. Download it under Settings → Models.")
+            }
+            let lease = try await broker.lease(
+                .mainLLM,
+                model: modelURL,
+                priority: .interactive,
+                purpose: "agent session")
+            let authenticationToken = await server.authenticationToken()
+            let endpoint = AgentLLMEndpoint(
+                baseURL: server.baseURL,
+                model: entry.id,
+                contextTokens: AgentLLMEndpoint.defaultContextTokens,
+                apiKey: authenticationToken)
+            return AgentLLMConnection(endpoint: endpoint, lease: lease)
+
+        case .unsupported(let reason):
+            throw ThinkExecutionError.agentConfiguration(reason)
+        }
+    }
+
+    /// Pure settings-to-endpoint resolution shared by Agent Mode and the
+    /// external agent-access wake path. Runtime acquisition remains explicit.
+    nonisolated static func agentResolution(
+        settings: AppSettings
+    ) -> AgentLLMResolution {
+        switch settings.summarizerBackend {
+        case .builtIn:
+            guard let entry = ModelCatalog.entry(
+                id: settings.builtInModelID,
+                custom: settings.customBuiltInModels)
+                    ?? ModelCatalog.entry(id: ModelCatalog.recommendedSummarizationID) else {
+                return .unsupported(
+                    reason: "No built-in model is configured. Pick one under Settings → Models.")
+            }
+            return .builtIn(modelID: entry.id)
+
+        case .appleIntelligence:
+            return .unsupported(
+                reason: "Apple Intelligence doesn't expose a local endpoint Agent Mode can use. Switch the Main LLM engine to Built-in (on-device), Ollama, or an OpenAI-compatible server under Settings → Models.")
+
+        case .ollama:
+            guard let base = URL(string: settings.ollamaBaseURL) else {
+                return .unsupported(
+                    reason: "The Ollama server URL under Settings → Models isn't a valid URL.")
+            }
+            guard InferenceEndpointPolicy.isAllowed(
+                base,
+                approvedOrigins: settings.approvedRemoteInferenceOrigins) else {
+                return .unsupported(
+                    reason: "Approve this remote Ollama server under Settings → Models before Agent Mode sends context to it.")
+            }
+            guard InferenceEndpointPolicy.isLoopback(base)
+                    || base.scheme?.lowercased() == "https" else {
+                return .unsupported(
+                    reason: "Remote Ollama servers must use HTTPS so meeting context is encrypted in transit.")
+            }
+            guard !settings.ollamaModel.isEmpty else {
+                return .unsupported(
+                    reason: "Pick an Ollama model under Settings → Models — Agent Mode needs an explicit model.")
+            }
+            return .ready(AgentLLMEndpoint(
+                baseURL: base.appendingPathComponent("v1"),
+                model: settings.ollamaModel,
+                contextTokens: AgentLLMEndpoint.defaultContextTokens,
+                apiKey: nil))
+
+        case .openAICompatible:
+            guard let base = URL(string: settings.openAIBaseURL) else {
+                return .unsupported(
+                    reason: "The server URL under Settings → Models isn't a valid URL.")
+            }
+            guard InferenceEndpointPolicy.isAllowed(
+                base,
+                approvedOrigins: settings.approvedRemoteInferenceOrigins) else {
+                return .unsupported(
+                    reason: "Approve this remote inference server under Settings → Models before Agent Mode sends context to it.")
+            }
+            guard InferenceEndpointPolicy.isLoopback(base)
+                    || base.scheme?.lowercased() == "https" else {
+                return .unsupported(
+                    reason: "Remote inference servers must use HTTPS; LokalBot will not send meeting context or API keys over HTTP.")
+            }
+            guard !settings.openAIModel.isEmpty else {
+                return .unsupported(
+                    reason: "Set a model name for the OpenAI-compatible server under Settings → Models.")
+            }
+            let key = settings.openAIAPIKey
+            return .ready(AgentLLMEndpoint(
+                baseURL: base,
+                model: settings.openAIModel,
+                contextTokens: AgentLLMEndpoint.defaultContextTokens,
+                apiKey: key.isEmpty ? nil : key))
+        }
+    }
+
+    private func builtInEntry(_ settings: AppSettings) throws -> ModelCatalog.Entry {
+        guard let entry = ModelCatalog.entry(
+            id: settings.builtInModelID,
+            custom: settings.customBuiltInModels)
+                ?? ModelCatalog.entry(id: ModelCatalog.recommendedSummarizationID) else {
+            throw ThinkExecutionError.invalidConfiguration
+        }
+        return entry
+    }
+}

--- a/LokalBot/HeadlessCommands.swift
+++ b/LokalBot/HeadlessCommands.swift
@@ -259,8 +259,8 @@ struct HeadlessCommandRunner {
                 let service = DreamService(
                     storageRoot: app.storage.rootURL,
                     makeEngine: {
-                        let settings = await app.settings
-                        let engine = try await app.pipeline.makeTextEngine(
+                        let settings = app.settings
+                        let engine = try await app.thinkExecution.makeTextEngine(
                             settings, purpose: "dreaming")
                         return (engine, DreamInferenceProvenance(settings: settings))
                     })
@@ -287,7 +287,7 @@ struct HeadlessCommandRunner {
         Task { @MainActor in
             do {
                 app.searchIndex.reindexAll(app.meetings, storage: app.storage)
-                let engine = try await app.pipeline.makeTextEngine(app.settings)
+                let engine = try await app.thinkExecution.makeTextEngine(app.settings)
                 let tools = MeetingChatTools(
                     meetings: { [weak app] in app?.meetings ?? [] },
                     storage: app.storage, searchIndex: app.searchIndex, embeddingIndex: app.embeddingIndex,

--- a/LokalBot/HeadlessCommands.swift
+++ b/LokalBot/HeadlessCommands.swift
@@ -97,6 +97,18 @@ enum DreamDayArgumentError: LocalizedError, Equatable {
     }
 }
 
+enum DayDigestCLIOutput {
+    static func render(
+        result: DayDigestGenerationResult,
+        modelID: String,
+        day: Date
+    ) -> String {
+        "LokalBot --digest: \(result.url.path) "
+            + "(\(result.text.count) chars; model=\(modelID); "
+            + "day=\(DreamDay.key(for: day)))"
+    }
+}
+
 /// Executes headless subcommands against the app's real subsystems (pipeline,
 /// indexes, recorder). Test hooks for CI and `Scripts/e2e.sh` — the same code
 /// paths as the UI, no window required.
@@ -212,18 +224,11 @@ struct HeadlessCommandRunner {
                     config.builtInModelID = modelID
                     config.dayDigestCustomPrompt = ""
                 }
-                let todays = app.meetings.filter {
-                    Calendar.current.isDate($0.startedAt, inSameDayAs: day)
-                        && $0.endedAt != nil
-                }
-                let result = try await app.pipeline.generateDayDigest(
-                    for: day, blocks: app.activityStore.blocks(on: day),
-                    meetings: todays,
-                    screenContexts: app.activityStore.screenContexts(on: day),
-                    config: config)
-                print("LokalBot --digest: model=\(config.builtInModelID) "
-                      + "day=\(DreamDay.key(for: day)) \(result.url.path) "
-                      + "(\(result.text.count) chars)")
+                let result = try await app.dayDigest.generate(for: day, settings: config)
+                print(DayDigestCLIOutput.render(
+                    result: result,
+                    modelID: config.builtInModelID,
+                    day: day))
                 await LlamaServer.shared.stop()
                 exit(0)
             } catch {

--- a/LokalBot/Models/ModelReadinessSnapshot.swift
+++ b/LokalBot/Models/ModelReadinessSnapshot.swift
@@ -111,15 +111,18 @@ struct ModelReadinessSnapshot: Equatable, Sendable {
         }.reduce(Int64(0)) { $0 + Int64($1.sizeBytes ?? 0) }
     }
 
-    @MainActor
-    static func make(app: AppState, downloads: ModelDownloadManager) -> Self {
-        let settings = app.settings
+    static func make(
+        settings: AppSettings,
+        storage: StorageManager,
+        activeDownloads: Int,
+        failedDownloads: Int
+    ) -> Self {
         let transcriptionReady = transcriptionReady(settings)
-        let thinkReady = thinkReady(settings, storage: app.storage)
-        let autocompleteReady = autocompleteReady(settings, storage: app.storage)
+        let thinkReady = thinkReady(settings, storage: storage)
+        let autocompleteReady = autocompleteReady(settings, storage: storage)
         let provenance: Provenance = settings.summarizerBackend == .builtIn
             ? .local : .externalThink(settings.summarizerBackend.displayName)
-        let modelsFolder = app.storage.rootURL.appendingPathComponent("models", isDirectory: true)
+        let modelsFolder = storage.rootURL.appendingPathComponent("models", isDirectory: true)
         return Self(
             transcriptionReady: transcriptionReady,
             thinkReady: thinkReady,
@@ -127,8 +130,8 @@ struct ModelReadinessSnapshot: Equatable, Sendable {
             provenance: provenance,
             storedBytes: directoryBytes(modelsFolder),
             availableBytes: DiskSpacePrecheck.availableBytes(at: modelsFolder),
-            activeDownloads: downloads.progress.count,
-            failedDownloads: downloads.errors.values.filter { !$0.isEmpty }.count)
+            activeDownloads: activeDownloads,
+            failedDownloads: failedDownloads)
     }
 
     private static func directoryBytes(_ root: URL) -> Int64 {

--- a/LokalBot/Models/ModelRoles.swift
+++ b/LokalBot/Models/ModelRoles.swift
@@ -103,6 +103,7 @@ final class ModelRoles: ObservableObject {
         TranscriptionModelChoice,
         ModelPreparationProgressHandler?
     ) async throws -> Void
+    typealias DownloadedTranscriptionModels = @MainActor (AppSettings) -> Set<String>
 
     @Published private(set) var downloadProgress: [String: Double]
     @Published private(set) var downloadErrors: [String: String]
@@ -114,6 +115,7 @@ final class ModelRoles: ObservableObject {
     private let storage: StorageManager
     private let downloads: ModelDownloadManager
     private let prepareTranscription: PrepareTranscription
+    private let downloadedTranscriptionModels: DownloadedTranscriptionModels
     private let onReadinessChanged: () -> Void
     private var downloadObserver: AnyCancellable?
     private var preparationTask: (id: String, token: UUID, task: Task<Void, Never>)?
@@ -123,6 +125,7 @@ final class ModelRoles: ObservableObject {
         storage: StorageManager,
         downloads: ModelDownloadManager? = nil,
         prepareTranscription: PrepareTranscription? = nil,
+        downloadedTranscriptionModels: DownloadedTranscriptionModels? = nil,
         onReadinessChanged: @escaping () -> Void
     ) {
         let downloads = downloads ?? ModelDownloadManager.shared
@@ -133,6 +136,10 @@ final class ModelRoles: ObservableObject {
         self.downloadErrors = downloads.errors
         self.prepareTranscription = prepareTranscription ?? { settings, choice, progress in
             try await settings.transcriptionEngine(for: choice).prepare(progress: progress)
+        }
+        self.downloadedTranscriptionModels = downloadedTranscriptionModels ?? { settings in
+            TranscriptionModelStore.downloadedChoices(
+                graniteConfiguration: settings.graniteSpeechModel)
         }
         self.onReadinessChanged = onReadinessChanged
         downloadObserver = downloads.$progress
@@ -150,15 +157,20 @@ final class ModelRoles: ObservableObject {
 
     var snapshot: ModelRolesSnapshot {
         let settings = settings()
-        let readiness = ModelReadinessSnapshot.make(
+        let downloadedTranscriptionModelIDs = downloadedTranscriptionModels(settings)
+        var readiness = ModelReadinessSnapshot.make(
             settings: settings,
             storage: storage,
             activeDownloads: downloadProgress.count,
             failedDownloads: downloadErrors.values.filter { !$0.isEmpty }.count)
+        readiness.transcriptionReady = downloadedTranscriptionModelIDs.contains(
+            settings.transcriptionModel.id)
         return ModelRolesSnapshot(
             readiness: readiness,
             statuses: [
-                .transcribe: transcriptionStatus(for: settings.transcriptionModel),
+                .transcribe: transcriptionStatus(
+                    for: settings.transcriptionModel,
+                    downloadedIDs: downloadedTranscriptionModelIDs),
                 .think: ggufStatus(
                     ready: readiness.thinkReady,
                     id: settings.summarizerBackend == .builtIn
@@ -170,27 +182,42 @@ final class ModelRoles: ObservableObject {
     }
 
     var downloadedTranscriptionModelIDs: Set<String> {
-        TranscriptionModelStore.downloadedChoices(
-            graniteConfiguration: settings().graniteSpeechModel)
+        downloadedTranscriptionModels(settings())
     }
 
     var isPreparingTranscription: Bool { preparationTask != nil }
 
     func transcriptionStatus(for choice: TranscriptionModelChoice) -> ModelRoleStatus {
+        transcriptionStatus(for: choice, downloadedIDs: downloadedTranscriptionModelIDs)
+    }
+
+    private func transcriptionStatus(
+        for choice: TranscriptionModelChoice,
+        downloadedIDs: Set<String>
+    ) -> ModelRoleStatus {
         if let preparation = transcriptionPreparations[choice.id] {
             return .preparing(progress: preparation.progress, label: preparation.label)
         }
         if let error = transcriptionErrors[choice.id], !error.isEmpty {
             return .needsAttention(error)
         }
-        return downloadedTranscriptionModelIDs.contains(choice.id) ? .ready : .unavailable
+        return downloadedIDs.contains(choice.id) ? .ready : .unavailable
     }
 
     func settingsDidChange(from old: AppSettings, to new: AppSettings) {
         guard ModelReadinessSnapshot.processingReadinessChanged(from: old, to: new)
                 || old.cotypingBuiltInModelID != new.cotypingBuiltInModelID else { return }
-        if old.transcriptionModel != new.transcriptionModel
-            || old.graniteSpeechModel != new.graniteSpeechModel {
+        let selectionChanged = old.transcriptionModel != new.transcriptionModel
+        let graniteConfigurationChanged = old.graniteSpeechModel != new.graniteSpeechModel
+        if graniteConfigurationChanged {
+            transcriptionErrors[TranscriptionModelChoice.graniteSpeech.id] = nil
+        }
+        let changedAwayFromActiveSelection = selectionChanged
+            && preparationTask?.id == old.transcriptionModel.id
+            && preparationTask?.id != new.transcriptionModel.id
+        let invalidatedActiveGranitePreparation = graniteConfigurationChanged
+            && preparationTask?.id == TranscriptionModelChoice.graniteSpeech.id
+        if changedAwayFromActiveSelection || invalidatedActiveGranitePreparation {
             cancelPreparation()
         }
         revision &+= 1
@@ -213,12 +240,21 @@ final class ModelRoles: ObservableObject {
                 ModelCatalog.localURL(for: entry, storage: storage) == nil else { continue }
             downloads.download(entry, storage: storage)
         }
-        if ModelReadinessSnapshot.transcriptionReady(settings) {
-            cancelPreparation()
+        let selectedTranscriptionID = settings.transcriptionModel.id
+        let transcriptionIsDownloaded = downloadedTranscriptionModels(settings)
+            .contains(selectedTranscriptionID)
+        let transcriptionHasError = transcriptionErrors[selectedTranscriptionID]
+            .map { !$0.isEmpty } ?? false
+        if transcriptionIsDownloaded && !transcriptionHasError {
             readinessDidChange()
         } else {
             prepareTranscriptionModel(settings.transcriptionModel)
         }
+    }
+
+    func deleteGGUFModel(_ entry: ModelCatalog.Entry) {
+        downloads.delete(entry, storage: storage)
+        readinessDidChange()
     }
 
     func prepareTranscriptionModel(_ choice: TranscriptionModelChoice) {

--- a/LokalBot/Models/ModelRoles.swift
+++ b/LokalBot/Models/ModelRoles.swift
@@ -1,0 +1,288 @@
+import Combine
+import Foundation
+
+enum ModelRole: String, CaseIterable, Hashable, Sendable {
+    case transcribe
+    case think
+    case autocomplete
+}
+
+enum ModelRoleStatus: Equatable, Sendable {
+    case unavailable
+    case downloading(progress: Double?)
+    case preparing(progress: Double?, label: String)
+    case ready
+    case needsAttention(String)
+
+    var isReady: Bool { self == .ready }
+
+    var isWorking: Bool {
+        switch self {
+        case .downloading, .preparing: true
+        case .unavailable, .ready, .needsAttention: false
+        }
+    }
+
+    var progress: Double? {
+        switch self {
+        case .downloading(let progress), .preparing(let progress, _): progress
+        case .unavailable, .ready, .needsAttention: nil
+        }
+    }
+
+    var errorMessage: String? {
+        if case .needsAttention(let message) = self { return message }
+        return nil
+    }
+
+    var label: String {
+        switch self {
+        case .unavailable:
+            "Download required"
+        case .downloading(let progress):
+            progress.map { "Downloading… \(Int($0 * 100))%" } ?? "Downloading…"
+        case .preparing(_, let label):
+            label
+        case .ready:
+            "Ready"
+        case .needsAttention:
+            "Needs attention"
+        }
+    }
+}
+
+struct ModelRolesSnapshot: Equatable, Sendable {
+    var readiness: ModelReadinessSnapshot
+    var statuses: [ModelRole: ModelRoleStatus]
+
+    subscript(_ role: ModelRole) -> ModelRoleStatus {
+        statuses[role] ?? .unavailable
+    }
+
+    var coreReady: Bool { ModelRole.allCases.allSatisfy { self[$0].isReady } }
+    var headline: String { readiness.headline }
+    var storageSummary: String { readiness.storageSummary }
+    var activeDownloads: Int { readiness.activeDownloads }
+    var failedDownloads: Int { readiness.failedDownloads }
+
+    var detail: String {
+        if coreReady { return readiness.detail }
+        if let working = ModelRole.allCases.lazy.map({ self[$0] }).first(where: \.isWorking) {
+            return working.label
+        }
+        if ModelRole.allCases.contains(where: { self[$0].errorMessage != nil }) {
+            return "A selected model needs attention before the stack is ready."
+        }
+        return readiness.detail
+    }
+
+    var primaryActionStatus: ModelRoleStatus {
+        if coreReady { return .ready }
+        if let error = ModelRole.allCases.lazy.compactMap({ self[$0].errorMessage }).first {
+            return .needsAttention(error)
+        }
+        if let working = ModelRole.allCases.lazy.map({ self[$0] }).first(where: \.isWorking) {
+            return working
+        }
+        return .unavailable
+    }
+}
+
+/// Owns selection readiness, model preparation, progress, failures, and the
+/// wake-up signal for work parked behind missing models. Onboarding, Settings,
+/// and automation all read the same role lifecycle through this interface.
+@MainActor
+final class ModelRoles: ObservableObject {
+    struct TranscriptionPreparation: Equatable, Sendable {
+        var progress: Double?
+        var label: String
+    }
+
+    typealias PrepareTranscription = @MainActor (
+        AppSettings,
+        TranscriptionModelChoice,
+        ModelPreparationProgressHandler?
+    ) async throws -> Void
+
+    @Published private(set) var downloadProgress: [String: Double]
+    @Published private(set) var downloadErrors: [String: String]
+    @Published private(set) var transcriptionPreparations: [String: TranscriptionPreparation] = [:]
+    @Published private(set) var transcriptionErrors: [String: String] = [:]
+    @Published private(set) var revision = 0
+
+    private let settings: () -> AppSettings
+    private let storage: StorageManager
+    private let downloads: ModelDownloadManager
+    private let prepareTranscription: PrepareTranscription
+    private let onReadinessChanged: () -> Void
+    private var downloadObserver: AnyCancellable?
+    private var preparationTask: (id: String, token: UUID, task: Task<Void, Never>)?
+
+    init(
+        settings: @escaping () -> AppSettings,
+        storage: StorageManager,
+        downloads: ModelDownloadManager? = nil,
+        prepareTranscription: PrepareTranscription? = nil,
+        onReadinessChanged: @escaping () -> Void
+    ) {
+        let downloads = downloads ?? ModelDownloadManager.shared
+        self.settings = settings
+        self.storage = storage
+        self.downloads = downloads
+        self.downloadProgress = downloads.progress
+        self.downloadErrors = downloads.errors
+        self.prepareTranscription = prepareTranscription ?? { settings, choice, progress in
+            try await settings.transcriptionEngine(for: choice).prepare(progress: progress)
+        }
+        self.onReadinessChanged = onReadinessChanged
+        downloadObserver = downloads.$progress
+            .combineLatest(downloads.$errors)
+            .dropFirst()
+            .sink { [weak self] progress, errors in
+                guard let self else { return }
+                let completedDownloads = !self.downloadProgress.isEmpty && progress.isEmpty
+                self.downloadProgress = progress
+                self.downloadErrors = errors
+                self.revision &+= 1
+                if completedDownloads { self.onReadinessChanged() }
+            }
+    }
+
+    var snapshot: ModelRolesSnapshot {
+        let settings = settings()
+        let readiness = ModelReadinessSnapshot.make(
+            settings: settings,
+            storage: storage,
+            activeDownloads: downloadProgress.count,
+            failedDownloads: downloadErrors.values.filter { !$0.isEmpty }.count)
+        return ModelRolesSnapshot(
+            readiness: readiness,
+            statuses: [
+                .transcribe: transcriptionStatus(for: settings.transcriptionModel),
+                .think: ggufStatus(
+                    ready: readiness.thinkReady,
+                    id: settings.summarizerBackend == .builtIn
+                        ? settings.builtInModelID : nil),
+                .autocomplete: ggufStatus(
+                    ready: readiness.autocompleteReady,
+                    id: settings.cotypingBuiltInModelID),
+            ])
+    }
+
+    var downloadedTranscriptionModelIDs: Set<String> {
+        TranscriptionModelStore.downloadedChoices(
+            graniteConfiguration: settings().graniteSpeechModel)
+    }
+
+    var isPreparingTranscription: Bool { preparationTask != nil }
+
+    func transcriptionStatus(for choice: TranscriptionModelChoice) -> ModelRoleStatus {
+        if let preparation = transcriptionPreparations[choice.id] {
+            return .preparing(progress: preparation.progress, label: preparation.label)
+        }
+        if let error = transcriptionErrors[choice.id], !error.isEmpty {
+            return .needsAttention(error)
+        }
+        return downloadedTranscriptionModelIDs.contains(choice.id) ? .ready : .unavailable
+    }
+
+    func settingsDidChange(from old: AppSettings, to new: AppSettings) {
+        guard ModelReadinessSnapshot.processingReadinessChanged(from: old, to: new)
+                || old.cotypingBuiltInModelID != new.cotypingBuiltInModelID else { return }
+        if old.transcriptionModel != new.transcriptionModel
+            || old.graniteSpeechModel != new.graniteSpeechModel {
+            cancelPreparation()
+        }
+        revision &+= 1
+        onReadinessChanged()
+    }
+
+    func readinessDidChange() {
+        revision &+= 1
+        onReadinessChanged()
+    }
+
+    func startCoreModelDownloads() {
+        let settings = settings()
+        var ids = [settings.cotypingBuiltInModelID]
+        if settings.summarizerBackend == .builtIn { ids.append(settings.builtInModelID) }
+        for id in ids {
+            guard let entry = ModelCatalog.entry(
+                id: id,
+                custom: settings.customBuiltInModels),
+                ModelCatalog.localURL(for: entry, storage: storage) == nil else { continue }
+            downloads.download(entry, storage: storage)
+        }
+        if ModelReadinessSnapshot.transcriptionReady(settings) {
+            cancelPreparation()
+            readinessDidChange()
+        } else {
+            prepareTranscriptionModel(settings.transcriptionModel)
+        }
+    }
+
+    func prepareTranscriptionModel(_ choice: TranscriptionModelChoice) {
+        guard preparationTask == nil else { return }
+        let configuration = settings()
+        let token = UUID()
+        transcriptionErrors[choice.id] = nil
+        transcriptionPreparations[choice.id] = .init(
+            progress: nil,
+            label: "Preparing…")
+        let task = Task { [weak self] in
+            guard let self else { return }
+            let failure: String?
+            do {
+                try await self.prepareTranscription(configuration, choice) { [weak self] update in
+                    guard let self,
+                          self.preparationTask?.token == token else { return }
+                    self.transcriptionPreparations[choice.id] = .init(
+                        progress: update.fractionCompleted,
+                        label: update.status)
+                }
+                failure = nil
+            } catch is CancellationError {
+                return
+            } catch {
+                let displayName = choice == .graniteSpeech
+                    ? configuration.graniteSpeechModel.displayName
+                    : choice.displayName
+                failure = "Could not prepare \(displayName): \(error.localizedDescription)"
+            }
+            guard self.preparationTask?.token == token else { return }
+            self.preparationTask = nil
+            self.transcriptionPreparations[choice.id] = nil
+            self.transcriptionErrors[choice.id] = failure
+            self.readinessDidChange()
+        }
+        preparationTask = (choice.id, token, task)
+    }
+
+    func deleteTranscriptionModel(_ choice: TranscriptionModelChoice) {
+        if preparationTask?.id == choice.id { cancelPreparation() }
+        do {
+            try TranscriptionModelStore.delete(
+                choice,
+                graniteConfiguration: settings().graniteSpeechModel)
+            transcriptionErrors[choice.id] = nil
+            readinessDidChange()
+        } catch {
+            transcriptionErrors[choice.id] = error.localizedDescription
+        }
+    }
+
+    private func ggufStatus(ready: Bool, id: String?) -> ModelRoleStatus {
+        if ready { return .ready }
+        guard let id else { return .unavailable }
+        if let progress = downloadProgress[id] { return .downloading(progress: progress) }
+        if let error = downloadErrors[id], !error.isEmpty { return .needsAttention(error) }
+        return .unavailable
+    }
+
+    private func cancelPreparation() {
+        guard let preparationTask else { return }
+        preparationTask.task.cancel()
+        transcriptionPreparations[preparationTask.id] = nil
+        self.preparationTask = nil
+    }
+}

--- a/LokalBot/Services/AgentAccessManager.swift
+++ b/LokalBot/Services/AgentAccessManager.swift
@@ -128,7 +128,7 @@ final class AgentAccessManager: ObservableObject {
         settings: AppSettings,
         storage: StorageManager
     ) async -> ResolvedBuiltInModel {
-        switch AgentLLMEndpointResolver.resolve(settings: settings) {
+        switch ThinkExecution.agentResolution(settings: settings) {
         case .builtIn(let modelID):
             guard let entry = ModelCatalog.entry(
                 id: modelID,

--- a/LokalBot/Services/Calendar/UpcomingMeetingPreparation.swift
+++ b/LokalBot/Services/Calendar/UpcomingMeetingPreparation.swift
@@ -585,7 +585,7 @@ final class UpcomingMeetingPreparationModel: ObservableObject {
             if generatingSignature == signature { generatingSignature = nil }
         }
         do {
-            let engine = try await app.pipeline.makeTextEngine(
+            let engine = try await app.thinkExecution.makeTextEngine(
                 app.settings,
                 priority: .background,
                 purpose: "pre-meeting brief")

--- a/LokalBot/Services/Chat/ChatViewModel.swift
+++ b/LokalBot/Services/Chat/ChatViewModel.swift
@@ -168,7 +168,7 @@ final class ChatStore {
 
 /// Drives the Chat section: owns the message list and runs `ChatAgent` against
 /// the same `TextEngine` the summariser uses (resolved lazily per send via
-/// `ProcessingPipeline.makeTextEngine`, so it always reflects the current
+/// `ThinkExecution.makeTextEngine`, so it always reflects the current
 /// Settings → Models choice and boots the built-in server on first use).
 @MainActor
 final class ChatViewModel: ObservableObject {

--- a/LokalBot/Services/DayDigestEvidence.swift
+++ b/LokalBot/Services/DayDigestEvidence.swift
@@ -21,6 +21,21 @@ struct DayDigestMeetingEvidence: Equatable, Sendable {
     var endedAt: Date
     var sourceSummary: String
     var outcomes: String
+    /// Latest write among the summary/outcomes files consumed for this meeting.
+    /// It is evidence even when the meeting's own end time is unchanged.
+    var artifactModifiedAt: Date?
+}
+
+enum DayDigestMeetingArtifacts {
+    static let fileNames = ["summary.md", MeetingOutcomes.fileName]
+
+    static func latestModifiedAt(in folder: URL) -> Date? {
+        fileNames.compactMap { name -> Date? in
+            let url = folder.appendingPathComponent(name)
+            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+            return attributes?[.modificationDate] as? Date
+        }.max()
+    }
 }
 
 /// One deterministic slice of the day that receives a substantive-work
@@ -63,7 +78,8 @@ struct DayDigestEvidence: Equatable, Sendable {
         let activityEnd = activities.map(\.end).max()
         let contextCapture = standaloneContexts.map(\.capturedAt).max()
         let meetingEnd = meetings.map(\.endedAt).max()
-        return [activityEnd, contextCapture, meetingEnd]
+        let meetingArtifact = meetings.compactMap(\.artifactModifiedAt).max()
+        return [activityEnd, contextCapture, meetingEnd, meetingArtifact]
             .compactMap { $0 }
             .max()
     }

--- a/LokalBot/Services/DayDigestLifecycle.swift
+++ b/LokalBot/Services/DayDigestLifecycle.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+/// Owns the complete Day Digest lifecycle shared by manual, scheduled, and
+/// headless entry points. Callers choose when to request a digest; this module
+/// owns what evidence belongs to that request, where the journal lives, how
+/// freshness is derived, and how automatic repair is scheduled.
+@MainActor
+final class DayDigestLifecycle {
+    struct Snapshot: Equatable, Sendable {
+        var text: String?
+        var modifiedAt: Date?
+        var latestEvidenceAt: Date?
+
+        var isStale: Bool {
+            DayDigestFreshness.isStale(
+                digestModifiedAt: modifiedAt,
+                latestEvidenceAt: latestEvidenceAt)
+        }
+    }
+
+    typealias Generator = @MainActor (
+        _ day: Date,
+        _ blocks: [ActivityBlock],
+        _ meetings: [Meeting],
+        _ screenContexts: [DayScreenContext],
+        _ settings: AppSettings
+    ) async throws -> DayDigestGenerationResult
+
+    private struct EvidenceInput {
+        var blocks: [ActivityBlock]
+        var meetings: [Meeting]
+        var screenContexts: [DayScreenContext]
+
+        var isEmpty: Bool {
+            blocks.isEmpty && meetings.isEmpty && screenContexts.isEmpty
+        }
+    }
+
+    private let storageRoot: URL
+    private let blocks: (Date) -> [ActivityBlock]
+    private let screenContexts: (Date) -> [DayScreenContext]
+    private let meetings: () -> [Meeting]
+    private let latestActivityEvidenceAt: (Date) -> Date?
+    private let settings: () -> AppSettings
+    private let generator: Generator
+    private let calendar: Calendar
+    private let scheduler: DayDigestScheduler
+
+    init(
+        storageRoot: URL,
+        calendar: Calendar = .current,
+        scheduler: DayDigestScheduler? = nil,
+        blocks: @escaping (Date) -> [ActivityBlock],
+        screenContexts: @escaping (Date) -> [DayScreenContext],
+        meetings: @escaping () -> [Meeting],
+        latestActivityEvidenceAt: @escaping (Date) -> Date?,
+        settings: @escaping () -> AppSettings,
+        generator: @escaping Generator
+    ) {
+        self.storageRoot = storageRoot
+        self.calendar = calendar
+        self.scheduler = scheduler ?? DayDigestScheduler()
+        self.blocks = blocks
+        self.screenContexts = screenContexts
+        self.meetings = meetings
+        self.latestActivityEvidenceAt = latestActivityEvidenceAt
+        self.settings = settings
+        self.generator = generator
+    }
+
+    convenience init(
+        storage: StorageManager,
+        activityStore: ActivityStore,
+        pipeline: ProcessingPipeline,
+        meetings: @escaping () -> [Meeting],
+        settings: @escaping () -> AppSettings
+    ) {
+        self.init(
+            storageRoot: storage.rootURL,
+            blocks: { activityStore.blocks(on: $0) },
+            screenContexts: { activityStore.screenContexts(on: $0) },
+            meetings: meetings,
+            latestActivityEvidenceAt: { activityStore.latestEvidenceAt(on: $0) },
+            settings: settings,
+            generator: { day, blocks, meetings, screenContexts, settings in
+                try await pipeline.generateDayDigest(
+                    for: day,
+                    blocks: blocks,
+                    meetings: meetings,
+                    screenContexts: screenContexts,
+                    config: settings)
+            })
+    }
+
+    func journalURL(for day: Date) -> URL {
+        storageRoot.appendingPathComponent("journal/\(DreamDay.key(for: day, calendar: calendar)).md")
+    }
+
+    func snapshot(for day: Date) -> Snapshot {
+        let url = journalURL(for: day)
+        let text = try? String(contentsOf: url, encoding: .utf8)
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        return Snapshot(
+            text: text,
+            modifiedAt: attributes?[.modificationDate] as? Date,
+            latestEvidenceAt: latestEvidenceAt(for: day))
+    }
+
+    func meetings(for day: Date, includeInProgress: Bool = true) -> [Meeting] {
+        meetings().filter { meeting in
+            calendar.isDate(meeting.startedAt, inSameDayAs: day)
+                && (includeInProgress || meeting.endedAt != nil)
+        }
+    }
+
+    func latestEvidenceAt(for day: Date) -> Date? {
+        let meetingEnd = meetings(for: day).compactMap(\.endedAt).max()
+        return [latestActivityEvidenceAt(day), meetingEnd]
+            .compactMap { $0 }
+            .max()
+    }
+
+    @discardableResult
+    func generate(
+        for day: Date,
+        settings override: AppSettings? = nil
+    ) async throws -> DayDigestGenerationResult {
+        let input = evidenceInput(for: day)
+        return try await generator(
+            day,
+            input.blocks,
+            input.meetings,
+            input.screenContexts,
+            override ?? settings())
+    }
+
+    func configureAutomaticGeneration(
+        _ configuration: DayDigestScheduler.Configuration,
+        canRun: @escaping () -> Bool,
+        onError: @escaping (String) -> Void
+    ) {
+        scheduler.configure(
+            configuration,
+            digestModifiedAt: { [weak self] day in
+                guard let self else { return nil }
+                return DayDigestGenerationMetadataStore.completedAt(
+                    for: self.journalURL(for: day))
+            },
+            latestEvidenceAt: { [weak self] day in
+                self?.latestEvidenceAt(for: day)
+            },
+            canRun: canRun,
+            generate: { [weak self] day in
+                guard let self else {
+                    throw TextEngineError.unavailable("LokalBot is shutting down.")
+                }
+                let input = self.evidenceInput(for: day)
+                guard !input.isEmpty else { return .deferred }
+                let result = try await self.generator(
+                    day,
+                    input.blocks,
+                    input.meetings,
+                    input.screenContexts,
+                    self.settings())
+                return result.quality.needsRepair ? .needsRepair : .completed
+            },
+            onError: onError)
+    }
+
+    func stopAutomaticGeneration() {
+        scheduler.stop()
+    }
+
+    private func evidenceInput(for day: Date) -> EvidenceInput {
+        EvidenceInput(
+            blocks: blocks(day),
+            meetings: meetings(for: day, includeInProgress: false),
+            screenContexts: screenContexts(day))
+    }
+}

--- a/LokalBot/Services/DayDigestLifecycle.swift
+++ b/LokalBot/Services/DayDigestLifecycle.swift
@@ -114,8 +114,12 @@ final class DayDigestLifecycle {
     }
 
     func latestEvidenceAt(for day: Date) -> Date? {
-        let meetingEnd = meetings(for: day).compactMap(\.endedAt).max()
-        return [latestActivityEvidenceAt(day), meetingEnd]
+        let finishedMeetings = meetings(for: day, includeInProgress: false)
+        let meetingEnd = finishedMeetings.compactMap(\.endedAt).max()
+        let meetingArtifactWrite = finishedMeetings
+            .compactMap(latestArtifactWriteAt(for:))
+            .max()
+        return [latestActivityEvidenceAt(day), meetingEnd, meetingArtifactWrite]
             .compactMap { $0 }
             .max()
     }
@@ -143,8 +147,7 @@ final class DayDigestLifecycle {
             configuration,
             digestModifiedAt: { [weak self] day in
                 guard let self else { return nil }
-                return DayDigestGenerationMetadataStore.completedAt(
-                    for: self.journalURL(for: day))
+                return self.automaticCompletionAt(for: day)
             },
             latestEvidenceAt: { [weak self] day in
                 self?.latestEvidenceAt(for: day)
@@ -176,5 +179,33 @@ final class DayDigestLifecycle {
             blocks: blocks(day),
             meetings: meetings(for: day, includeInProgress: false),
             screenContexts: screenContexts(day))
+    }
+
+    /// Summaries and outcomes are produced after a meeting ends, and both are
+    /// consumed by `ProcessingPipeline.generateDayDigest`. Their writes must
+    /// therefore advance the evidence watermark even though the meeting's
+    /// `endedAt` value is unchanged.
+    private func latestArtifactWriteAt(for meeting: Meeting) -> Date? {
+        let folder = storageRoot.appendingPathComponent(
+            meeting.relativePath,
+            isDirectory: true)
+        return DayDigestMeetingArtifacts.latestModifiedAt(in: folder)
+    }
+
+    /// Preserve the scheduler's once-per-evening policy for ordinary activity,
+    /// but invalidate its completion marker when a digest predates meeting
+    /// artifacts it actually consumes. This makes the next quiet tick repair
+    /// the journal without regenerating it for every later activity sample.
+    private func automaticCompletionAt(for day: Date) -> Date? {
+        let completedAt = DayDigestGenerationMetadataStore.completedAt(
+            for: journalURL(for: day))
+        guard let completedAt else { return nil }
+        let latestArtifactWrite = meetings(for: day, includeInProgress: false)
+            .compactMap(latestArtifactWriteAt(for:))
+            .max()
+        guard let latestArtifactWrite, latestArtifactWrite > completedAt else {
+            return completedAt
+        }
+        return nil
     }
 }

--- a/LokalBot/Services/Dreaming/DreamScheduler.swift
+++ b/LokalBot/Services/Dreaming/DreamScheduler.swift
@@ -169,13 +169,12 @@ final class DreamScheduler: ObservableObject {
         start(target: target, advancesScanCursor: true)
     }
 
-    /// Manual run from Settings: ignores the hour, the existing report (the
-    /// day is re-dreamed and its files replaced), and the downtime gate — the
-    /// user explicitly asked. Still one dream at a time.
+    /// Manual run from a user action: ignores whether overnight automation is
+    /// enabled, the hour, the existing report (the day is re-dreamed and its
+    /// files replaced), and the downtime gate. Still one dream at a time.
     func dreamNow() {
         guard dreamTask == nil,
-              let configuration,
-              configuration.enabled,
+              configuration != nil,
               dream != nil else { return }
         let calendar = calendarSnapshot()
         let day = Self.previousDay(of: now(), calendar: calendar)

--- a/LokalBot/Services/Dreaming/DreamService.swift
+++ b/LokalBot/Services/Dreaming/DreamService.swift
@@ -16,7 +16,7 @@ struct DreamService {
 
     var storageRoot: URL
     /// Resolved per-dream so backend/model changes apply to the next night;
-    /// same seam as chat/dictation (`ProcessingPipeline.makeTextEngine`).
+    /// same seam as chat/dictation (`ThinkExecution.makeTextEngine`).
     var makeEngine: () async throws -> EngineSelection
     var now: () -> Date = Date.init
 

--- a/LokalBot/Services/NavigationHandoff.swift
+++ b/LokalBot/Services/NavigationHandoff.swift
@@ -1,0 +1,101 @@
+import Combine
+import Foundation
+
+struct AskNavigationHandoff: Equatable, Sendable {
+    let query: String?
+    let dayScope: Date?
+    let screenSnapshotIDs: [Int64]
+    let submit: Bool
+}
+
+struct MeetingSeekHandoff: Equatable, Sendable {
+    let meetingID: Meeting.ID
+    let seconds: TimeInterval
+}
+
+struct AgentLaunchContext: Equatable, Sendable {
+    let title: String
+    let prompt: String
+    let meetingID: Meeting.ID?
+    let actionID: String?
+}
+
+/// Owns the short-lived payloads passed between navigation destinations.
+/// Each destination consumes its complete payload at once, so SwiftUI view
+/// mounting and coalesced state updates cannot split or misroute a handoff.
+@MainActor
+final class NavigationHandoff: ObservableObject {
+    @Published private(set) var revision: UInt = 0
+
+    private var pendingAsk: AskNavigationHandoff?
+    private var pendingMeetingSeek: MeetingSeekHandoff?
+    private var pendingScreenSnapshotID: Int64?
+    private(set) var agentContext: AgentLaunchContext?
+
+    func stageAsk(
+        query: String,
+        dayScope: Date?,
+        screenSnapshotIDs: [Int64],
+        submit: Bool
+    ) {
+        pendingAsk = AskNavigationHandoff(
+            query: query.isEmpty ? nil : query,
+            dayScope: dayScope,
+            screenSnapshotIDs: screenSnapshotIDs,
+            submit: submit)
+        changed()
+    }
+
+    func consumeAsk() -> AskNavigationHandoff? {
+        guard let pendingAsk else { return nil }
+        self.pendingAsk = nil
+        changed()
+        return pendingAsk
+    }
+
+    /// Every meeting navigation replaces the previous seek request. Opening a
+    /// meeting without a timestamp therefore cannot inherit an older seek.
+    func stageMeeting(_ meetingID: Meeting.ID, seek seconds: TimeInterval?) {
+        pendingMeetingSeek = seconds.map {
+            MeetingSeekHandoff(meetingID: meetingID, seconds: $0)
+        }
+        changed()
+    }
+
+    func consumeMeetingSeek(for meetingID: Meeting.ID) -> TimeInterval? {
+        guard pendingMeetingSeek?.meetingID == meetingID,
+              let seconds = pendingMeetingSeek?.seconds else { return nil }
+        pendingMeetingSeek = nil
+        changed()
+        return seconds
+    }
+
+    func stageScreenSnapshot(_ snapshotID: Int64) {
+        pendingScreenSnapshotID = snapshotID
+        changed()
+    }
+
+    func consumeScreenSnapshot() -> Int64? {
+        guard let pendingScreenSnapshotID else { return nil }
+        self.pendingScreenSnapshotID = nil
+        changed()
+        return pendingScreenSnapshotID
+    }
+
+    func stageAgent(_ context: AgentLaunchContext?) {
+        agentContext = context
+        changed()
+    }
+
+    @discardableResult
+    func consumeAgentContext() -> AgentLaunchContext? {
+        guard let agentContext else { return nil }
+        self.agentContext = nil
+        changed()
+        return agentContext
+    }
+
+    private func changed() {
+        revision &+= 1
+    }
+}

--- a/LokalBot/Services/ProcessingPipeline.swift
+++ b/LokalBot/Services/ProcessingPipeline.swift
@@ -833,7 +833,8 @@ final class ProcessingPipeline: ObservableObject {
                 startedAt: meeting.startedAt,
                 endedAt: endedAt,
                 sourceSummary: sourceSummary,
-                outcomes: outcomes)
+                outcomes: outcomes,
+                artifactModifiedAt: DayDigestMeetingArtifacts.latestModifiedAt(in: folder))
         }
     }
 

--- a/LokalBot/Services/ProcessingPipeline.swift
+++ b/LokalBot/Services/ProcessingPipeline.swift
@@ -7,7 +7,7 @@ import Foundation
 @MainActor
 final class ProcessingPipeline: ObservableObject {
 
-    typealias BuiltInModelPreparer = (ModelCatalog.Entry, StorageManager) async throws -> URL
+    typealias BuiltInModelPreparer = ThinkExecution.BuiltInModelPreparer
 
     enum Stage: Equatable {
         case queued
@@ -119,7 +119,7 @@ final class ProcessingPipeline: ObservableObject {
 
     private let storage: StorageManager
     private let settings: () -> AppSettings
-    private let builtInModelPreparer: BuiltInModelPreparer
+    let thinkExecution: ThinkExecution
     private let automationReadiness: AutomationReadiness
     /// In-memory work list; `jobStore` mirrors it on disk so a crash mid-queue
     /// loses nothing — see `resumePending(meetings:)`.
@@ -139,6 +139,7 @@ final class ProcessingPipeline: ObservableObject {
 
     init(storage: StorageManager, jobStore: PipelineJobStore? = nil,
          settings: @escaping () -> AppSettings,
+         thinkExecution: ThinkExecution? = nil,
          builtInModelPreparer: @escaping BuiltInModelPreparer = { entry, storage in
              try await ModelDownloadManager.shared.ensureAvailable(entry, storage: storage)
          },
@@ -146,7 +147,9 @@ final class ProcessingPipeline: ObservableObject {
         self.storage = storage
         self.jobStore = jobStore
         self.settings = settings
-        self.builtInModelPreparer = builtInModelPreparer
+        self.thinkExecution = thinkExecution ?? ThinkExecution(
+            storage: storage,
+            builtInModelPreparer: builtInModelPreparer)
         self.automationReadiness = automationReadiness
     }
 
@@ -373,7 +376,7 @@ final class ProcessingPipeline: ObservableObject {
                 }
                 if config.summarizerBackend == .builtIn {
                     stages[meeting.id] = .preparingSummaryModel
-                    _ = try await prepareBuiltInModel(config)
+                    _ = try await thinkExecution.prepareBuiltInModel(config)
                 }
                 stages[meeting.id] = .summarizing
                 var transcript = try loadTranscript(from: folder)
@@ -407,17 +410,10 @@ final class ProcessingPipeline: ObservableObject {
                     do {
                         summary = try await summarize(transcript, meeting: meeting, config: config)
                     } catch {
-                        // The built-in engine has already health-checked,
-                        // relaunched, and replayed once inside LeasedTextEngine.
-                        // Do not turn one exhausted recovery into four process
-                        // starts through this provider-level retry as well.
-                        if config.summarizerBackend == .builtIn,
-                           let engineError = error as? TextEngineError,
-                           case .serverUnreachable = engineError {
-                            throw error
-                        }
-                        guard let delay = TextEngineRetryPolicy.delay(
-                            for: error, attempt: 0) else { throw error }
+                        guard let delay = thinkExecution.retryDelay(
+                            for: error,
+                            settings: config,
+                            attempt: 0) else { throw error }
                         // One bounded retry for transient network, rate-limit,
                         // or server failures. Deterministic 4xx/schema/payload
                         // failures surface immediately instead of doubling work.
@@ -654,7 +650,7 @@ final class ProcessingPipeline: ObservableObject {
     private func summarize(_ transcript: Transcript, meeting: Meeting,
                            config: AppSettings) async throws -> String {
         let started = Date()
-        let engine = try await makeTextEngine(config)
+        let engine = try await thinkExecution.makeTextEngine(config)
         let wordCount = transcript.languageDetectionText
             .split(whereSeparator: { $0.isWhitespace }).count
         // Resolve `.matchTranscript` against raw spoken text now so both the
@@ -708,7 +704,7 @@ final class ProcessingPipeline: ObservableObject {
                                  config: AppSettings) async {
         do {
             try Task.checkCancellation()
-            let engine = try await makeTextEngine(config)
+            let engine = try await thinkExecution.makeTextEngine(config)
             let userSpeakerLabel = transcript.displaySpeaker(for: "me")
             let output = try await engine.generate(
                 system: OutcomesExtractor.systemPrompt(userSpeakerLabel: userSpeakerLabel),
@@ -774,7 +770,9 @@ final class ProcessingPipeline: ObservableObject {
         } else {
             do {
                 try Task.checkCancellation()
-                let engine = try await makeTextEngine(config, purpose: "day digest")
+                let engine = try await thinkExecution.makeTextEngine(
+                    config,
+                    purpose: "day digest")
                 overview = try await generateDayOverview(
                     evidence: evidence,
                     engine: engine,
@@ -862,88 +860,12 @@ final class ProcessingPipeline: ObservableObject {
         return lines.joined(separator: "\n")
     }
 
-    func makeTextEngine(_ config: AppSettings, server: LlamaServer = .shared,
-                        priority: InferencePriority = .background,
-                        purpose: String = "summary",
-                        broker: InferenceBroker = .shared) async throws -> TextEngine {
-        switch config.summarizerBackend {
-        case .builtIn:
-            guard let entry = ModelCatalog.entry(id: config.builtInModelID,
-                                                 custom: config.customBuiltInModels)
-                    ?? ModelCatalog.entry(id: ModelCatalog.recommendedSummarizationID) else {
-                throw PipelineError.badServerURL
-            }
-            let modelURL = try await prepareBuiltInModel(config)
-            let authenticationToken = await server.authenticationToken()
-            let engine = OpenAICompatibleEngine(
-                baseURL: server.baseURL,
-                model: entry.id,
-                apiKey: authenticationToken,
-                extraBody: MainLLMRuntimePolicy.requestOverrides(for: entry.id),
-                chatDialect: .llamaServer,
-                defaultThinkingBudgetTokens:
-                    MainLLMRuntimePolicy.highReasoningBudgetTokens,
-                displayNameOverride: "Built-in — \(entry.displayName)")
-            guard let role = InferenceRole(serverPort: server.port) else {
-                // A LlamaServer outside the broker's three roles (never true
-                // today) keeps the legacy boot-at-creation path.
-                try await server.ensureRunning(modelAt: modelURL)
-                return engine
-            }
-            // The server boots on the first generate call, under a lease that
-            // pins it for the duration of each request.
-            return LeasedTextEngine(base: engine, broker: broker, role: role,
-                                    modelURL: modelURL, priority: priority,
-                                    purpose: purpose)
-        case .appleIntelligence:
-            if case .unavailable(let reason) = FoundationModelAvailability.current() {
-                throw TextEngineError.unavailable(reason)
-            }
-            return AppleIntelligenceEngine()
-        case .ollama:
-            guard let url = URL(string: config.ollamaBaseURL) else { throw PipelineError.badServerURL }
-            try InferenceEndpointPolicy.validate(
-                url, approvedOrigins: config.approvedRemoteInferenceOrigins)
-            var model = config.ollamaModel
-            if model.isEmpty {
-                // Zero-config: a running Ollama with any model just works.
-                model = await OllamaEngine.listModels(baseURL: url).first ?? ""
-            }
-            return OllamaEngine(baseURL: url, model: model)
-        case .openAICompatible:
-            guard let url = URL(string: config.openAIBaseURL) else { throw PipelineError.badServerURL }
-            try InferenceEndpointPolicy.validate(
-                url, approvedOrigins: config.approvedRemoteInferenceOrigins)
-            return OpenAICompatibleEngine(
-                baseURL: url,
-                model: config.openAIModel,
-                apiKey: config.openAIAPIKey,
-                chatDialect: .inferred(from: url))
-        }
-    }
-
-    /// Ensure the selected built-in model is present before the first request.
-    /// `ModelDownloadManager` coalesces UI/prewarm/pipeline callers onto one
-    /// download, so the first recap waits for preparation instead of failing.
-    @discardableResult
-    func prepareBuiltInModel(_ config: AppSettings) async throws -> URL {
-        guard let entry = ModelCatalog.entry(id: config.builtInModelID,
-                                             custom: config.customBuiltInModels)
-                ?? ModelCatalog.entry(id: ModelCatalog.recommendedSummarizationID) else {
-            throw PipelineError.badServerURL
-        }
-        // The preparer also validates legacy on-disk models. Bypassing it for a
-        // GGUF header match would skip the newly pinned SHA-256 digest.
-        return try await builtInModelPreparer(entry, storage)
-    }
-
     enum PipelineError: LocalizedError {
-        case noAudio, noTranscript, badServerURL
+        case noAudio, noTranscript
         var errorDescription: String? {
             switch self {
             case .noAudio: "No audio tracks found in the meeting folder."
             case .noTranscript: "No transcript yet — transcribe the meeting first."
-            case .badServerURL: "Invalid LLM server URL in Settings → Models."
             }
         }
     }

--- a/LokalBot/Services/RecordingController.swift
+++ b/LokalBot/Services/RecordingController.swift
@@ -455,7 +455,7 @@ final class RecordingController: ObservableObject {
             let started = Date()
             lokalbotLog("summary prewarm start model=\(config.builtInModelID) reason=\(reason)")
             do {
-                try await self?.pipeline.prepareBuiltInModel(config)
+                try await self?.pipeline.thinkExecution.prepareBuiltInModel(config)
                 let elapsed = Date().timeIntervalSince(started)
                 lokalbotLog(
                     "summary prewarm ready model=\(config.builtInModelID) elapsed=\(String(format: "%.2fs", elapsed))")

--- a/LokalBot/Views/AgentSessionView.swift
+++ b/LokalBot/Views/AgentSessionView.swift
@@ -138,7 +138,7 @@ struct AgentSessionView: View {
                 Text(emptyStateDetail)
                     .workspaceTextRole(.trust)
             }
-            if let context = app.agentLaunchContext {
+            if let context = app.navigationHandoff.agentContext {
                 VStack(alignment: .leading, spacing: 5) {
                     Text("Selected outcome").font(WorkspaceTypography.metadataEmphasis)
                         .foregroundStyle(.secondary)
@@ -460,7 +460,7 @@ struct AgentSessionView: View {
             }
             guard canSend else { return }
             controller.draft = ""
-            app.agentLaunchContext = nil
+            app.navigationHandoff.consumeAgentContext()
             await controller.send(prompt: text)
         }
     }

--- a/LokalBot/Views/AskView.swift
+++ b/LokalBot/Views/AskView.swift
@@ -51,9 +51,7 @@ private struct AskContent: View {
         .onChange(of: facet) { runSearch() }
         .onChange(of: screenDateScope) { runSearch() }
         .onChange(of: selectedScreenApp) { runSearch() }
-        .onChange(of: app.askPrefill) { consumePrefill() }
-        .onChange(of: app.askScreenContextIDs) { consumeScreenContext() }
-        .onChange(of: app.askSubmitRequested) { consumeSubmitRequest() }
+        .onChange(of: app.navigationHandoff.revision) { consumeNavigationHandoff() }
         .onChange(of: model.currentID) {
             // A saved conversation selection is an explicit mode switch. An
             // old search query must not keep masking the selected transcript.
@@ -62,9 +60,7 @@ private struct AskContent: View {
         }
         .onAppear {
             matchByMeaning = app.settings.semanticSearchEnabled
-            consumePrefill()
-            consumeScreenContext()
-            consumeSubmitRequest()
+            consumeNavigationHandoff()
             inputFocused = true
             #if LOKALBOT_UI_TEST_HOST
             if query.isEmpty,
@@ -76,33 +72,20 @@ private struct AskContent: View {
         }
     }
 
-    private func consumePrefill() {
-        guard let prefill = app.askPrefill else { return }
-        mode = .ask
-        query = prefill
-        app.askPrefill = nil
-    }
-
-    private func consumeScreenContext() {
-        guard !app.askScreenContextIDs.isEmpty else { return }
-        for snapshotID in app.askScreenContextIDs {
+    private func consumeNavigationHandoff() {
+        guard let handoff = app.navigationHandoff.consumeAsk() else { return }
+        app.askDayScope = handoff.dayScope
+        if handoff.query != nil || handoff.submit { mode = .ask }
+        if let handedQuery = handoff.query {
+            query = handedQuery
+        }
+        for snapshotID in handoff.screenSnapshotIDs {
             guard !pinnedScreens.contains(where: { $0.snapshotID == snapshotID }),
                   let screenshot = app.activityStore.screenshot(id: snapshotID) else { continue }
             let ocr = app.activityStore.ocrText(snapshotID: snapshotID) ?? ""
             pinnedScreens.append(ScreenAskContext(screenshot: screenshot, ocrText: ocr))
         }
-        app.askScreenContextIDs = []
-    }
-
-    private func consumeSubmitRequest() {
-        guard app.askSubmitRequested else { return }
-        // Consume all handoff state in one pass. SwiftUI may coalesce the
-        // individual @Published updates from `openAsk`, so this remains
-        // ordering-independent even when Ask is already visible.
-        consumePrefill()
-        consumeScreenContext()
-        app.askSubmitRequested = false
-        escalate()
+        if handoff.submit { escalate() }
     }
 
     // MARK: - Input + facets
@@ -585,8 +568,9 @@ private struct AskContent: View {
                                       snippet: hit.text)
                                 .contentShape(Rectangle())
                                 .onTapGesture {
-                                    if hit.start > 0 { app.pendingSeek = hit.start }
-                                    app.openMeeting(hit.meetingID)
+                                    app.openMeeting(
+                                        hit.meetingID,
+                                        seek: hit.start > 0 ? hit.start : nil)
                                 }
                                 .accessibilityIdentifier("search.hit.semantic.\(hit.meetingID.uuidString)")
                         }

--- a/LokalBot/Views/CaptureView.swift
+++ b/LokalBot/Views/CaptureView.swift
@@ -295,7 +295,7 @@ struct TimelineContentView: View {
             clearMeetingSelectionOutsideSelectedDay()
         }
         .onAppear(perform: consumePendingScreenMoment)
-        .onChange(of: app.pendingScreenSnapshotID) { consumePendingScreenMoment() }
+        .onChange(of: app.navigationHandoff.revision) { consumePendingScreenMoment() }
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
                 TrackingPauseButton(sampler: app.sampler, presentation: .toolbar)
@@ -311,8 +311,7 @@ struct TimelineContentView: View {
     }
 
     private func consumePendingScreenMoment() {
-        guard let snapshotID = app.pendingScreenSnapshotID else { return }
-        defer { app.pendingScreenSnapshotID = nil }
+        guard let snapshotID = app.navigationHandoff.consumeScreenSnapshot() else { return }
         guard let screenshot = app.activityStore.screenshot(id: snapshotID) else {
             app.lastError = "That captured screen is no longer available."
             return

--- a/LokalBot/Views/CaptureView.swift
+++ b/LokalBot/Views/CaptureView.swift
@@ -55,9 +55,10 @@ final class CaptureModel: ObservableObject {
     }
 
     var digestIsStale: Bool {
-        DayDigestFreshness.isStale(
-            digestModifiedAt: digestUpdatedAt,
-            latestEvidenceAt: latestDigestEvidenceAt)
+        DayDigestLifecycle.Snapshot(
+            text: digest,
+            modifiedAt: digestUpdatedAt,
+            latestEvidenceAt: latestDigestEvidenceAt).isStale
     }
 
     /// Change the selected day and synchronously replace every day-scoped
@@ -86,11 +87,10 @@ final class CaptureModel: ObservableObject {
         let reloadedShots = app.activityStore.screenshots(on: day, includingTextOnly: true)
         shots = reloadedShots
         rewindFrames = ScreenRewindSequence.frames(from: reloadedShots)
-        let digestURL = journalURL(app: app)
-        digest = try? String(contentsOf: digestURL, encoding: .utf8)
-        let attributes = try? FileManager.default.attributesOfItem(atPath: digestURL.path)
-        digestUpdatedAt = attributes?[.modificationDate] as? Date
-        latestDigestEvidenceAt = latestEvidenceDate(app: app)
+        let digestSnapshot = app.dayDigest.snapshot(for: day)
+        digest = digestSnapshot.text
+        digestUpdatedAt = digestSnapshot.modifiedAt
+        latestDigestEvidenceAt = digestSnapshot.latestEvidenceAt
         digestError = nil
         selection = nil
         selectedSessionID = nil
@@ -101,20 +101,7 @@ final class CaptureModel: ObservableObject {
     /// The selected day's meetings, live recording included, for the track
     /// and the overview stats.
     func meetings(in app: AppState) -> [Meeting] {
-        ((app.currentMeeting.map { [$0] } ?? []) + app.meetings)
-            .filter { Calendar.current.isDate($0.startedAt, inSameDayAs: day) }
-    }
-
-    private func journalURL(app: AppState) -> URL {
-        let name = DreamDay.key(for: day)
-        return app.storage.rootURL.appendingPathComponent("journal/\(name).md")
-    }
-
-    private func latestEvidenceDate(app: AppState) -> Date? {
-        let meetingEnd = meetings(in: app).compactMap(\.endedAt).max()
-        return [app.activityStore.latestEvidenceAt(on: day), meetingEnd]
-            .compactMap { $0 }
-            .max()
+        app.dayDigest.meetings(for: day)
     }
 
     func generateDigest(app: AppState) async {
@@ -126,21 +113,16 @@ final class CaptureModel: ObservableObject {
         defer {
             if digestGeneration == generation { generating = false }
         }
-        let todays = meetings(in: app).filter { $0.endedAt != nil }
         let freshBlocks = app.activityStore.blocks(on: requestedDay)
-        let screenContexts = app.activityStore.screenContexts(on: requestedDay)
         do {
-            let result = try await app.pipeline.generateDayDigest(
-                for: requestedDay, blocks: freshBlocks, meetings: todays,
-                screenContexts: screenContexts, config: app.settings)
+            let result = try await app.dayDigest.generate(for: requestedDay)
             guard digestGeneration == generation,
                   Calendar.current.isDate(day, inSameDayAs: requestedDay) else { return }
             blocks = freshBlocks
             digest = result.text
-            let attributes = try? FileManager.default.attributesOfItem(
-                atPath: result.url.path)
-            digestUpdatedAt = attributes?[.modificationDate] as? Date
-            latestDigestEvidenceAt = latestEvidenceDate(app: app)
+            let snapshot = app.dayDigest.snapshot(for: requestedDay)
+            digestUpdatedAt = snapshot.modifiedAt
+            latestDigestEvidenceAt = snapshot.latestEvidenceAt
             digestError = nil
         } catch {
             guard digestGeneration == generation else { return }

--- a/LokalBot/Views/MeetingWorkspaceView.swift
+++ b/LokalBot/Views/MeetingWorkspaceView.swift
@@ -212,12 +212,7 @@ private struct MeetingWorkspaceDetail: View {
             }
 #endif
         }
-        .onChange(of: app.pendingSeek) { _, value in
-            guard let value else { return }
-            app.pendingSeek = nil
-            transcriptExpanded = true
-            player.play(at: value)
-        }
+        .onChange(of: app.navigationHandoff.revision) { consumeMeetingSeek() }
         .sheet(item: $correction) { draft in
             ActionCorrectionSheet(draft: draft) { text, owner, due in
                 _ = app.outcomeIndex.correctAction(
@@ -306,8 +301,11 @@ private struct MeetingWorkspaceDetail: View {
         speakerNameHints = app.speakerNameHints(for: meeting)
         player.load(folder: folder, hasSystemTrack: meeting.hasSystemTrack)
         app.outcomeIndex.refresh(meeting: meeting)
-        if let seek = app.pendingSeek {
-            app.pendingSeek = nil
+        consumeMeetingSeek()
+    }
+
+    private func consumeMeetingSeek() {
+        if let seek = app.navigationHandoff.consumeMeetingSeek(for: meeting.id) {
             transcriptExpanded = true
             player.play(at: seek)
         }

--- a/LokalBot/Views/ModelStackOverviewView.swift
+++ b/LokalBot/Views/ModelStackOverviewView.swift
@@ -143,7 +143,7 @@ struct ModelStackOverviewView<Configuration: View>: View {
                 toggle(stackRole)
             }
             .controlSize(.small)
-            .accessibilityIdentifier("models.stack.change.\(stackRole.rawValue)")
+            .accessibilityIdentifier(changeButtonIdentifier(for: stackRole))
         }
         .padding(.vertical, 8)
     }
@@ -154,6 +154,13 @@ struct ModelStackOverviewView<Configuration: View>: View {
         } else {
             expandedRoles.insert(role)
         }
+    }
+
+    private func changeButtonIdentifier(for role: ModelRole) -> String {
+        // Keep the established UI automation contract while the product term
+        // and domain role use the clearer Autocomplete name.
+        let suffix = role == .autocomplete ? "type" : role.rawValue
+        return "models.stack.change.\(suffix)"
     }
 
     private var presets: some View {
@@ -265,7 +272,7 @@ struct ModelStackOverviewView<Configuration: View>: View {
         }
 
         do {
-            let engine = try await app.pipeline.makeTextEngine(
+            let engine = try await app.thinkExecution.makeTextEngine(
                 app.settings, priority: .interactive, purpose: "model stack smoke test")
             _ = try await engine.generate(
                 system: PromptTemplates.connectivityTestSystem,

--- a/LokalBot/Views/ModelStackOverviewView.swift
+++ b/LokalBot/Views/ModelStackOverviewView.swift
@@ -1,16 +1,9 @@
 import SwiftUI
 
-enum ModelStackRole: String, Hashable {
-    case transcribe
-    case think
-    case type
-}
-
 struct ModelStackOverviewView<Configuration: View>: View {
     @EnvironmentObject var app: AppState
-    @ObservedObject private var downloads = ModelDownloadManager.shared
 
-    @Binding private var expandedRoles: Set<ModelStackRole>
+    @Binding private var expandedRoles: Set<ModelRole>
     private let configuration: Configuration
 
     @State private var pendingPreset: ModelStackPreset?
@@ -18,7 +11,7 @@ struct ModelStackOverviewView<Configuration: View>: View {
     @State private var smokeResults: [String: String] = [:]
 
     init(
-        expandedRoles: Binding<Set<ModelStackRole>>,
+        expandedRoles: Binding<Set<ModelRole>>,
         @ViewBuilder configuration: () -> Configuration
     ) {
         _expandedRoles = expandedRoles
@@ -29,16 +22,24 @@ struct ModelStackOverviewView<Configuration: View>: View {
         ModelCatalog.entry(id: app.settings.cotypingBuiltInModelID,
                            custom: app.settings.customBuiltInModels)
     }
-    private var snapshot: ModelReadinessSnapshot {
+    private var snapshot: ModelRolesSnapshot {
 #if LOKALBOT_UI_TEST_HOST
         if ProcessInfo.processInfo.environment["LOKALBOT_MODELS_DEMO_READY"] == "1" {
-            return .init(
-                transcriptionReady: true, thinkReady: true, autocompleteReady: true,
-                provenance: .local, storedBytes: 7_900_000_000,
-                availableBytes: 128_000_000_000, activeDownloads: 0, failedDownloads: 0)
+            return ModelRolesSnapshot(
+                readiness: .init(
+                    transcriptionReady: true,
+                    thinkReady: true,
+                    autocompleteReady: true,
+                    provenance: .local,
+                    storedBytes: 7_900_000_000,
+                    availableBytes: 128_000_000_000,
+                    activeDownloads: 0,
+                    failedDownloads: 0),
+                statuses: Dictionary(
+                    uniqueKeysWithValues: ModelRole.allCases.map { ($0, .ready) }))
         }
 #endif
-        return .make(app: app, downloads: downloads)
+        return app.modelRoles.snapshot
     }
 
     var body: some View {
@@ -69,9 +70,9 @@ struct ModelStackOverviewView<Configuration: View>: View {
 
     private var readinessBanner: some View {
         HStack(spacing: 12) {
-            Image(systemName: snapshot.coreReady ? "checkmark.seal.fill" : "arrow.down.circle")
+            Image(systemName: readinessIcon)
                 .font(.title2)
-                .foregroundStyle(snapshot.coreReady ? .green : Brand.teal)
+                .foregroundStyle(readinessColor)
             VStack(alignment: .leading, spacing: 2) {
                 Text(snapshot.headline)
                     .font(WorkspaceTypography.sectionTitle)
@@ -97,7 +98,7 @@ struct ModelStackOverviewView<Configuration: View>: View {
                 role: "Transcribe",
                 model: app.settings.transcriptionModelDisplayName,
                 detail: "Meeting audio to cited transcript",
-                ready: snapshot.transcriptionReady,
+                status: snapshot[.transcribe],
                 result: smokeResults["Transcribe"])
             Divider()
             coreRow(
@@ -106,22 +107,22 @@ struct ModelStackOverviewView<Configuration: View>: View {
                 role: "Think",
                 model: app.settings.thinkModelDisplayName,
                 detail: "Summaries, Ask, outcomes, and Agent",
-                ready: snapshot.thinkReady,
+                status: snapshot[.think],
                 result: smokeResults["Think"])
             Divider()
             coreRow(
                 icon: "text.cursor",
-                stackRole: .type,
+                stackRole: .autocomplete,
                 role: "Autocomplete",
                 model: autocompleteEntry?.displayName ?? "LFM2.5 1.2B Instruct",
                 detail: "Low-latency writing completion",
-                ready: snapshot.autocompleteReady,
+                status: snapshot[.autocomplete],
                 result: smokeResults["Autocomplete"])
         }
     }
 
-    private func coreRow(icon: String, stackRole: ModelStackRole, role: String,
-                         model: String, detail: String, ready: Bool,
+    private func coreRow(icon: String, stackRole: ModelRole, role: String,
+                         model: String, detail: String, status: ModelRoleStatus,
                          result: String?) -> some View {
         HStack(spacing: 12) {
             Image(systemName: icon).foregroundStyle(Brand.teal).frame(width: 22)
@@ -133,8 +134,8 @@ struct ModelStackOverviewView<Configuration: View>: View {
             VStack(alignment: .trailing, spacing: 2) {
                 Text(model).font(WorkspaceTypography.rowTitle).lineLimit(1)
                 HStack(spacing: 5) {
-                    StatusDot(color: ready ? .green : .orange, size: 7)
-                    Text(result ?? (ready ? "Ready" : "Download required"))
+                    StatusDot(color: roleColor(status), size: 7)
+                    Text(result ?? status.label)
                         .font(WorkspaceTypography.metadata).foregroundStyle(.secondary)
                 }
             }
@@ -147,7 +148,7 @@ struct ModelStackOverviewView<Configuration: View>: View {
         .padding(.vertical, 8)
     }
 
-    private func toggle(_ role: ModelStackRole) {
+    private func toggle(_ role: ModelRole) {
         if expandedRoles.contains(role) {
             expandedRoles.remove(role)
         } else {
@@ -214,7 +215,32 @@ struct ModelStackOverviewView<Configuration: View>: View {
         app.settings.cotypingBuiltInModelID = preset.autocompleteModelID
         // Shared kickoff also re-checks meetings parked as "waiting for
         // models" once the downloads land.
-        app.startCoreModelDownloads()
+        app.modelRoles.startCoreModelDownloads()
+    }
+
+    private var readinessIcon: String {
+        switch snapshot.primaryActionStatus {
+        case .ready: "checkmark.seal.fill"
+        case .needsAttention: "exclamationmark.triangle.fill"
+        case .downloading, .preparing: "arrow.down.circle.fill"
+        case .unavailable: "arrow.down.circle"
+        }
+    }
+
+    private var readinessColor: Color {
+        switch snapshot.primaryActionStatus {
+        case .ready: .green
+        case .needsAttention: Brand.error
+        case .downloading, .preparing, .unavailable: Brand.teal
+        }
+    }
+
+    private func roleColor(_ status: ModelRoleStatus) -> Color {
+        switch status {
+        case .ready: .green
+        case .needsAttention: Brand.error
+        case .downloading, .preparing, .unavailable: .orange
+        }
     }
 
     private func runSmokeTests() async {

--- a/LokalBot/Views/ModelsView.swift
+++ b/LokalBot/Views/ModelsView.swift
@@ -648,7 +648,7 @@ struct ModelsView: View {
                     ProgressView(value: fraction).frame(width: 70)
                     Button("Cancel") { downloads.cancel(entry) }.controlSize(.mini)
                 } else if available {
-                    Button("Delete") { downloads.delete(entry, storage: app.storage) }
+                    Button("Delete") { app.modelRoles.deleteGGUFModel(entry) }
                         .controlSize(.mini)
                 } else {
                     Button("Download") { downloads.download(entry, storage: app.storage) }

--- a/LokalBot/Views/ModelsView.swift
+++ b/LokalBot/Views/ModelsView.swift
@@ -12,12 +12,6 @@ struct ModelsView: View {
     @State private var ollamaReachable = false
     @State private var testResult: String?
     @State private var testing = false
-    @State private var preparingTranscriptionModelID: String?
-    @State private var downloadedTranscriptionModelIDs: Set<String> = []
-    @State private var readyTranscriptionModelIDs: Set<String> = []
-    @State private var transcriptionModelErrors: [String: String] = [:]
-    @State private var transcriptionModelProgress: [String: Double] = [:]
-    @State private var transcriptionModelStatus: [String: String] = [:]
     @State private var speechModelDownloaded = false
     @State private var preparingSpeechModel = false
     @State private var speechModelError: String?
@@ -32,7 +26,7 @@ struct ModelsView: View {
     @State private var openAIAPIKeySavedValue = ""
     @State private var didLoadOpenAIAPIKey = false
     @State private var openAIAPIKeySaved = false
-    @State private var expandedRoles: Set<ModelStackRole> = []
+    @State private var expandedRoles: Set<ModelRole> = []
 
     var body: some View {
         ScrollView {
@@ -41,7 +35,7 @@ struct ModelsView: View {
                     VStack(alignment: .leading, spacing: 16) {
                         if expandedRoles.contains(.transcribe) { transcriptionCard }
                         if expandedRoles.contains(.think) { summarizationCard }
-                        if expandedRoles.contains(.type) { cotypingCard }
+                        if expandedRoles.contains(.autocomplete) { cotypingCard }
                     }
                 }
                 ModelMemoryBanner()
@@ -54,12 +48,10 @@ struct ModelsView: View {
             .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .task {
-            refreshTranscriptionDownloads()
             refreshSpeechModel()
             await refreshOllama()
         }
         .onAppear {
-            refreshTranscriptionDownloads()
             refreshSpeechModel()
             if !didLoadOpenAIAPIKey {
                 let savedKey = app.settings.openAIAPIKey
@@ -114,21 +106,22 @@ struct ModelsView: View {
                   subtitle: "Speech → text for meeting audio",
                   cardIdentifier: "models.transcription") {
             ForEach(visibleTranscriptionChoices) { choice in
+                let status = app.modelRoles.transcriptionStatus(for: choice)
                 TranscriptionModelRow(
                     choice: choice,
                     displayName: transcriptionDisplayName(for: choice),
                     blurb: transcriptionBlurb(for: choice),
-                    preparing: preparingTranscriptionModelID == choice.id,
-                    prepareDisabled: preparingTranscriptionModelID != nil,
-                    downloaded: downloadedTranscriptionModelIDs.contains(choice.id),
-                    ready: readyTranscriptionModelIDs.contains(choice.id),
-                    error: transcriptionModelErrors[choice.id],
-                    progress: transcriptionModelProgress[choice.id],
-                    status: transcriptionModelStatus[choice.id]
+                    preparing: status.isWorking,
+                    prepareDisabled: app.modelRoles.isPreparingTranscription,
+                    downloaded: app.modelRoles.downloadedTranscriptionModelIDs.contains(choice.id),
+                    ready: status.isReady,
+                    error: status.errorMessage,
+                    progress: status.progress,
+                    status: status.isWorking ? status.label : nil
                 ) {
-                    Task { await prepareTranscriptionModel(choice) }
+                    app.modelRoles.prepareTranscriptionModel(choice)
                 } delete: {
-                    deleteTranscriptionModel(choice)
+                    app.modelRoles.deleteTranscriptionModel(choice)
                 } configure: {
                     showingGraniteModelPicker = true
                 }
@@ -152,7 +145,7 @@ struct ModelsView: View {
         let visible = TranscriptionModelChoice.allCases.filter { choice in
             !choice.isLegacy
                 || choice == app.settings.transcriptionModel
-                || downloadedTranscriptionModelIDs.contains(choice.id)
+                || app.modelRoles.downloadedTranscriptionModelIDs.contains(choice.id)
         }
         // The recommended engine is the most common thing to change and owns
         // the custom Hugging Face action, so keep it above the alternatives.
@@ -166,9 +159,6 @@ struct ModelsView: View {
             set: { configuration in
                 app.settings.graniteSpeechModel = configuration
                 app.settings.transcriptionModel = .graniteSpeech
-                transcriptionModelErrors[TranscriptionModelChoice.graniteSpeech.id] = nil
-                readyTranscriptionModelIDs.remove(TranscriptionModelChoice.graniteSpeech.id)
-                refreshTranscriptionDownloads()
             })
     }
 
@@ -747,55 +737,8 @@ struct ModelsView: View {
         }
     }
 
-    private func refreshTranscriptionDownloads() {
-        downloadedTranscriptionModelIDs = TranscriptionModelStore.downloadedChoices(
-            graniteConfiguration: app.settings.graniteSpeechModel)
-    }
-
     private func refreshSpeechModel() {
         speechModelDownloaded = KokoroSpeechEngine.isModelDownloaded
-    }
-
-    private func prepareTranscriptionModel(_ choice: TranscriptionModelChoice) async {
-        guard preparingTranscriptionModelID == nil else { return }
-        let id = choice.id
-        preparingTranscriptionModelID = choice.id
-        transcriptionModelErrors[choice.id] = nil
-        transcriptionModelProgress[choice.id] = nil
-        transcriptionModelStatus[choice.id] = "Preparing..."
-        defer {
-            preparingTranscriptionModelID = nil
-            transcriptionModelProgress[id] = nil
-            transcriptionModelStatus[id] = nil
-        }
-        let progressHandler: ModelPreparationProgressHandler = { update in
-            guard preparingTranscriptionModelID == id else { return }
-            transcriptionModelProgress[id] = update.fractionCompleted
-            transcriptionModelStatus[id] = update.status
-        }
-        do {
-            try await app.settings.transcriptionEngine(for: choice)
-                .prepare(progress: progressHandler)
-            downloadedTranscriptionModelIDs.insert(choice.id)
-            readyTranscriptionModelIDs.insert(choice.id)
-            app.modelReadinessDidChange()
-        } catch {
-            transcriptionModelErrors[choice.id] = error.localizedDescription
-        }
-    }
-
-    private func deleteTranscriptionModel(_ choice: TranscriptionModelChoice) {
-        do {
-            try TranscriptionModelStore.delete(
-                choice,
-                graniteConfiguration: app.settings.graniteSpeechModel)
-            downloadedTranscriptionModelIDs.remove(choice.id)
-            readyTranscriptionModelIDs.remove(choice.id)
-            transcriptionModelProgress[choice.id] = nil
-            transcriptionModelStatus[choice.id] = nil
-        } catch {
-            transcriptionModelErrors[choice.id] = error.localizedDescription
-        }
     }
 
     private func prepareSpeechModel() async {

--- a/LokalBot/Views/ModelsView.swift
+++ b/LokalBot/Views/ModelsView.swift
@@ -779,7 +779,7 @@ struct ModelsView: View {
         testResult = nil
         defer { testing = false }
         do {
-            let engine = try await app.pipeline.makeTextEngine(
+            let engine = try await app.thinkExecution.makeTextEngine(
                 app.settings,
                 priority: .interactive,
                 purpose: "model test")

--- a/LokalBot/Views/OnboardingView.swift
+++ b/LokalBot/Views/OnboardingView.swift
@@ -1,19 +1,6 @@
 import SwiftUI
 import AppKit
 
-enum OnboardingModelDownloadState: Equatable {
-    case ready
-    case downloading
-    case download(error: String?)
-
-    static func resolve(coreReady: Bool, activeDownloads: Int,
-                        isPreparingTranscription: Bool, error: String?) -> Self {
-        if coreReady { return .ready }
-        if activeDownloads > 0 || isPreparingTranscription { return .downloading }
-        return .download(error: error)
-    }
-}
-
 /// First-run onboarding and permission repair.
 ///
 /// The structure mirrors CoTabby's polished setup flow while staying native to
@@ -46,7 +33,6 @@ struct OnboardingView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @EnvironmentObject private var app: AppState
     @StateObject private var permissions = PermissionManager.shared
-    @ObservedObject private var downloads = ModelDownloadManager.shared
     @State private var step: WelcomeStep = .welcome
     @State private var navigatesForward = true
 
@@ -356,7 +342,7 @@ private extension OnboardingView {
     }
 
     var modelsPage: some View {
-        let snapshot = ModelReadinessSnapshot.make(app: app, downloads: downloads)
+        let snapshot = app.modelRoles.snapshot
         return VStack(spacing: WorkspaceMetric.sectionGap) {
             OnboardingStepHeader(
                 systemImage: "square.stack.3d.up",
@@ -370,21 +356,21 @@ private extension OnboardingView {
                     systemImage: "waveform",
                     role: "Transcribe",
                     model: app.settings.transcriptionModelDisplayName,
-                    ready: snapshot.transcriptionReady)
+                    ready: snapshot[.transcribe].isReady)
                 .onboardingReveal(1)
 
                 OnboardingModelRow(
                     systemImage: "brain",
                     role: "Think",
                     model: onboardingThinkModelName,
-                    ready: snapshot.thinkReady)
+                    ready: snapshot[.think].isReady)
                 .onboardingReveal(2)
 
                 OnboardingModelRow(
                     systemImage: "text.cursor",
                     role: "Autocomplete",
                     model: onboardingAutocompleteModelName,
-                    ready: snapshot.autocompleteReady)
+                    ready: snapshot[.autocomplete].isReady)
                 .onboardingReveal(3)
             }
 
@@ -402,13 +388,8 @@ private extension OnboardingView {
     }
 
     @ViewBuilder
-    private func modelDownloadAction(_ snapshot: ModelReadinessSnapshot) -> some View {
-        switch OnboardingModelDownloadState.resolve(
-            coreReady: snapshot.coreReady,
-            activeDownloads: snapshot.activeDownloads,
-            isPreparingTranscription: app.coreModelPreparationState.isPreparing,
-            error: modelDownloadError
-        ) {
+    private func modelDownloadAction(_ snapshot: ModelRolesSnapshot) -> some View {
+        switch snapshot.primaryActionStatus {
         case .ready:
             HStack(spacing: 7) {
                 Image(systemName: "checkmark.circle.fill")
@@ -416,40 +397,34 @@ private extension OnboardingView {
                 Text("Ready on this Mac")
                     .font(.system(size: 13, weight: .semibold, design: .rounded))
             }
-        case .downloading:
+        case .downloading, .preparing:
             LoadingStateLabel(
-                modelDownloadProgressLabel,
+                snapshot.primaryActionStatus.label,
                 font: .system(size: 13, weight: .medium, design: .rounded))
-        case .download(let error):
+        case .needsAttention(let error):
             VStack(spacing: 8) {
-                if let error {
-                    Label(error, systemImage: "exclamationmark.triangle.fill")
-                        .font(.caption)
-                        .foregroundStyle(Brand.error)
-                        .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                Button(error == nil ? modelDownloadButtonTitle(snapshot) : "Retry model downloads") {
-                    app.startCoreModelDownloads()
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(Brand.error)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button("Retry model downloads") {
+                    app.modelRoles.startCoreModelDownloads()
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(Brand.teal)
                 .controlSize(.large)
                 .accessibilityIdentifier("onboarding.downloadModels")
             }
+        case .unavailable:
+            Button(modelDownloadButtonTitle(snapshot)) {
+                app.modelRoles.startCoreModelDownloads()
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Brand.teal)
+            .controlSize(.large)
+            .accessibilityIdentifier("onboarding.downloadModels")
         }
-    }
-
-    private var modelDownloadError: String? {
-        if let error = app.coreModelPreparationState.errorMessage { return error }
-        var ids = [app.settings.cotypingBuiltInModelID]
-        if app.settings.summarizerBackend == .builtIn {
-            ids.append(app.settings.builtInModelID)
-        }
-        for id in ids {
-            if let error = downloads.errors[id], !error.isEmpty { return error }
-        }
-        return nil
     }
 
     private var onboardingThinkModelName: String {
@@ -463,23 +438,16 @@ private extension OnboardingView {
             ?? "LFM2.5 1.2B Instruct"
     }
 
-    private func modelDownloadButtonTitle(_ snapshot: ModelReadinessSnapshot) -> String {
+    private func modelDownloadButtonTitle(_ snapshot: ModelRolesSnapshot) -> String {
         let ggufBytes = ModelReadinessSnapshot.missingCoreModelBytes(
             app.settings, storage: app.storage)
         guard ggufBytes > 0 else { return "Download models" }
         let size = ByteCountFormatter.string(fromByteCount: ggufBytes, countStyle: .file)
         // The Transcribe model downloads through its engine and has no exact
         // byte count here — say so instead of pretending the total is exact.
-        return snapshot.transcriptionReady
+        return snapshot[.transcribe].isReady
             ? "Download models (\(size))"
             : "Download models (\(size) + speech model)"
-    }
-
-    private var modelDownloadProgressLabel: String {
-        let active = downloads.progress.values
-        guard !active.isEmpty else { return "Preparing speech model…" }
-        let percent = Int((active.reduce(0, +) / Double(active.count)) * 100)
-        return "Downloading models… \(percent)%"
     }
 
     var permissionPage: some View {

--- a/LokalBot/Views/OutcomeOverviewViews.swift
+++ b/LokalBot/Views/OutcomeOverviewViews.swift
@@ -68,8 +68,7 @@ struct OutcomeOverviewActionRow: View {
                     }
                     if let citation = reference.action.citations.first {
                         EvidencePill(citation: citation) {
-                            app.pendingSeek = citation.start
-                            app.openMeeting(reference.meetingID)
+                            app.openMeeting(reference.meetingID, seek: citation.start)
                         }
                     }
                 }

--- a/LokalBot/Views/TodayView.swift
+++ b/LokalBot/Views/TodayView.swift
@@ -227,11 +227,33 @@ struct TodayView: View {
 
     @ViewBuilder private func dreamInferenceNotice(_ dream: DreamReport) -> some View {
         if dream.isFallback {
-            Label(
-                dream.provenanceDescription + " Dream again from Settings → Recording.",
-                systemImage: "exclamationmark.triangle")
-                .font(.caption)
-                .foregroundStyle(Brand.error)
+            HStack(alignment: .center, spacing: 12) {
+                Label(dream.provenanceDescription, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(Brand.error)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                if TodayDreamSelection.isRetryableFailure(
+                    dream, referenceDate: model.day
+                ) {
+                    Button {
+                        app.dreamNow()
+                    } label: {
+                        if app.dreaming.isDreaming {
+                            LoadingStateLabel("Dreaming…", font: .caption)
+                        } else {
+                            Label("Dream again", systemImage: "arrow.clockwise")
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .fixedSize()
+                    .disabled(app.dreaming.isDreaming || !app.libraryReady)
+                    .help(app.libraryReady
+                          ? "Retry yesterday's dream with the configured Main LLM"
+                          : "Preparing your meeting library")
+                    .accessibilityIdentifier("today.dream.retry")
+                }
+            }
         } else if dream.inferenceProvenance?.location == .remote {
             Label("Generated using approved remote inference", systemImage: "network")
                 .font(.caption)
@@ -460,6 +482,19 @@ enum TodayDreamSelection {
     ) -> Bool {
         let yesterday = DreamScheduler.previousDay(of: referenceDate, calendar: calendar)
         return report.day == DreamDay.key(for: yesterday, calendar: calendar)
+    }
+
+    /// Only a current evidence-only brief caused by model generation deserves
+    /// an inline retry. Empty days have nothing to regenerate, and retrying an
+    /// older card would silently replace yesterday's report instead.
+    static func isRetryableFailure(
+        _ report: DreamReport,
+        referenceDate: Date,
+        calendar: Calendar = .current
+    ) -> Bool {
+        guard report.isFallback,
+              report.fallbackReason != .emptyDay else { return false }
+        return isCurrent(report, referenceDate: referenceDate, calendar: calendar)
     }
 
     /// A brief from yesterday earns "Priorities for today"; anything older is

--- a/LokalBotTests/AgentLLMEndpointTests.swift
+++ b/LokalBotTests/AgentLLMEndpointTests.swift
@@ -19,7 +19,7 @@ final class AgentLLMEndpointTests: XCTestCase {
     }
 
     func testBuiltInResolvesToModelID() {
-        let resolution = AgentLLMEndpointResolver.resolve(settings: settings(.builtIn))
+        let resolution = ThinkExecution.agentResolution(settings: settings(.builtIn))
         guard case .builtIn(let modelID) = resolution else {
             return XCTFail("expected .builtIn, got \(resolution)")
         }
@@ -27,7 +27,7 @@ final class AgentLLMEndpointTests: XCTestCase {
     }
 
     func testAppleIntelligenceIsUnsupportedWithGuidance() {
-        let resolution = AgentLLMEndpointResolver.resolve(settings: settings(.appleIntelligence))
+        let resolution = ThinkExecution.agentResolution(settings: settings(.appleIntelligence))
         guard case .unsupported(let reason) = resolution else {
             return XCTFail("expected unsupported resolution, got \(resolution)")
         }
@@ -38,7 +38,7 @@ final class AgentLLMEndpointTests: XCTestCase {
     func testOllamaRequiresExplicitModel() {
         var s = settings(.ollama)
         s.ollamaModel = ""
-        guard case .unsupported(let reason) = AgentLLMEndpointResolver.resolve(settings: s) else {
+        guard case .unsupported(let reason) = ThinkExecution.agentResolution(settings: s) else {
             return XCTFail("expected unsupported resolution for missing Ollama model")
         }
         XCTAssertTrue(reason.contains("Ollama"))
@@ -47,7 +47,7 @@ final class AgentLLMEndpointTests: XCTestCase {
     func testOllamaAppendsV1() {
         var s = settings(.ollama)
         s.ollamaModel = "qwen3:8b"
-        guard case .ready(let endpoint) = AgentLLMEndpointResolver.resolve(settings: s) else {
+        guard case .ready(let endpoint) = ThinkExecution.agentResolution(settings: s) else {
             return XCTFail("expected ready Ollama endpoint")
         }
         XCTAssertEqual(endpoint.baseURL.absoluteString, "http://localhost:11434/v1")
@@ -60,7 +60,7 @@ final class AgentLLMEndpointTests: XCTestCase {
         var s = settings(.openAICompatible)
         s.openAIBaseURL = "http://localhost:1234/v1"
         s.openAIModel = "my-model"
-        guard case .ready(let endpoint) = AgentLLMEndpointResolver.resolve(settings: s) else {
+        guard case .ready(let endpoint) = ThinkExecution.agentResolution(settings: s) else {
             return XCTFail("expected ready OpenAI-compatible endpoint")
         }
         XCTAssertEqual(endpoint.baseURL.absoluteString, "http://localhost:1234/v1")
@@ -70,7 +70,7 @@ final class AgentLLMEndpointTests: XCTestCase {
     func testOpenAICompatibleRequiresModel() {
         var s = settings(.openAICompatible)
         s.openAIModel = ""
-        guard case .unsupported = AgentLLMEndpointResolver.resolve(settings: s) else {
+        guard case .unsupported = ThinkExecution.agentResolution(settings: s) else {
             return XCTFail("expected unsupported resolution for missing OpenAI-compatible model")
         }
     }
@@ -80,7 +80,7 @@ final class AgentLLMEndpointTests: XCTestCase {
         s.ollamaBaseURL = "https://ollama.example.com"
         s.ollamaModel = "qwen3:8b"
 
-        guard case .unsupported(let reason) = AgentLLMEndpointResolver.resolve(settings: s) else {
+        guard case .unsupported(let reason) = ThinkExecution.agentResolution(settings: s) else {
             return XCTFail("expected remote Ollama to require approval")
         }
         XCTAssertTrue(reason.contains("Approve"))
@@ -92,7 +92,7 @@ final class AgentLLMEndpointTests: XCTestCase {
         s.openAIModel = "private-model"
         s.approvedRemoteInferenceOrigins = ["https://inference.example.com"]
 
-        guard case .ready(let endpoint) = AgentLLMEndpointResolver.resolve(settings: s) else {
+        guard case .ready(let endpoint) = ThinkExecution.agentResolution(settings: s) else {
             return XCTFail("expected approved remote endpoint")
         }
         XCTAssertEqual(endpoint.baseURL.absoluteString, "https://inference.example.com/v1")

--- a/LokalBotTests/AskRoutingTests.swift
+++ b/LokalBotTests/AskRoutingTests.swift
@@ -39,10 +39,12 @@ final class AskRoutingTests: XCTestCase {
             screenSnapshotIDs: [42],
             submit: true)
 
+        let handoff = app.navigationHandoff.consumeAsk()
         XCTAssertEqual(app.navSection, .ask)
-        XCTAssertEqual(app.askPrefill, "What was I looking at?")
-        XCTAssertEqual(app.askScreenContextIDs, [42])
-        XCTAssertTrue(app.askSubmitRequested)
+        XCTAssertEqual(handoff?.query, "What was I looking at?")
+        XCTAssertEqual(handoff?.screenSnapshotIDs, [42])
+        XCTAssertTrue(handoff?.submit == true)
+        XCTAssertNil(app.navigationHandoff.consumeAsk())
     }
 
     func testTodayOnlyScopeForcesCurrentDayAndHidesAmbientLibrary() async {

--- a/LokalBotTests/DayDigestEvidenceTests.swift
+++ b/LokalBotTests/DayDigestEvidenceTests.swift
@@ -165,7 +165,8 @@ final class DayDigestEvidenceTests: XCTestCase {
             startedAt: time(15),
             endedAt: time(15, 30),
             sourceSummary: "Reviewed launch status.",
-            outcomes: "Decision: ship after verification.")
+            outcomes: "Decision: ship after verification.",
+            artifactModifiedAt: nil)
         let evidence = DayDigestEvidence.build(
             day: day,
             blocks: blocks,
@@ -409,7 +410,8 @@ final class DayDigestEvidenceTests: XCTestCase {
             startedAt: time(9, 8),
             endedAt: time(9, 9),
             sourceSummary: "## TL;DR\nKept the critical meeting detail visible.",
-            outcomes: "Decision: retain the meeting evidence.")
+            outcomes: "Decision: retain the meeting evidence.",
+            artifactModifiedAt: nil)
         let evidence = DayDigestEvidence.build(
             day: day,
             blocks: blocks,
@@ -736,7 +738,8 @@ final class DayDigestEvidenceTests: XCTestCase {
             startedAt: time(10),
             endedAt: time(10, 30),
             sourceSummary: "## TL;DR\nReviewed deployment progress and open bugs.",
-            outcomes: "Decision: keep the current deployment tool.")
+            outcomes: "Decision: keep the current deployment tool.",
+            artifactModifiedAt: nil)
         let evidence = DayDigestEvidence.build(
             day: day,
             blocks: [],
@@ -784,6 +787,53 @@ final class DayDigestEvidenceTests: XCTestCase {
             generatedAt: time(19))
         XCTAssertEqual(repaired.degradedAttemptCount, 0)
         XCTAssertNotNil(DayDigestGenerationMetadataStore.completedAt(for: journal))
+    }
+
+    func testNewMeetingArtifactResetsExhaustedDegradedRepairBudget() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let journal = directory.appendingPathComponent("2026-08-20.md")
+        try "digest".write(to: journal, atomically: true, encoding: .utf8)
+        let meetingEnd = time(17)
+
+        for attempt in 1...DayDigestGenerationMetadataStore.maximumDegradedAttempts {
+            _ = try DayDigestGenerationMetadataStore.record(
+                quality: .fallback,
+                evidenceLatestAt: meetingEnd,
+                for: journal,
+                generatedAt: time(18, attempt))
+        }
+        XCTAssertNotNil(DayDigestGenerationMetadataStore.completedAt(for: journal))
+
+        let artifactModifiedAt = time(17, 30)
+        let evidence = DayDigestEvidence.build(
+            day: day,
+            blocks: [],
+            screenContexts: [],
+            meetings: [DayDigestMeetingEvidence(
+                id: UUID(),
+                title: "Architecture sync",
+                app: "Meet",
+                startedAt: time(16),
+                endedAt: meetingEnd,
+                sourceSummary: "Recovered architecture decisions.",
+                outcomes: "Decision: ship.",
+                artifactModifiedAt: artifactModifiedAt)],
+            calendar: calendar)
+        XCTAssertEqual(evidence.latestEvidenceAt, artifactModifiedAt)
+
+        let reopened = try DayDigestGenerationMetadataStore.record(
+            quality: .fallback,
+            evidenceLatestAt: evidence.latestEvidenceAt,
+            for: journal,
+            generatedAt: time(19))
+
+        XCTAssertEqual(reopened.degradedAttemptCount, 1)
+        XCTAssertNil(DayDigestGenerationMetadataStore.completedAt(for: journal))
     }
 
     func testInvalidFocusOutputFallsBackToNamedActivityWithoutAppMetadata() async throws {

--- a/LokalBotTests/DayDigestLifecycleTests.swift
+++ b/LokalBotTests/DayDigestLifecycleTests.swift
@@ -105,6 +105,178 @@ final class DayDigestLifecycleTests: XCTestCase {
         XCTAssertEqual(receivedScreens, [screen])
     }
 
+    func testSummaryWrittenAfterDigestAdvancesEvidenceAndMarksSnapshotStale() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("day-digest-lifecycle-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let day = try date("2026-08-23T12:00:00Z")
+        let meeting = try finishedMeeting()
+        let folder = root.appendingPathComponent(meeting.relativePath, isDirectory: true)
+        let journal = root.appendingPathComponent("journal/2026-08-23.md")
+        try FileManager.default.createDirectory(
+            at: folder,
+            withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: journal.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try "## Day summary\n\nInitial digest.".write(
+            to: journal,
+            atomically: true,
+            encoding: .utf8)
+        let digestAt = try date("2026-08-23T10:00:00Z")
+        try FileManager.default.setAttributes(
+            [.modificationDate: digestAt],
+            ofItemAtPath: journal.path)
+
+        let lifecycle = makeLifecycle(
+            root: root,
+            meetings: { [meeting] },
+            latestActivityEvidenceAt: { _ in nil })
+        XCTAssertFalse(lifecycle.snapshot(for: day).isStale)
+
+        let summary = folder.appendingPathComponent("summary.md")
+        try "## TL;DR\n\nArchitecture shipped.".write(
+            to: summary,
+            atomically: true,
+            encoding: .utf8)
+        let summaryAt = try date("2026-08-23T10:05:00Z")
+        try FileManager.default.setAttributes(
+            [.modificationDate: summaryAt],
+            ofItemAtPath: summary.path)
+
+        let snapshot = lifecycle.snapshot(for: day)
+        XCTAssertEqual(snapshot.latestEvidenceAt, summaryAt)
+        XCTAssertTrue(snapshot.isStale)
+    }
+
+    func testOutcomesWrittenAfterDigestMakeAutomaticGenerationRepairIt() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("day-digest-lifecycle-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let day = try date("2026-08-23T12:00:00Z")
+        let now = try date("2026-08-23T19:00:00Z")
+        let meeting = try finishedMeeting()
+        let folder = root.appendingPathComponent(meeting.relativePath, isDirectory: true)
+        let journal = root.appendingPathComponent("journal/2026-08-23.md")
+        try FileManager.default.createDirectory(
+            at: folder,
+            withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: journal.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try "## Day summary\n\nInitial digest.".write(
+            to: journal,
+            atomically: true,
+            encoding: .utf8)
+        let digestAt = try date("2026-08-23T18:01:00Z")
+        try FileManager.default.setAttributes(
+            [.modificationDate: digestAt],
+            ofItemAtPath: journal.path)
+
+        try MeetingOutcomes(decisions: ["Ship the lifecycle."]).write(to: folder)
+        let outcomes = folder.appendingPathComponent(MeetingOutcomes.fileName)
+        let outcomesAt = try date("2026-08-23T18:05:00Z")
+        try FileManager.default.setAttributes(
+            [.modificationDate: outcomesAt],
+            ofItemAtPath: outcomes.path)
+
+        let generated = expectation(description: "stale digest repaired")
+        let scheduler = DayDigestScheduler(calendar: calendar, now: { now })
+        let lifecycle = DayDigestLifecycle(
+            storageRoot: root,
+            calendar: calendar,
+            scheduler: scheduler,
+            blocks: { _ in [] },
+            screenContexts: { _ in [] },
+            meetings: { [meeting] },
+            latestActivityEvidenceAt: { _ in nil },
+            settings: AppSettings.init,
+            generator: { generatedDay, _, receivedMeetings, _, _ in
+                XCTAssertEqual(DreamDay.key(for: generatedDay, calendar: self.calendar),
+                               "2026-08-23")
+                XCTAssertEqual(receivedMeetings, [meeting])
+                generated.fulfill()
+                return DayDigestGenerationResult(
+                    text: "repaired",
+                    url: journal,
+                    quality: .complete)
+            })
+        let snapshot = lifecycle.snapshot(for: day)
+        XCTAssertEqual(snapshot.latestEvidenceAt, outcomesAt)
+        XCTAssertTrue(snapshot.isStale)
+
+        lifecycle.configureAutomaticGeneration(
+            .init(enabled: true, hour: 18),
+            canRun: { true },
+            onError: { XCTFail($0) })
+        await fulfillment(of: [generated], timeout: 2)
+        lifecycle.stopAutomaticGeneration()
+    }
+
+    func testArtifactWrittenAfterYesterdayFinalizationReopensAutomaticRepair() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("day-digest-lifecycle-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let day = try date("2026-08-23T12:00:00Z")
+        let now = try date("2026-08-24T08:00:00Z")
+        let meeting = try finishedMeeting()
+        let folder = root.appendingPathComponent(meeting.relativePath, isDirectory: true)
+        let journal = root.appendingPathComponent("journal/2026-08-23.md")
+        try FileManager.default.createDirectory(
+            at: folder,
+            withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: journal.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try "## Day summary\n\nFinalized digest.".write(
+            to: journal,
+            atomically: true,
+            encoding: .utf8)
+        let finalizedAt = try date("2026-08-24T00:05:00Z")
+        try FileManager.default.setAttributes(
+            [.modificationDate: finalizedAt],
+            ofItemAtPath: journal.path)
+
+        let summary = folder.appendingPathComponent("summary.md")
+        try "## TL;DR\n\nRecovered after finalization.".write(
+            to: summary,
+            atomically: true,
+            encoding: .utf8)
+        let summaryAt = try date("2026-08-24T00:10:00Z")
+        try FileManager.default.setAttributes(
+            [.modificationDate: summaryAt],
+            ofItemAtPath: summary.path)
+
+        let generated = expectation(description: "finalized digest repaired")
+        let scheduler = DayDigestScheduler(calendar: calendar, now: { now })
+        let lifecycle = DayDigestLifecycle(
+            storageRoot: root,
+            calendar: calendar,
+            scheduler: scheduler,
+            blocks: { _ in [] },
+            screenContexts: { _ in [] },
+            meetings: { [meeting] },
+            latestActivityEvidenceAt: { _ in nil },
+            settings: AppSettings.init,
+            generator: { generatedDay, _, _, _, _ in
+                XCTAssertEqual(DreamDay.key(for: generatedDay, calendar: self.calendar),
+                               "2026-08-23")
+                generated.fulfill()
+                return DayDigestGenerationResult(
+                    text: "repaired",
+                    url: journal,
+                    quality: .complete)
+            })
+        XCTAssertTrue(lifecycle.snapshot(for: day).isStale)
+
+        lifecycle.configureAutomaticGeneration(
+            .init(enabled: true, hour: 18),
+            canRun: { true },
+            onError: { XCTFail($0) })
+        await fulfillment(of: [generated], timeout: 2)
+        lifecycle.stopAutomaticGeneration()
+    }
+
     func testHeadlessOutputKeepsJournalPathAtStablePosition() throws {
         let day = try date("2026-08-23T12:00:00Z")
         let result = DayDigestGenerationResult(
@@ -125,6 +297,7 @@ final class DayDigestLifecycleTests: XCTestCase {
 
     private func makeLifecycle(
         root: URL,
+        meetings: @escaping () -> [Meeting] = { [] },
         latestActivityEvidenceAt: @escaping (Date) -> Date?
     ) -> DayDigestLifecycle {
         DayDigestLifecycle(
@@ -132,7 +305,7 @@ final class DayDigestLifecycleTests: XCTestCase {
             calendar: calendar,
             blocks: { _ in [] },
             screenContexts: { _ in [] },
-            meetings: { [] },
+            meetings: meetings,
             latestActivityEvidenceAt: latestActivityEvidenceAt,
             settings: AppSettings.init,
             generator: { day, _, _, _, _ in
@@ -142,5 +315,15 @@ final class DayDigestLifecycleTests: XCTestCase {
                         "journal/\(DreamDay.key(for: day)).md"),
                     quality: .complete)
             })
+    }
+
+    private func finishedMeeting() throws -> Meeting {
+        Meeting(
+            id: UUID(),
+            title: "Architecture",
+            appName: "Meet",
+            startedAt: try date("2026-08-23T09:00:00Z"),
+            endedAt: try date("2026-08-23T09:30:00Z"),
+            relativePath: "meetings/architecture")
     }
 }

--- a/LokalBotTests/DayDigestLifecycleTests.swift
+++ b/LokalBotTests/DayDigestLifecycleTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import LokalBot
+
+@MainActor
+final class DayDigestLifecycleTests: XCTestCase {
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private func date(_ value: String) throws -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return try XCTUnwrap(formatter.date(from: value))
+    }
+
+    func testSnapshotOwnsJournalFreshnessAndLatestEvidence() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("day-digest-lifecycle-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let day = try date("2026-08-23T12:00:00Z")
+        let journal = root.appendingPathComponent("journal/2026-08-23.md")
+        try FileManager.default.createDirectory(
+            at: journal.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try "## Focus\n\nShipped the lifecycle.".write(
+            to: journal,
+            atomically: true,
+            encoding: .utf8)
+        let modifiedAt = try date("2026-08-23T18:00:00Z")
+        try FileManager.default.setAttributes(
+            [.modificationDate: modifiedAt],
+            ofItemAtPath: journal.path)
+        let latestEvidenceAt = try date("2026-08-23T18:30:00Z")
+
+        let lifecycle = makeLifecycle(
+            root: root,
+            latestActivityEvidenceAt: { _ in latestEvidenceAt })
+        let snapshot = lifecycle.snapshot(for: day)
+
+        XCTAssertEqual(snapshot.text, "## Focus\n\nShipped the lifecycle.")
+        XCTAssertEqual(snapshot.modifiedAt, modifiedAt)
+        XCTAssertEqual(snapshot.latestEvidenceAt, latestEvidenceAt)
+        XCTAssertTrue(snapshot.isStale)
+    }
+
+    func testGenerateCollectsFinishedDayEvidenceThroughOneInterface() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("day-digest-lifecycle-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let day = try date("2026-08-23T12:00:00Z")
+        let finished = Meeting(
+            id: UUID(),
+            title: "Architecture",
+            appName: "Meet",
+            startedAt: try date("2026-08-23T09:00:00Z"),
+            endedAt: try date("2026-08-23T09:30:00Z"),
+            relativePath: "meetings/architecture")
+        let inProgress = Meeting(
+            id: UUID(),
+            title: "Live",
+            appName: "Meet",
+            startedAt: try date("2026-08-23T11:00:00Z"),
+            endedAt: nil,
+            relativePath: "meetings/live")
+        let block = ActivityBlock(
+            id: 7,
+            app: "Xcode",
+            title: "DayDigestLifecycle.swift",
+            start: try date("2026-08-23T10:00:00Z"),
+            end: try date("2026-08-23T10:30:00Z"))
+        let screen = DayScreenContext(
+            snapshotID: 42,
+            capturedAt: try date("2026-08-23T10:15:00Z"),
+            app: "Xcode",
+            windowTitle: "LokalBot",
+            text: "Deepen the Day Digest module")
+        var receivedBlocks: [ActivityBlock] = []
+        var receivedMeetings: [Meeting] = []
+        var receivedScreens: [DayScreenContext] = []
+
+        let lifecycle = DayDigestLifecycle(
+            storageRoot: root,
+            calendar: calendar,
+            blocks: { _ in [block] },
+            screenContexts: { _ in [screen] },
+            meetings: { [finished, inProgress] },
+            latestActivityEvidenceAt: { _ in nil },
+            settings: AppSettings.init,
+            generator: { _, blocks, meetings, screens, _ in
+                receivedBlocks = blocks
+                receivedMeetings = meetings
+                receivedScreens = screens
+                return DayDigestGenerationResult(
+                    text: "digest",
+                    url: root.appendingPathComponent("journal/2026-08-23.md"),
+                    quality: .complete)
+            })
+
+        _ = try await lifecycle.generate(for: day)
+
+        XCTAssertEqual(receivedBlocks, [block])
+        XCTAssertEqual(receivedMeetings, [finished])
+        XCTAssertEqual(receivedScreens, [screen])
+    }
+
+    func testHeadlessOutputKeepsJournalPathAtStablePosition() throws {
+        let day = try date("2026-08-23T12:00:00Z")
+        let result = DayDigestGenerationResult(
+            text: "## Focus",
+            url: URL(fileURLWithPath: "/tmp/journal/2026-08-23.md"),
+            quality: .complete)
+
+        let output = DayDigestCLIOutput.render(
+            result: result,
+            modelID: "qwen",
+            day: day)
+
+        XCTAssertTrue(output.hasPrefix(
+            "LokalBot --digest: /tmp/journal/2026-08-23.md ("))
+        XCTAssertTrue(output.contains("model=qwen"))
+        XCTAssertTrue(output.contains("day=2026-08-23"))
+    }
+
+    private func makeLifecycle(
+        root: URL,
+        latestActivityEvidenceAt: @escaping (Date) -> Date?
+    ) -> DayDigestLifecycle {
+        DayDigestLifecycle(
+            storageRoot: root,
+            calendar: calendar,
+            blocks: { _ in [] },
+            screenContexts: { _ in [] },
+            meetings: { [] },
+            latestActivityEvidenceAt: latestActivityEvidenceAt,
+            settings: AppSettings.init,
+            generator: { day, _, _, _, _ in
+                DayDigestGenerationResult(
+                    text: "",
+                    url: root.appendingPathComponent(
+                        "journal/\(DreamDay.key(for: day)).md"),
+                    quality: .complete)
+            })
+    }
+}

--- a/LokalBotTests/DreamingTests.swift
+++ b/LokalBotTests/DreamingTests.swift
@@ -206,6 +206,31 @@ final class DreamingTests: XCTestCase {
         scheduler.stop()
     }
 
+    @MainActor
+    func testManualDreamRunsWhenAutomationIsDisabledAndBypassesScheduleGates() async throws {
+        let current = try date("2026-07-19T12:00:00Z")
+        let scheduler = DreamScheduler(calendar: calendar, now: { current })
+        let started = expectation(description: "manual dream started")
+        var dreamedDayKey: String?
+
+        scheduler.configure(
+            .init(enabled: false, hour: 23, firstEligibleDayKey: ""),
+            hasReport: { _ in true },
+            canRun: { false },
+            dream: { target in
+                dreamedDayKey = target.dayKey
+                started.fulfill()
+            },
+            onError: { XCTFail($0) })
+
+        scheduler.dreamNow()
+
+        await fulfillment(of: [started], timeout: 5)
+        while scheduler.isDreaming { await Task.yield() }
+        XCTAssertEqual(dreamedDayKey, "2026-07-18")
+        scheduler.stop()
+    }
+
     func testDreamingActivationBoundaryDefaultsAndRoundTrips() throws {
         let defaults = AppSettings()
         XCTAssertTrue(defaults.dreamingEnabled)
@@ -854,6 +879,37 @@ final class DreamingTests: XCTestCase {
             report,
             referenceDate: try date("2026-07-19T08:00:00Z"),
             calendar: calendar))
+    }
+
+    func testTodayRetryIsLimitedToCurrentModelFailureFallbacks() throws {
+        let referenceDate = try date("2026-07-19T08:00:00Z")
+        var report = DreamReport(
+            day: "2026-07-18",
+            generatedAt: try date("2026-07-19T04:01:00Z"),
+            engineName: nil,
+            fallbackReason: .engineUnavailable,
+            narrative: "Evidence only.")
+
+        XCTAssertTrue(TodayDreamSelection.isRetryableFailure(
+            report, referenceDate: referenceDate, calendar: calendar))
+        report.fallbackReason = .unparseableResponse
+        XCTAssertTrue(TodayDreamSelection.isRetryableFailure(
+            report, referenceDate: referenceDate, calendar: calendar))
+        report.fallbackReason = nil // Legacy evidence-only report.
+        XCTAssertTrue(TodayDreamSelection.isRetryableFailure(
+            report, referenceDate: referenceDate, calendar: calendar))
+
+        report.fallbackReason = .emptyDay
+        XCTAssertFalse(TodayDreamSelection.isRetryableFailure(
+            report, referenceDate: referenceDate, calendar: calendar))
+        report.fallbackReason = .engineUnavailable
+        report.engineName = "Built-in — Test"
+        XCTAssertFalse(TodayDreamSelection.isRetryableFailure(
+            report, referenceDate: referenceDate, calendar: calendar))
+        report.engineName = nil
+        report.day = "2026-07-17"
+        XCTAssertFalse(TodayDreamSelection.isRetryableFailure(
+            report, referenceDate: referenceDate, calendar: calendar))
     }
 
     func testPrioritiesHeadingFramesStaleBriefsByTheirDay() throws {

--- a/LokalBotTests/ModelRolesTests.swift
+++ b/LokalBotTests/ModelRolesTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import LokalBot
+
+final class ModelRolesTests: XCTestCase {
+    func testCoreReadyOnlyWhenEveryRoleIsReady() {
+        let snapshot = makeSnapshot(statuses: [
+            .transcribe: .ready,
+            .think: .ready,
+            .autocomplete: .ready,
+        ])
+
+        XCTAssertTrue(snapshot.coreReady)
+        XCTAssertEqual(snapshot.primaryActionStatus, .ready)
+    }
+
+    func testFailureStopsOnboardingSpinnerAndOffersRecovery() {
+        let snapshot = makeSnapshot(statuses: [
+            .transcribe: .ready,
+            .think: .needsAttention("Network unavailable"),
+            .autocomplete: .unavailable,
+        ])
+
+        XCTAssertEqual(snapshot.primaryActionStatus, .needsAttention("Network unavailable"))
+        XCTAssertEqual(
+            snapshot.detail,
+            "A selected model needs attention before the stack is ready.")
+    }
+
+    func testPreparationAndDownloadExposeRoleSpecificProgress() {
+        let preparing = makeSnapshot(statuses: [
+            .transcribe: .preparing(progress: 0.25, label: "Loading vocabulary…"),
+            .think: .unavailable,
+            .autocomplete: .unavailable,
+        ])
+        let downloading = makeSnapshot(statuses: [
+            .transcribe: .ready,
+            .think: .downloading(progress: 0.42),
+            .autocomplete: .unavailable,
+        ])
+
+        XCTAssertEqual(
+            preparing.primaryActionStatus,
+            .preparing(progress: 0.25, label: "Loading vocabulary…"))
+        XCTAssertEqual(downloading.primaryActionStatus.label, "Downloading… 42%")
+    }
+
+    func testMissingStatusDefaultsToUnavailable() {
+        let snapshot = makeSnapshot(statuses: [.transcribe: .ready])
+
+        XCTAssertEqual(snapshot[.think], .unavailable)
+        XCTAssertFalse(snapshot.coreReady)
+    }
+
+    private func makeSnapshot(
+        statuses: [ModelRole: ModelRoleStatus]
+    ) -> ModelRolesSnapshot {
+        ModelRolesSnapshot(
+            readiness: ModelReadinessSnapshot(
+                transcriptionReady: statuses[.transcribe]?.isReady == true,
+                thinkReady: statuses[.think]?.isReady == true,
+                autocompleteReady: statuses[.autocomplete]?.isReady == true,
+                provenance: .local,
+                storedBytes: 0,
+                availableBytes: nil,
+                activeDownloads: statuses.values.filter(\.isWorking).count,
+                failedDownloads: statuses.values.filter {
+                    $0.errorMessage != nil
+                }.count),
+            statuses: statuses)
+    }
+}

--- a/LokalBotTests/ModelRolesTests.swift
+++ b/LokalBotTests/ModelRolesTests.swift
@@ -1,7 +1,54 @@
 import XCTest
 @testable import LokalBot
 
+@MainActor
 final class ModelRolesTests: XCTestCase {
+    private enum TestPreparationError: LocalizedError {
+        case failed
+
+        var errorDescription: String? { "Expected preparation failure" }
+    }
+
+    private actor PreparationGate {
+        private var started = false
+        private var released = false
+        private var completed = false
+        private var startWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+        private var completionWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func run() async {
+            started = true
+            let waitingForStart = startWaiters
+            startWaiters.removeAll()
+            for waiter in waitingForStart { waiter.resume() }
+            if !released {
+                await withCheckedContinuation { releaseWaiters.append($0) }
+            }
+            completed = true
+            let waitingForCompletion = completionWaiters
+            completionWaiters.removeAll()
+            for waiter in waitingForCompletion { waiter.resume() }
+        }
+
+        func waitUntilStarted() async {
+            if started { return }
+            await withCheckedContinuation { startWaiters.append($0) }
+        }
+
+        func release() {
+            released = true
+            let waiters = releaseWaiters
+            releaseWaiters.removeAll()
+            for waiter in waiters { waiter.resume() }
+        }
+
+        func waitUntilCompleted() async {
+            if completed { return }
+            await withCheckedContinuation { completionWaiters.append($0) }
+        }
+    }
+
     func testCoreReadyOnlyWhenEveryRoleIsReady() {
         let snapshot = makeSnapshot(statuses: [
             .transcribe: .ready,
@@ -51,6 +98,124 @@ final class ModelRolesTests: XCTestCase {
         XCTAssertFalse(snapshot.coreReady)
     }
 
+    func testRetryRerunsFailedPreparationWhenModelIsAlreadyDownloaded() async {
+        let storage = temporaryStorage()
+        defer { try? FileManager.default.removeItem(at: storage.rootURL) }
+        let settings = isolatedSettings(transcription: .graniteSpeech)
+        var preparationAttempts = 0
+        let roles = ModelRoles(
+            settings: { settings },
+            storage: storage,
+            downloads: ModelDownloadManager(),
+            prepareTranscription: { _, _, _ in
+                preparationAttempts += 1
+                if preparationAttempts == 1 { throw TestPreparationError.failed }
+            },
+            downloadedTranscriptionModels: { _ in [TranscriptionModelChoice.graniteSpeech.id] },
+            onReadinessChanged: {})
+
+        roles.prepareTranscriptionModel(.graniteSpeech)
+        await waitUntil {
+            preparationAttempts == 1 && !roles.isPreparingTranscription
+        }
+        XCTAssertNotNil(roles.transcriptionErrors[TranscriptionModelChoice.graniteSpeech.id])
+
+        roles.startCoreModelDownloads()
+        await waitUntil {
+            preparationAttempts == 2 && !roles.isPreparingTranscription
+        }
+
+        XCTAssertNil(roles.transcriptionErrors[TranscriptionModelChoice.graniteSpeech.id])
+        XCTAssertEqual(roles.transcriptionStatus(for: .graniteSpeech), .ready)
+    }
+
+    func testSelectingActivePreparationKeepsItRunningButChangingAwayCancelsIt() async {
+        let storage = temporaryStorage()
+        defer { try? FileManager.default.removeItem(at: storage.rootURL) }
+        var settings = isolatedSettings(transcription: .parakeetV3)
+        let gate = PreparationGate()
+        let roles = ModelRoles(
+            settings: { settings },
+            storage: storage,
+            downloads: ModelDownloadManager(),
+            prepareTranscription: { _, _, _ in await gate.run() },
+            downloadedTranscriptionModels: { _ in [] },
+            onReadinessChanged: {})
+
+        roles.prepareTranscriptionModel(.qwenASR06B)
+        await gate.waitUntilStarted()
+
+        var previous = settings
+        settings.transcriptionModel = .qwenASR06B
+        roles.settingsDidChange(from: previous, to: settings)
+        XCTAssertTrue(roles.isPreparingTranscription,
+                      "selecting the active preparation must keep its progress alive")
+
+        previous = settings
+        settings.transcriptionModel = .parakeetV3
+        roles.settingsDidChange(from: previous, to: settings)
+        XCTAssertFalse(roles.isPreparingTranscription,
+                       "changing away from the active selected model should cancel it")
+
+        await gate.release()
+        await gate.waitUntilCompleted()
+    }
+
+    func testGraniteConfigurationChangeClearsFailureFromPreviousConfiguration() async throws {
+        let storage = temporaryStorage()
+        defer { try? FileManager.default.removeItem(at: storage.rootURL) }
+        var settings = isolatedSettings(transcription: .graniteSpeech)
+        let roles = ModelRoles(
+            settings: { settings },
+            storage: storage,
+            downloads: ModelDownloadManager(),
+            prepareTranscription: { _, _, _ in throw TestPreparationError.failed },
+            downloadedTranscriptionModels: { _ in [TranscriptionModelChoice.graniteSpeech.id] },
+            onReadinessChanged: {})
+
+        roles.prepareTranscriptionModel(.graniteSpeech)
+        await waitUntil { !roles.isPreparingTranscription }
+        XCTAssertNotNil(roles.transcriptionErrors[TranscriptionModelChoice.graniteSpeech.id])
+
+        let previous = settings
+        settings.graniteSpeechModel = try alternateGraniteConfiguration()
+        roles.settingsDidChange(from: previous, to: settings)
+
+        XCTAssertNil(roles.transcriptionErrors[TranscriptionModelChoice.graniteSpeech.id])
+        XCTAssertEqual(roles.transcriptionStatus(for: .graniteSpeech), .ready)
+    }
+
+    func testDeletingGGUFThroughModelRolesInvalidatesReadiness() throws {
+        let storage = temporaryStorage()
+        defer { try? FileManager.default.removeItem(at: storage.rootURL) }
+        let entry = try XCTUnwrap(ModelCatalog.entry(id: ModelCatalog.defaultSummarizationID))
+        let modelURL = storage.rootURL.appendingPathComponent("models/\(entry.fileName)")
+        try FileManager.default.createDirectory(
+            at: modelURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try Data("GGUF".utf8).write(to: modelURL)
+        var settings = isolatedSettings(transcription: .graniteSpeech)
+        settings.summarizerBackend = .builtIn
+        settings.builtInModelID = entry.id
+        var readinessChanges = 0
+        let roles = ModelRoles(
+            settings: { settings },
+            storage: storage,
+            downloads: ModelDownloadManager(),
+            downloadedTranscriptionModels: { _ in [] },
+            onReadinessChanged: { readinessChanges += 1 })
+
+        XCTAssertEqual(roles.snapshot[.think], .ready)
+        let previousRevision = roles.revision
+
+        roles.deleteGGUFModel(entry)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: modelURL.path))
+        XCTAssertEqual(roles.snapshot[.think], .unavailable)
+        XCTAssertGreaterThan(roles.revision, previousRevision)
+        XCTAssertEqual(readinessChanges, 1)
+    }
+
     private func makeSnapshot(
         statuses: [ModelRole: ModelRoleStatus]
     ) -> ModelRolesSnapshot {
@@ -67,5 +232,45 @@ final class ModelRolesTests: XCTestCase {
                     $0.errorMessage != nil
                 }.count),
             statuses: statuses)
+    }
+
+    private func isolatedSettings(
+        transcription: TranscriptionModelChoice
+    ) -> AppSettings {
+        var settings = AppSettings()
+        settings.transcriptionModel = transcription
+        settings.summarizerBackend = .appleIntelligence
+        settings.cotypingBuiltInModelID = "model-roles-test-no-download"
+        return settings
+    }
+
+    private func temporaryStorage() -> StorageManager {
+        StorageManager(rootURL: FileManager.default.temporaryDirectory
+            .appendingPathComponent("model-roles-tests-\(UUID().uuidString)", isDirectory: true))
+    }
+
+    private func alternateGraniteConfiguration() throws -> GraniteSpeechModelConfiguration {
+        try GraniteSpeechModelConfiguration(
+            repository: "lokalbot-tests/granite-speech",
+            revision: String(repeating: "a", count: 40),
+            model: .init(
+                path: "granite-speech-test-Q4_K_M.gguf",
+                sizeBytes: 8,
+                sha256: String(repeating: "b", count: 64)),
+            projector: .init(
+                path: "mmproj-model-test.gguf",
+                sizeBytes: 8,
+                sha256: String(repeating: "c", count: 64)))
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 1,
+        _ condition: () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        XCTAssertTrue(condition(), "Timed out waiting for ModelRoles state")
     }
 }

--- a/LokalBotTests/NavigationHandoffTests.swift
+++ b/LokalBotTests/NavigationHandoffTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import LokalBot
+
+@MainActor
+final class NavigationHandoffTests: XCTestCase {
+    func testAskHandoffIsAtomicLatestWinsAndConsumesOnce() {
+        let handoff = NavigationHandoff()
+        let day = Date(timeIntervalSince1970: 1_700_000_000)
+
+        handoff.stageAsk(
+            query: "first",
+            dayScope: nil,
+            screenSnapshotIDs: [1],
+            submit: false)
+        handoff.stageAsk(
+            query: "second",
+            dayScope: day,
+            screenSnapshotIDs: [2, 3],
+            submit: true)
+
+        XCTAssertEqual(
+            handoff.consumeAsk(),
+            AskNavigationHandoff(
+                query: "second",
+                dayScope: day,
+                screenSnapshotIDs: [2, 3],
+                submit: true))
+        XCTAssertNil(handoff.consumeAsk())
+    }
+
+    func testMeetingSeekOnlyMatchesItsDestination() {
+        let handoff = NavigationHandoff()
+        let expectedMeetingID = UUID()
+
+        handoff.stageMeeting(expectedMeetingID, seek: 42)
+
+        XCTAssertNil(handoff.consumeMeetingSeek(for: UUID()))
+        XCTAssertEqual(handoff.consumeMeetingSeek(for: expectedMeetingID), 42)
+        XCTAssertNil(handoff.consumeMeetingSeek(for: expectedMeetingID))
+    }
+
+    func testOpeningMeetingWithoutSeekClearsOlderRequest() {
+        let handoff = NavigationHandoff()
+        let meetingID = UUID()
+
+        handoff.stageMeeting(meetingID, seek: 42)
+        handoff.stageMeeting(meetingID, seek: nil)
+
+        XCTAssertNil(handoff.consumeMeetingSeek(for: meetingID))
+    }
+
+    func testDestinationPayloadsCanCoexist() {
+        let handoff = NavigationHandoff()
+        let context = AgentLaunchContext(
+            title: "Prepare follow-up",
+            prompt: "Draft the note",
+            meetingID: UUID(),
+            actionID: "action-1")
+
+        handoff.stageAsk(
+            query: "roadmap",
+            dayScope: nil,
+            screenSnapshotIDs: [],
+            submit: false)
+        handoff.stageScreenSnapshot(77)
+        handoff.stageAgent(context)
+
+        XCTAssertEqual(handoff.consumeScreenSnapshot(), 77)
+        XCTAssertEqual(handoff.consumeAsk()?.query, "roadmap")
+        XCTAssertEqual(handoff.agentContext, context)
+        XCTAssertEqual(handoff.consumeAgentContext(), context)
+        XCTAssertNil(handoff.agentContext)
+    }
+}

--- a/LokalBotTests/ProcessingPipelineAutomationGateTests.swift
+++ b/LokalBotTests/ProcessingPipelineAutomationGateTests.swift
@@ -280,24 +280,6 @@ final class ProcessingPipelineAutomationGateTests: XCTestCase {
             "non-readiness settings must not churn parked jobs")
     }
 
-    func testOnboardingDownloadStateStopsSpinningAndAllowsRetryAfterFailure() {
-        XCTAssertEqual(
-            OnboardingModelDownloadState.resolve(
-                coreReady: false, activeDownloads: 0,
-                isPreparingTranscription: false, error: "Network unavailable"),
-            .download(error: "Network unavailable"))
-        XCTAssertEqual(
-            OnboardingModelDownloadState.resolve(
-                coreReady: false, activeDownloads: 0,
-                isPreparingTranscription: true, error: nil),
-            .downloading)
-        XCTAssertEqual(
-            OnboardingModelDownloadState.resolve(
-                coreReady: true, activeDownloads: 0,
-                isPreparingTranscription: false, error: nil),
-            .ready)
-    }
-
     func testForgetDropsParkedJobsForDeletedMeetings() async throws {
         let root = try makeRoot()
         let jobStore = PipelineJobStore(

--- a/LokalBotTests/ProcessingPipelineModelPreparationTests.swift
+++ b/LokalBotTests/ProcessingPipelineModelPreparationTests.swift
@@ -74,8 +74,8 @@ final class ProcessingPipelineModelPreparationTests: XCTestCase {
                 return url
             })
 
-        _ = try await pipeline.makeTextEngine(settings)
-        _ = try await pipeline.makeTextEngine(settings)
+        _ = try await pipeline.thinkExecution.makeTextEngine(settings)
+        _ = try await pipeline.thinkExecution.makeTextEngine(settings)
 
         XCTAssertEqual(preparationCount, 1,
                        "first use downloads once; later summaries reuse the validated model")

--- a/LokalBotTests/TextEngineTests.swift
+++ b/LokalBotTests/TextEngineTests.swift
@@ -269,6 +269,38 @@ final class TextEngineTests: XCTestCase {
         XCTAssertNil(body["temperature"])
     }
 
+    func testOpenRouterSchemaOnlyFallbackDropsStructuredRequirements() throws {
+        let engine = OpenAICompatibleEngine(
+            baseURL: URL(string: "https://openrouter.ai/api/v1")!,
+            model: "stealth/ox-alpha",
+            apiKey: "test-token",
+            chatDialect: .openRouter)
+        let schema: [String: Any] = [
+            "type": "object",
+            "properties": ["answer": ["type": "string"]],
+            "required": ["answer"],
+            "additionalProperties": false,
+        ]
+
+        let request = try engine.makeChatRequest(
+            system: "system",
+            prompt: "prompt",
+            context: [],
+            schema: schema,
+            options: nil,
+            openRouterReasoning: .highEffort)
+        let data = try XCTUnwrap(request.httpBody)
+        let body = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let reasoning = try XCTUnwrap(body["reasoning"] as? [String: Any])
+        let provider = try XCTUnwrap(body["provider"] as? [String: Any])
+
+        XCTAssertEqual(reasoning["effort"] as? String, "high")
+        XCTAssertNil(body["response_format"])
+        XCTAssertEqual(provider["data_collection"] as? String, "deny")
+        XCTAssertNil(provider["require_parameters"])
+    }
+
     func testOpenRouterParameterMismatchTriggersHighReasoningFallbackOnce() {
         let mismatch = TextEngineError.httpStatus(
             code: 404,
@@ -281,22 +313,33 @@ final class TextEngineTests: XCTestCase {
 
         XCTAssertTrue(OpenAICompatibleEngine.shouldFallbackToHighReasoning(
             dialect: .openRouter, error: mismatch, usedFallback: false,
+            requestedSchema: false,
             requestedReasoningBudget: 256))
         XCTAssertTrue(OpenAICompatibleEngine.shouldFallbackToHighReasoning(
             dialect: .openRouter, error: mismatch, usedFallback: false,
+            requestedSchema: false,
             requestedReasoningBudget: 0),
                        "effort:none retries also need the high-reasoning fallback")
+        XCTAssertTrue(OpenAICompatibleEngine.shouldFallbackToHighReasoning(
+            dialect: .openRouter, error: mismatch, usedFallback: false,
+            requestedSchema: true,
+            requestedReasoningBudget: nil),
+                       "schema-only callers such as Dreaming need the compatibility fallback")
         XCTAssertFalse(OpenAICompatibleEngine.shouldFallbackToHighReasoning(
             dialect: .openRouter, error: mismatch, usedFallback: true,
+            requestedSchema: true,
             requestedReasoningBudget: 256))
         XCTAssertFalse(OpenAICompatibleEngine.shouldFallbackToHighReasoning(
             dialect: .openRouter, error: missingModel, usedFallback: false,
+            requestedSchema: true,
             requestedReasoningBudget: 256))
         XCTAssertFalse(OpenAICompatibleEngine.shouldFallbackToHighReasoning(
             dialect: .generic, error: mismatch, usedFallback: false,
+            requestedSchema: true,
             requestedReasoningBudget: 256))
         XCTAssertFalse(OpenAICompatibleEngine.shouldFallbackToHighReasoning(
             dialect: .openRouter, error: mismatch, usedFallback: false,
+            requestedSchema: false,
             requestedReasoningBudget: nil))
     }
 

--- a/LokalBotTests/ThinkExecutionTests.swift
+++ b/LokalBotTests/ThinkExecutionTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import LokalBot
+
+@MainActor
+final class ThinkExecutionTests: XCTestCase {
+    func testBuiltInManagedRecoveryDoesNotStackProviderRetry() {
+        let execution = ThinkExecution(storage: StorageManager())
+        var settings = AppSettings()
+        settings.summarizerBackend = .builtIn
+        let error = TextEngineError.serverUnreachable(
+            "http://127.0.0.1:17872",
+            transportCode: -1_004)
+
+        XCTAssertNil(execution.retryDelay(
+            for: error,
+            settings: settings,
+            attempt: 0,
+            jitter: 0))
+    }
+
+    func testRemoteThinkKeepsOneBoundedTransientRetry() {
+        let execution = ThinkExecution(storage: StorageManager())
+        var settings = AppSettings()
+        settings.summarizerBackend = .openAICompatible
+        let error = TextEngineError.httpStatus(
+            code: 503,
+            detail: "warming",
+            retryAfter: nil)
+
+        XCTAssertEqual(
+            execution.retryDelay(
+                for: error,
+                settings: settings,
+                attempt: 0,
+                jitter: 0),
+            1)
+        XCTAssertNil(execution.retryDelay(
+            for: error,
+            settings: settings,
+            attempt: 1,
+            jitter: 0))
+    }
+}

--- a/Scripts/e2e.sh
+++ b/Scripts/e2e.sh
@@ -136,7 +136,7 @@ sqlite3 -cmd ".timeout 5000" "$ROOT/lokalbotv3.sqlite" \
   "INSERT INTO ocr_fts (text, ts, app) VALUES ('Working through the Project Zephyrus migration runbook: rollback steps, feature flags, and the on-call rota for the cutover.', $NOW, 'Safari');" 2>/dev/null
 sqlite3 -cmd ".timeout 5000" "$ROOT/lokalbotv3.sqlite" \
   "INSERT INTO activity_blocks (app, title, start, end) VALUES ('Safari', 'Internal wiki', $((NOW-600)), $NOW);" 2>/dev/null
-OUT=$("$BIN" --digest today 2>/dev/null | tail -1)
+OUT=$("$BIN" --digest 2>/dev/null | tail -1)
 JOURNAL="${OUT#*: }"; JOURNAL="${JOURNAL%% (*}"
 if [[ "$OUT" == *"--digest: /"* && -s "$JOURNAL" ]]; then
   grep -qi "zephyrus" "$JOURNAL" \

--- a/Scripts/e2e.sh
+++ b/Scripts/e2e.sh
@@ -120,7 +120,7 @@ case $? in
 esac
 
 echo "== T7: day digest (activity + meetings → journal/*.md) =="
-OUT=$("$BIN" --digest today 2>/dev/null | tail -1)
+OUT=$("$BIN" --digest 2>/dev/null | tail -1)
 JOURNAL="${OUT#*: }"; JOURNAL="${JOURNAL%% (*}"
 if [[ "$OUT" == *"--digest: /"* && -s "$JOURNAL" ]] && grep -q "^## " "$JOURNAL"; then
   pass "digest written: $(basename "$JOURNAL")"


### PR DESCRIPTION
## Summary

Deepen four core product concepts behind stable boundaries:

- give UI, scheduled, and headless Day Digest flows one lifecycle and a stable headless output contract
- give Transcribe, Think, and Autocomplete one shared readiness lifecycle across onboarding and Settings
- replace ambient navigation state with destination-scoped, consume-once handoffs
- centralize Think backend selection, model preparation, privacy checks, leases, and retry policy, with a small domain glossary

User-facing gains: onboarding and Settings now agree on model status and recovery, headless Day Digest output is script-safe, navigation cannot inherit stale Ask/seek context, and every Think-powered feature follows the same local-first execution policy.

## Review follow-up

- retry failed transcription preparation even when model files already exist, clear stale Granite errors after configuration changes, and keep active preparation aligned with model selection
- route GGUF deletion through app-owned state so readiness is invalidated immediately
- treat meeting summary and outcome writes as Day Digest freshness evidence, propagate their timestamp into durable repair metadata, and reopen same-day or yesterday repair when newer evidence arrives
- use the supported no-argument `--digest` form in the headless E2E script

## Dreaming recovery follow-up

- retry OpenRouter parameter-compatibility 404s for schema-only Dreaming requests, not only requests that set an explicit reasoning budget
- keep recovery bounded to one compatibility retry, dropping strict structured-output requirements while preserving approved privacy routing
- put a direct **Dream again** action on yesterday's failed morning brief and show live in-progress state there
- keep manual Dream retries independent from the overnight automation toggle, while withholding retry from empty-day placeholders and older briefs

## Validation

Latest follow-up head: `766b44d`

- hosted build passed in 6m06s
- full hosted unit suite passed in 7m33s
- full hosted XCUITest suite passed in 17m21s
- hosted SwiftLint, XcodeGen, Vercel, and preview comments passed
- local `DreamingTests`: 53 passed, 0 failures
- local `TextEngineTests`: 22 passed, 0 failures
- full app/test compilation completed as part of the focused Xcode run
- local SwiftLint strict: 0 violations across 433 Swift files
- `git diff --check`
- permission-preserving signed reinstall verified the same bundle ID, Team ID, designated requirement, and byte-identical installed binary
- UI tests were not run locally; the full hosted UI suite is green

Before the Dreaming follow-up, the architecture suite passed 77 tests with 0 failures, the full local non-UI run passed 1,561 tests with 10 skipped and 0 failures, and the previous hosted head also passed build, full unit tests, full UI tests, SwiftLint, XcodeGen, Vercel, and preview comments.

## Risk / rollout notes

- No storage schema or permission changes.
- Remote inference still requires explicit endpoint approval and encrypted transport where applicable.
- Recovery remains bounded: the compatibility retry runs once and is not stacked with another provider retry.
- The retry action re-dreams yesterday and replaces that report only after an explicit click.
