### PR TITLE
Detect meeting audio from helper processes in the app's bundle namespace

### DIFF
--- a/LokalBot/AppState.swift
+++ b/LokalBot/AppState.swift
@@ -580,7 +580,11 @@ final class AppState: ObservableObject {
     private var indexCleanupTasks: [Meeting.ID: (token: UUID, task: Task<Void, Never>)] = [:]
     private var deletedMeetingIDs: Set<Meeting.ID> = []
     @Published private(set) var libraryReady = false
-    private var pendingRecordingStart: (context: MeetingDetectionContext?, source: String)?
+    private var pendingRecordingStart: (
+        context: MeetingDetectionContext?,
+        source: String,
+        systemAudioPolicy: RecordingSystemAudioPolicy
+    )?
     private lazy var searchIndexWorkQueue = SearchIndexWorkQueue(
         databaseURL: storage.rootURL.appendingPathComponent("lokalbotv3.sqlite"),
         rootURL: storage.rootURL)
@@ -589,18 +593,25 @@ final class AppState: ObservableObject {
     var isRecording: Bool { recording.isRecording }
     var currentMeeting: Meeting? { recording.currentMeeting }
 
-    func startRecording(context: MeetingDetectionContext? = nil, source: String = "ui") {
+    func startRecording(
+        context: MeetingDetectionContext? = nil,
+        source: String = "ui",
+        systemAudioPolicy: RecordingSystemAudioPolicy = .meetingAppWhenAvailable
+    ) {
         RecordingNotifier.shared.invalidateMeetingDetections()
         guard !dictation.isStarting, !dictation.state.isWorking else {
             lastError = "Finish or cancel dictation before starting a meeting recording."
             return
         }
         guard libraryReady else {
-            pendingRecordingStart = (context, source)
+            pendingRecordingStart = (context, source, systemAudioPolicy)
             lastError = "Preparing your meeting library; recording will start when it is ready."
             return
         }
-        recording.start(context: context, source: source)
+        recording.start(
+            context: context,
+            source: source,
+            systemAudioPolicy: systemAudioPolicy)
     }
 
     func stopRecording(process: Bool = true) {
@@ -875,7 +886,10 @@ final class AppState: ObservableObject {
             if let pending = self.pendingRecordingStart {
                 self.pendingRecordingStart = nil
                 self.lastError = nil
-                self.startRecording(context: pending.context, source: pending.source)
+                self.startRecording(
+                    context: pending.context,
+                    source: pending.source,
+                    systemAudioPolicy: pending.systemAudioPolicy)
             }
         }
     }

--- a/LokalBot/HeadlessCommands.swift
+++ b/LokalBot/HeadlessCommands.swift
@@ -102,6 +102,8 @@ enum DreamDayArgumentError: LocalizedError, Equatable {
 /// paths as the UI, no window required.
 @MainActor
 struct HeadlessCommandRunner {
+    static let recordSystemAudioPolicy: RecordingSystemAudioPolicy = .microphoneOnly
+
     let app: AppState
 
     func run(_ command: HeadlessCommand) {
@@ -155,7 +157,10 @@ struct HeadlessCommandRunner {
             print("LokalBot --record: SKIP (microphone not granted)")
             exit(3)
         }
-        app.startRecording(context: nil, source: "headless")
+        app.startRecording(
+            context: nil,
+            source: "headless",
+            systemAudioPolicy: Self.recordSystemAudioPolicy)
         Task { @MainActor in
             try? await Task.sleep(for: .seconds(seconds))
             guard app.isRecording else {

--- a/LokalBot/Services/MeetingDetector.swift
+++ b/LokalBot/Services/MeetingDetector.swift
@@ -313,12 +313,21 @@ final class MeetingDetector {
         DispatchQueue.main.asyncAfter(deadline: .now() + debounce, execute: work)
     }
 
+    /// Which running bundles count as native meeting apps, in priority order.
+    /// Split out from `NSRunningApplication` so the choice is testable.
+    static func meetingAppCandidates(bundleIDs: [(bundleID: String, pid: pid_t)]) -> [DetectedApp] {
+        bundleIDs.compactMap { entry in
+            guard let name = knownApps[entry.bundleID] else { return nil }
+            return DetectedApp(name: name, bundleID: entry.bundleID, pid: entry.pid)
+        }
+    }
+
     private static func nativeMeetingApp(in running: [NSRunningApplication],
                                          requireAudio: Bool = false) -> DetectedApp? {
-        let candidates = running.compactMap { app -> DetectedApp? in
-            guard let bid = app.bundleIdentifier, let name = knownApps[bid] else { return nil }
-            return DetectedApp(name: name, bundleID: bid, pid: app.processIdentifier)
-        }
+        let candidates = meetingAppCandidates(bundleIDs: running.compactMap { app in
+            guard let bid = app.bundleIdentifier else { return nil }
+            return (bundleID: bid, pid: app.processIdentifier)
+        })
         guard requireAudio else { return candidates.first }
         let active = candidates.filter { hasAudio(for: $0) }
         guard !active.isEmpty else { return nil }
@@ -457,12 +466,65 @@ final class MeetingDetector {
             guard let bundleID = process.bundleID else { return false }
             return audioBundleID(bundleID, belongsTo: app.bundleID)
         }
-        // Siblings before the host, for the same reason the browser branch
-        // prefers helpers: the host is the process least likely to own audio —
-        // for Teams it owns no Core Audio object at all.
-        return bestOutputAudioProcess(for: app, in: processes)
-            ?? namespace.first { $0.bundleID != app.bundleID }
-            ?? namespace.first
+        // A process emitting right now is the answer, and worth remembering:
+        // it is the only moment we learn which sibling of this app actually
+        // carries call audio.
+        if let emitting = bestOutputAudioProcess(for: app, in: processes) {
+            rememberCaptureTarget(emitting.id, for: app.bundleID)
+            return emitting
+        }
+        // Nothing is emitting. Core Audio specifies no order for the process
+        // list, so picking the first sibling would tap a different one from
+        // one call to the next — and with several Teams or browser helpers
+        // alive, usually one that never carries call audio. Prefer the process
+        // this app was last seen emitting from.
+        if let remembered = rememberedCaptureTarget(for: app.bundleID),
+           let process = namespace.first(where: { $0.id == remembered }) {
+            return process
+        }
+        // Still nothing known: siblings before the host, for the same reason
+        // the browser branch prefers helpers — the host is the process least
+        // likely to own audio, and for Teams it owns no Core Audio object at
+        // all. Lowest PID within each group so the choice is at least stable
+        // across the retries the watchdog makes.
+        let siblings = namespace.filter { $0.bundleID != app.bundleID }
+        return siblings.min { $0.id < $1.id } ?? namespace.min { $0.id < $1.id }
+    }
+
+    /// The PID each app was last seen emitting from. Small and per-bundle: it
+    /// only has to survive between a quiet start and the watchdog's next look.
+    private static var lastEmittingCaptureTargets: [String: pid_t] = [:]
+
+    private static func rememberCaptureTarget(_ pid: pid_t, for bundleID: String) {
+        processSnapshotLock.lock()
+        lastEmittingCaptureTargets[bundleID] = pid
+        processSnapshotLock.unlock()
+    }
+
+    private static func rememberedCaptureTarget(for bundleID: String) -> pid_t? {
+        processSnapshotLock.lock()
+        defer { processSnapshotLock.unlock() }
+        return lastEmittingCaptureTargets[bundleID]
+    }
+
+    /// Clears what capture learned about which sibling carries audio. For
+    /// tests, so one case cannot leak its choice into the next.
+    static func resetCaptureTargetMemory() {
+        processSnapshotLock.lock()
+        lastEmittingCaptureTargets.removeAll()
+        processSnapshotLock.unlock()
+    }
+
+    /// A running native meeting app to capture from when nothing was detected.
+    /// Deliberately does *not* require current output: a recording started by
+    /// hand routinely begins before the remote side says anything, and a tap on
+    /// a silent process records nothing until audio arrives rather than
+    /// failing. Without this the manual path creates no system target at all,
+    /// so remote speech arriving later cannot trigger watchdog recovery either.
+    static func captureCandidateApp(
+        in running: [NSRunningApplication] = NSWorkspace.shared.runningApplications
+    ) -> DetectedApp? {
+        nativeMeetingApp(in: running, requireAudio: false)
     }
 
     static func currentCaptureTargetProcess(for app: DetectedApp) -> AudioProcess? {

--- a/LokalBot/Services/MeetingDetector.swift
+++ b/LokalBot/Services/MeetingDetector.swift
@@ -442,6 +442,33 @@ final class MeetingDetector {
         return bestOutputAudioProcess(for: app, in: processes)
     }
 
+    /// The process to attach the capture tap to.
+    ///
+    /// Detection asks whether the app is producing output *right now*; capture
+    /// only needs a process that *can* produce it — a tap on a momentarily
+    /// silent process simply records nothing until audio starts. Falling back
+    /// to the host PID is not an option: Teams' main process owns no Core Audio
+    /// object at all, so `AudioHardwarePropertyTranslatePIDToProcessObject`
+    /// fails and the tap is refused with `processNotFound` whenever the meeting
+    /// happens to be quiet at the moment recording starts.
+    static func captureTargetProcess(for app: DetectedApp,
+                                     in processes: [AudioProcess]) -> AudioProcess? {
+        let namespace = processes.filter { process in
+            guard let bundleID = process.bundleID else { return false }
+            return audioBundleID(bundleID, belongsTo: app.bundleID)
+        }
+        // Siblings before the host, for the same reason the browser branch
+        // prefers helpers: the host is the process least likely to own audio —
+        // for Teams it owns no Core Audio object at all.
+        return bestOutputAudioProcess(for: app, in: processes)
+            ?? namespace.first { $0.bundleID != app.bundleID }
+            ?? namespace.first
+    }
+
+    static func currentCaptureTargetProcess(for app: DetectedApp) -> AudioProcess? {
+        captureTargetProcess(for: app, in: currentAudioProcesses())
+    }
+
     static func currentAudioProcesses(now: Date = Date()) -> [AudioProcess] {
         processSnapshotLock.lock()
         if let processSnapshot,

--- a/LokalBot/Services/MeetingDetector.swift
+++ b/LokalBot/Services/MeetingDetector.swift
@@ -44,6 +44,18 @@ final class MeetingDetector {
         highConfidenceNativeAudioBundles.contains(bundleID) || calendarBacked
     }
 
+    /// Processes whose Core Audio streams stay open while the host app is idle.
+    /// They are valid capture targets, but their running state is not evidence
+    /// that a meeting is in progress.
+    static let alwaysOpenAudioBundles: Set<String> = [
+        "com.microsoft.teams2.modulehost",
+    ]
+
+    static func carriesMeetingSignal(bundleID: String?) -> Bool {
+        guard let bundleID else { return true }
+        return !alwaysOpenAudioBundles.contains(bundleID.lowercased())
+    }
+
     /// Browsers whose focused-window title we inspect for web meetings
     /// (needs Accessibility; silently skipped without it).
     static let browsers: Set<String> = [
@@ -420,7 +432,8 @@ final class MeetingDetector {
                                        in processes: [AudioProcess]) -> AudioProcess? {
         if browsers.contains(app.bundleID) || app.bundleID == "us.zoom.xos" {
             let matches = processes.filter { process in
-                guard process.isRunningOutput, let bundleID = process.bundleID else { return false }
+                guard process.isRunningOutput, let bundleID = process.bundleID,
+                      carriesMeetingSignal(bundleID: bundleID) else { return false }
                 return audioBundleID(bundleID, belongsTo: app.bundleID)
             }
             // Chrome/Edge/Safari often emit meeting audio from helper processes,
@@ -438,10 +451,16 @@ final class MeetingDetector {
         // detector never surfaces the app, and the process tap is skipped
         // entirely, leaving the meeting recorded mic-only. The host keeps
         // precedence so apps whose main process emits audio are unaffected.
-        return processes.first { $0.id == app.pid && $0.isRunningOutput }
-            ?? processes.first { $0.isRunningOutput && $0.bundleID == app.bundleID }
+        return processes.first {
+            $0.id == app.pid && $0.isRunningOutput
+                && carriesMeetingSignal(bundleID: $0.bundleID)
+        } ?? processes.first {
+            $0.isRunningOutput && $0.bundleID == app.bundleID
+                && carriesMeetingSignal(bundleID: $0.bundleID)
+        }
             ?? processes.first { process in
-                guard process.isRunningOutput, let bundleID = process.bundleID else { return false }
+                guard process.isRunningOutput, let bundleID = process.bundleID,
+                      carriesMeetingSignal(bundleID: bundleID) else { return false }
                 return audioBundleID(bundleID, belongsTo: app.bundleID)
             }
     }
@@ -461,17 +480,26 @@ final class MeetingDetector {
     /// fails and the tap is refused with `processNotFound` whenever the meeting
     /// happens to be quiet at the moment recording starts.
     static func captureTargetProcess(for app: DetectedApp,
-                                     in processes: [AudioProcess]) -> AudioProcess? {
-        let namespace = processes.filter { process in
+                                     in processes: [AudioProcess],
+                                     excludingPID: pid_t? = nil) -> AudioProcess? {
+        let available = processes.filter { $0.id != excludingPID }
+        let namespace = available.filter { process in
             guard let bundleID = process.bundleID else { return false }
             return audioBundleID(bundleID, belongsTo: app.bundleID)
         }
         // A process emitting right now is the answer, and worth remembering:
         // it is the only moment we learn which sibling of this app actually
         // carries call audio.
-        if let emitting = bestOutputAudioProcess(for: app, in: processes) {
+        if let emitting = bestOutputAudioProcess(for: app, in: available) {
             rememberCaptureTarget(emitting.id, for: app.bundleID)
             return emitting
+        }
+        // An always-open stream is intentionally excluded from meeting
+        // detection, but it is preferable to a streamless helper for capture:
+        // Core Audio will deliver silent buffers now and call audio later.
+        if let openStream = namespace.filter(\.isRunningOutput).min(by: { $0.id < $1.id }) {
+            rememberCaptureTarget(openStream.id, for: app.bundleID)
+            return openStream
         }
         // Nothing is emitting. Core Audio specifies no order for the process
         // list, so picking the first sibling would tap a different one from
@@ -527,8 +555,14 @@ final class MeetingDetector {
         nativeMeetingApp(in: running, requireAudio: false)
     }
 
-    static func currentCaptureTargetProcess(for app: DetectedApp) -> AudioProcess? {
-        captureTargetProcess(for: app, in: currentAudioProcesses())
+    static func currentCaptureTargetProcess(
+        for app: DetectedApp,
+        excludingPID: pid_t? = nil
+    ) -> AudioProcess? {
+        captureTargetProcess(
+            for: app,
+            in: currentAudioProcesses(),
+            excludingPID: excludingPID)
     }
 
     static func currentAudioProcesses(now: Date = Date()) -> [AudioProcess] {

--- a/LokalBot/Services/MeetingDetector.swift
+++ b/LokalBot/Services/MeetingDetector.swift
@@ -399,7 +399,12 @@ final class MeetingDetector {
                 || bundle == "us.zoom.cpthost"
                 || bundle.hasPrefix("us.zoom.xos.")
         }
-        return bundle == host || bundle.hasPrefix("\(host).helper")
+        // Any bundle inside the host's own namespace is that app's audio.
+        // Teams alone emits call audio from `<host>.helper` (WebView) *and*
+        // `<host>.modulehost`, so matching only `.helper` misses the process
+        // that is usually the one running. This mirrors the `us.zoom.xos.`
+        // prefix rule above rather than enumerating every suffix Microsoft ships.
+        return bundle == host || bundle.hasPrefix("\(host).")
     }
 
     static func bestOutputAudioProcess(for app: DetectedApp,
@@ -417,8 +422,19 @@ final class MeetingDetector {
                 ?? matches.first { $0.id == app.pid }
                 ?? matches.first
         }
+        // Electron meeting apps (Teams, Slack, Webex) route call audio through
+        // helper processes just as Chromium browsers do. `audioBundleID` already
+        // models that `<host>.helper` relationship for every host, so honour it
+        // here as a fallback — without it `hasOutputAudio` stays false, the
+        // detector never surfaces the app, and the process tap is skipped
+        // entirely, leaving the meeting recorded mic-only. The host keeps
+        // precedence so apps whose main process emits audio are unaffected.
         return processes.first { $0.id == app.pid && $0.isRunningOutput }
             ?? processes.first { $0.isRunningOutput && $0.bundleID == app.bundleID }
+            ?? processes.first { process in
+                guard process.isRunningOutput, let bundleID = process.bundleID else { return false }
+                return audioBundleID(bundleID, belongsTo: app.bundleID)
+            }
     }
 
     static func currentOutputAudioProcess(for app: DetectedApp) -> AudioProcess? {

--- a/LokalBot/Services/RecordingController.swift
+++ b/LokalBot/Services/RecordingController.swift
@@ -270,7 +270,7 @@ final class RecordingController: ObservableObject {
                 try Task.checkCancellation()
 
                 if let detectedApp {
-                    let captureProcess = MeetingDetector.currentOutputAudioProcess(for: detectedApp)
+                    let captureProcess = MeetingDetector.currentCaptureTargetProcess(for: detectedApp)
                     let pid = captureProcess?.id ?? detectedApp.pid
                     do {
                         try systemRecorder.start(

--- a/LokalBot/Services/RecordingController.swift
+++ b/LokalBot/Services/RecordingController.swift
@@ -269,9 +269,15 @@ final class RecordingController: ObservableObject {
                 startRecordingHealthWatchdog()
                 try Task.checkCancellation()
 
-                if let detectedApp {
-                    let captureProcess = MeetingDetector.currentCaptureTargetProcess(for: detectedApp)
-                    let pid = captureProcess?.id ?? detectedApp.pid
+                // A recording started by hand has no detected app, but a
+                // meeting app is often running all the same — and without a
+                // system target here, remote speech arriving later cannot
+                // trigger watchdog recovery either. Falls back to a running
+                // native meeting app; nil when there is genuinely none, which
+                // keeps a plain voice memo mic-only as before.
+                if let captureApp = detectedApp ?? MeetingDetector.captureCandidateApp() {
+                    let captureProcess = MeetingDetector.currentCaptureTargetProcess(for: captureApp)
+                    let pid = captureProcess?.id ?? captureApp.pid
                     do {
                         try systemRecorder.start(
                             capturingPID: pid,
@@ -280,17 +286,25 @@ final class RecordingController: ObservableObject {
                                 .appendingPathComponent(AudioPreviewTee.systemFileName))
                         meeting.hasSystemTrack = true
                         systemAudioTarget = SystemAudioTarget(
-                            bundleID: detectedApp.bundleID,
+                            bundleID: captureApp.bundleID,
                             pid: pid)
-                        if pid != detectedApp.pid || captureProcess?.bundleID != detectedApp.bundleID {
+                        if pid != captureApp.pid || captureProcess?.bundleID != captureApp.bundleID {
                             lokalbotLog(
-                                "system audio capture resolved detectedPID=\(detectedApp.pid) capturePID=\(pid) captureBundle=\(captureProcess?.bundleID ?? "unknown") hostBundle=\(detectedApp.bundleID)")
+                                "system audio capture resolved detectedPID=\(captureApp.pid) capturePID=\(pid) captureBundle=\(captureProcess?.bundleID ?? "unknown") hostBundle=\(captureApp.bundleID)")
                         }
-                        lokalbotLog("system audio tap started pid=\(pid) bundle=\(detectedApp.bundleID)")
+                        lokalbotLog(
+                            "system audio tap started pid=\(pid) bundle=\(captureApp.bundleID) detected=\(detectedApp != nil)")
                     } catch {
-                        // Degrade gracefully: mic-only recording.
-                        onError("System audio tap failed (\(error.localizedDescription)) — recording mic only.")
-                        lokalbotLog("system audio tap FAILED: \(error.localizedDescription)")
+                        // Degrade gracefully: mic-only recording. Only worth
+                        // telling the user about when a meeting was actually
+                        // detected — on a hand-started voice memo the app was
+                        // merely running nearby and no system track was asked
+                        // for, so a banner would be noise.
+                        if detectedApp != nil {
+                            onError("System audio tap failed (\(error.localizedDescription)) — recording mic only.")
+                        }
+                        lokalbotLog(
+                            "system audio tap FAILED detected=\(detectedApp != nil): \(error.localizedDescription)")
                     }
                 }
                 try Task.checkCancellation()

--- a/LokalBot/Services/RecordingController.swift
+++ b/LokalBot/Services/RecordingController.swift
@@ -17,6 +17,40 @@ struct SystemAudioSamePIDRetryBudget: Equatable {
     }
 }
 
+enum RecordingSystemAudioPolicy: Equatable {
+    case microphoneOnly
+    case meetingAppWhenAvailable
+
+    func captureApp(
+        detectedApp: MeetingDetector.DetectedApp?,
+        fallback: () -> MeetingDetector.DetectedApp?
+    ) -> MeetingDetector.DetectedApp? {
+        switch self {
+        case .microphoneOnly:
+            return nil
+        case .meetingAppWhenAvailable:
+            return detectedApp ?? fallback()
+        }
+    }
+}
+
+enum SystemAudioRecoveryCandidatePolicy {
+    static func excludedPID(
+        currentPID: pid_t,
+        framesSinceAttach: Int64
+    ) -> pid_t? {
+        framesSinceAttach == 0 ? currentPID : nil
+    }
+
+    static func shouldRetrySamePID(
+        framesSinceAttach: Int64,
+        audibleDuration: TimeInterval,
+        minimumAudibleDuration: TimeInterval
+    ) -> Bool {
+        framesSinceAttach == 0 || audibleDuration < minimumAudibleDuration
+    }
+}
+
 struct RecordingMemoryHealthSnapshot: Equatable, Sendable {
     var isRecording: Bool
     var microphoneStatus: String
@@ -202,7 +236,11 @@ final class RecordingController: ObservableObject {
 
     // MARK: - Start / stop
 
-    func start(context: MeetingDetectionContext? = nil, source: String = "ui") {
+    func start(
+        context: MeetingDetectionContext? = nil,
+        source: String = "ui",
+        systemAudioPolicy: RecordingSystemAudioPolicy
+    ) {
         guard case .idle = status, startTask == nil else { return }
         let detectedApp = context?.detectedApp
         let calendarEvent = context?.calendarEvent
@@ -269,13 +307,14 @@ final class RecordingController: ObservableObject {
                 startRecordingHealthWatchdog()
                 try Task.checkCancellation()
 
-                // A recording started by hand has no detected app, but a
-                // meeting app is often running all the same — and without a
-                // system target here, remote speech arriving later cannot
-                // trigger watchdog recovery either. Falls back to a running
-                // native meeting app; nil when there is genuinely none, which
-                // keeps a plain voice memo mic-only as before.
-                if let captureApp = detectedApp ?? MeetingDetector.captureCandidateApp() {
+                // Meeting-intent callers may fall back to a running native app
+                // before it emits audio, giving the watchdog a target to repair.
+                // Mic-only callers never evaluate that fallback, so headless
+                // voice recording cannot silently widen its capture scope.
+                if let captureApp = systemAudioPolicy.captureApp(
+                    detectedApp: detectedApp,
+                    fallback: { MeetingDetector.captureCandidateApp() }
+                ) {
                     let captureProcess = MeetingDetector.currentCaptureTargetProcess(for: captureApp)
                     let pid = captureProcess?.id ?? captureApp.pid
                     do {
@@ -411,7 +450,10 @@ final class RecordingController: ObservableObject {
         lokalbotLog(
             "calendar handoff split old=\(currentMeeting.calendarEventID ?? "?") new=\(nextEventID)")
         stop()
-        start(context: context, source: "calendar-handoff")
+        start(
+            context: context,
+            source: "calendar-handoff",
+            systemAudioPolicy: .meetingAppWhenAvailable)
     }
 
     private func cleanupCancelledStart(created: Meeting?) {
@@ -599,7 +641,19 @@ final class RecordingController: ObservableObject {
             return
         }
 
-        guard let candidate = currentSystemAudioCandidate(for: target) else {
+        let excludedPID = SystemAudioRecoveryCandidatePolicy.excludedPID(
+            currentPID: target.pid,
+            framesSinceAttach: health.framesSinceAttach)
+        let alternativeCandidate = currentSystemAudioCandidate(
+            for: target,
+            excludingPID: excludedPID)
+        // Rebuilding a tap on the same PID is still useful when that is the
+        // only process left: the process may have opened its stream after the
+        // original tap was created. Same-PID retries remain budgeted below.
+        let candidate = alternativeCandidate ?? (excludedPID == nil
+            ? nil
+            : currentSystemAudioCandidate(for: target))
+        guard let candidate else {
             warnOnceAboutSilentSystemAudio(elapsed: elapsed, captured: health.duration,
                                            audible: health.audibleDuration,
                                            rms: health.lastRMSLevel,
@@ -610,7 +664,10 @@ final class RecordingController: ObservableObject {
         // If the tap has never delivered audio, retry even on the same PID.
         // Once samples exist, reattach only when Core Audio reports a different
         // active process for the same meeting app/browser family.
-        let shouldRetrySamePID = health.audibleDuration < AudioFileInspector.minimumTranscribableDuration
+        let shouldRetrySamePID = SystemAudioRecoveryCandidatePolicy.shouldRetrySamePID(
+            framesSinceAttach: health.framesSinceAttach,
+            audibleDuration: health.audibleDuration,
+            minimumAudibleDuration: AudioFileInspector.minimumTranscribableDuration)
         let isSamePIDRetry = candidate.id == target.pid && shouldRetrySamePID
         guard candidate.id != target.pid || shouldRetrySamePID else {
             warnOnceAboutSilentSystemAudio(elapsed: elapsed, captured: health.duration,
@@ -640,7 +697,14 @@ final class RecordingController: ObservableObject {
             }
             didWarnAboutSilentSystemAudio = false
             lokalbotLog(
-                "system audio reattached oldPID=\(previousPID) newPID=\(candidate.id) bundle=\(candidate.bundleID ?? "unknown") captured=\(String(format: "%.2fs", health.duration)) audible=\(String(format: "%.2fs", health.audibleDuration)) silentFor=\(String(format: "%.2fs", silentFor)) rms=\(String(format: "%.6f", health.lastRMSLevel)) peakRMS=\(String(format: "%.6f", health.peakRMSLevel))")
+                "system audio reattached oldPID=\(previousPID) newPID=\(candidate.id) "
+                    + "bundle=\(candidate.bundleID ?? "unknown") "
+                    + "framesSinceAttach=\(health.framesSinceAttach) "
+                    + "captured=\(String(format: "%.2fs", health.duration)) "
+                    + "audible=\(String(format: "%.2fs", health.audibleDuration)) "
+                    + "silentFor=\(String(format: "%.2fs", silentFor)) "
+                    + "rms=\(String(format: "%.6f", health.lastRMSLevel)) "
+                    + "peakRMS=\(String(format: "%.6f", health.peakRMSLevel))")
         } catch {
             lastSystemAudioReattachAt = now
             onError("System audio capture was interrupted (\(error.localizedDescription)); still recording microphone.")
@@ -648,11 +712,16 @@ final class RecordingController: ObservableObject {
         }
     }
 
-    private func currentSystemAudioCandidate(for target: SystemAudioTarget) -> AudioProcess? {
-        MeetingDetector.currentOutputAudioProcess(for: MeetingDetector.DetectedApp(
-            name: target.bundleID,
-            bundleID: target.bundleID,
-            pid: target.pid))
+    private func currentSystemAudioCandidate(
+        for target: SystemAudioTarget,
+        excludingPID: pid_t? = nil
+    ) -> AudioProcess? {
+        MeetingDetector.currentCaptureTargetProcess(
+            for: MeetingDetector.DetectedApp(
+                name: target.bundleID,
+                bundleID: target.bundleID,
+                pid: target.pid),
+            excludingPID: excludingPID)
     }
 
     /// Helper processes routinely exit during a live browser/Zoom meeting.
@@ -670,8 +739,10 @@ final class RecordingController: ObservableObject {
                 guard self.isRecording, var target = self.systemAudioTarget,
                       target.pid == terminatedPID else { return }
                 MeetingDetector.invalidateAudioProcessSnapshot()
-                guard let candidate = self.currentSystemAudioCandidate(for: target),
-                      candidate.id != terminatedPID else { continue }
+                guard let candidate = self.currentSystemAudioCandidate(
+                    for: target,
+                    excludingPID: terminatedPID
+                ) else { continue }
                 do {
                     try self.systemRecorder.reattach(capturingPID: candidate.id)
                     target.pid = candidate.id
@@ -696,7 +767,7 @@ final class RecordingController: ObservableObject {
     private func retargetSystemAudio(to app: MeetingDetector.DetectedApp) {
         guard isRecording else { return }
         MeetingDetector.invalidateAudioProcessSnapshot()
-        guard let candidate = MeetingDetector.currentOutputAudioProcess(for: app) else { return }
+        guard let candidate = MeetingDetector.currentCaptureTargetProcess(for: app) else { return }
         if systemAudioTarget?.bundleID == app.bundleID,
            systemAudioTarget?.pid == candidate.id { return }
         do {

--- a/LokalBot/Services/SystemAudioRecorder.swift
+++ b/LokalBot/Services/SystemAudioRecorder.swift
@@ -40,6 +40,9 @@ final class SystemAudioRecorder {
     private var tapFormat: AVAudioFormat?
     private var outputURL: URL?
     private var framesWritten: AVAudioFramePosition = 0
+    /// Frames delivered by the current tap only. Recovery padding deliberately
+    /// does not advance this counter, so zero identifies a dead attachment.
+    private var framesSinceAttach: AVAudioFramePosition = 0
     private var audibleFramesWritten: AVAudioFramePosition = 0
     private var recordingSampleRate: Double = 0
     private var lastAudioWriteAt: Date?
@@ -75,6 +78,7 @@ final class SystemAudioRecorder {
     struct CaptureHealth {
         let duration: TimeInterval
         let audibleDuration: TimeInterval
+        let framesSinceAttach: AVAudioFramePosition
         let lastAudioWriteAt: Date?
         let lastAudibleWriteAt: Date?
         let capturedPID: pid_t
@@ -97,6 +101,7 @@ final class SystemAudioRecorder {
             let startedInstant = ContinuousClock.now
             ioQueue.sync {
                 framesWritten = 0
+                framesSinceAttach = 0
                 audibleFramesWritten = 0
                 recordingSampleRate = 0
                 lastAudioWriteAt = nil
@@ -130,6 +135,7 @@ final class SystemAudioRecorder {
             throw RecorderError.processNotFound
         }
         teardownTap()
+        ioQueue.sync { framesSinceAttach = 0 }
         do {
             try appendRecoverySilence(
                 until: ContinuousClock.now,
@@ -155,6 +161,7 @@ final class SystemAudioRecorder {
                 : 0
             return CaptureHealth(duration: duration,
                                  audibleDuration: audibleDuration,
+                                 framesSinceAttach: framesSinceAttach,
                                  lastAudioWriteAt: lastAudioWriteAt,
                                  lastAudibleWriteAt: lastAudibleWriteAt,
                                  capturedPID: capturedPID,
@@ -261,6 +268,7 @@ final class SystemAudioRecorder {
                     let now = Date()
                     let nowInstant = ContinuousClock.now
                     self.framesWritten += AVAudioFramePosition(copy.frameLength)
+                    self.framesSinceAttach += AVAudioFramePosition(copy.frameLength)
                     self.lastAudioWriteAt = now
                     self.lastAudioWriteInstant = nowInstant
                     self.lastRMSLevel = rmsLevel
@@ -346,6 +354,7 @@ final class SystemAudioRecorder {
         capturedPID = 0
         ioQueue.sync {
             framesWritten = 0
+            framesSinceAttach = 0
             audibleFramesWritten = 0
             recordingSampleRate = 0
             lastAudioWriteAt = nil

--- a/LokalBotTests/AudioSourceMonitorTests.swift
+++ b/LokalBotTests/AudioSourceMonitorTests.swift
@@ -161,6 +161,72 @@ final class AudioSourceMonitorTests: XCTestCase {
             moduleHost.id)
     }
 
+    /// Measured on a real Teams call: `translatePIDToProcessObject` fails for
+    /// the Teams host PID because that process owns no Core Audio object. When
+    /// the meeting is momentarily quiet no sibling is `isRunningOutput` either,
+    /// so a capture lookup that requires current output resolves to nothing and
+    /// the tap is refused. Capture must therefore accept a silent-but-present
+    /// process in the namespace — the tap records once audio starts.
+    func testCaptureTargetFallsBackToASilentProcessInTheNamespace() {
+        let host = AudioProcess(id: 100,
+                                name: "Microsoft Teams",
+                                bundleID: "com.microsoft.teams2",
+                                objectID: AudioObjectID(100),
+                                isRunningOutput: false)
+        let quietModuleHost = AudioProcess(id: 300,
+                                           name: "Microsoft Teams ModuleHost",
+                                           bundleID: "com.microsoft.teams2.modulehost",
+                                           objectID: AudioObjectID(300),
+                                           isRunningOutput: false)
+        let app = MeetingDetector.DetectedApp(name: "Teams",
+                                              bundleID: "com.microsoft.teams2",
+                                              pid: host.id)
+
+        // Detection correctly reports "not producing output right now"...
+        XCTAssertNil(MeetingDetector.bestOutputAudioProcess(
+            for: app, in: [host, quietModuleHost]))
+        // ...but capture still has somewhere to attach.
+        XCTAssertEqual(
+            MeetingDetector.captureTargetProcess(for: app, in: [host, quietModuleHost])?.id,
+            quietModuleHost.id)
+    }
+
+    /// A process that *is* producing output still wins over a silent sibling.
+    func testCaptureTargetPrefersTheProcessThatIsActuallyEmitting() {
+        let quiet = AudioProcess(id: 300,
+                                 name: "Microsoft Teams ModuleHost",
+                                 bundleID: "com.microsoft.teams2.modulehost",
+                                 objectID: AudioObjectID(300),
+                                 isRunningOutput: false)
+        let emitting = AudioProcess(id: 400,
+                                    name: "Microsoft Teams WebView",
+                                    bundleID: "com.microsoft.teams2.helper",
+                                    objectID: AudioObjectID(400),
+                                    isRunningOutput: true)
+        let app = MeetingDetector.DetectedApp(name: "Teams",
+                                              bundleID: "com.microsoft.teams2",
+                                              pid: 100)
+
+        XCTAssertEqual(
+            MeetingDetector.captureTargetProcess(for: app, in: [quiet, emitting])?.id,
+            emitting.id)
+    }
+
+    /// Capture must not attach to an unrelated app just because nothing of the
+    /// meeting app is running.
+    func testCaptureTargetIgnoresUnrelatedProcesses() {
+        let unrelated = AudioProcess(id: 500,
+                                     name: "Music",
+                                     bundleID: "com.apple.Music",
+                                     objectID: AudioObjectID(500),
+                                     isRunningOutput: true)
+        let app = MeetingDetector.DetectedApp(name: "Teams",
+                                              bundleID: "com.microsoft.teams2",
+                                              pid: 100)
+
+        XCTAssertNil(MeetingDetector.captureTargetProcess(for: app, in: [unrelated]))
+    }
+
     /// The namespace rule must not swallow a *different* app whose bundle id
     /// merely starts with the same characters.
     func testNamespaceMatchDoesNotSpanUnrelatedBundles() {

--- a/LokalBotTests/AudioSourceMonitorTests.swift
+++ b/LokalBotTests/AudioSourceMonitorTests.swift
@@ -263,4 +263,73 @@ final class AudioSourceMonitorTests: XCTestCase {
     func testUnknownAppIsNotExcluded() {
         XCTAssertFalse(AudioSourceMonitor.isMediaPlayer("com.example.SomeNewMeetingApp"))
     }
+
+    // MARK: - Choosing a target when nothing is emitting
+
+    private func teamsApp(pid: pid_t = 100) -> MeetingDetector.DetectedApp {
+        MeetingDetector.DetectedApp(name: "Teams", bundleID: "com.microsoft.teams2", pid: pid)
+    }
+
+    private func teamsHelper(_ id: pid_t) -> AudioProcess {
+        AudioProcess(id: id, name: "Microsoft Teams WebView",
+                     bundleID: "com.microsoft.teams2.helper",
+                     objectID: AudioObjectID(id), isRunningOutput: false)
+    }
+
+    /// The moment a process emits is the only time we learn which sibling
+    /// actually carries call audio, so that choice must survive the quiet
+    /// stretch that follows rather than being re-guessed from list order.
+    func testCaptureTargetRemembersTheProcessLastSeenEmitting() {
+        MeetingDetector.resetCaptureTargetMemory()
+        let app = teamsApp()
+        let emitting = AudioProcess(id: 400, name: "Microsoft Teams WebView",
+                                    bundleID: "com.microsoft.teams2.helper",
+                                    objectID: AudioObjectID(400), isRunningOutput: true)
+        let otherHelper = teamsHelper(700)
+
+        XCTAssertEqual(
+            MeetingDetector.captureTargetProcess(for: app, in: [otherHelper, emitting])?.id,
+            emitting.id)
+
+        // Same processes, none of them emitting any more.
+        let quiet = teamsHelper(400)
+        XCTAssertEqual(
+            MeetingDetector.captureTargetProcess(for: app, in: [otherHelper, quiet])?.id,
+            quiet.id)
+    }
+
+    /// With nothing emitting and nothing remembered, the choice must not
+    /// depend on the order Core Audio happened to return the processes in.
+    func testCaptureTargetIsStableAcrossProcessListOrder() {
+        MeetingDetector.resetCaptureTargetMemory()
+        let app = teamsApp()
+        let first = teamsHelper(700)
+        let second = teamsHelper(300)
+
+        let forward = MeetingDetector.captureTargetProcess(for: app, in: [first, second])?.id
+        MeetingDetector.resetCaptureTargetMemory()
+        let reversed = MeetingDetector.captureTargetProcess(for: app, in: [second, first])?.id
+
+        XCTAssertEqual(forward, reversed)
+        XCTAssertEqual(forward, second.id)
+    }
+
+    // MARK: - Capture target for a recording started by hand
+
+    /// A hand-started recording has no detected app, but the tap still needs a
+    /// target; a running meeting app qualifies even while it is silent.
+    func testMeetingAppCandidatesIgnoreAudioAndUnknownBundles() {
+        let candidates = MeetingDetector.meetingAppCandidates(bundleIDs: [
+            (bundleID: "com.apple.Music", pid: 10),
+            (bundleID: "com.microsoft.teams2", pid: 20),
+            (bundleID: "us.zoom.xos", pid: 30),
+        ])
+
+        XCTAssertEqual(candidates.map(\.bundleID), ["com.microsoft.teams2", "us.zoom.xos"])
+        XCTAssertEqual(candidates.first?.pid, 20)
+
+        XCTAssertTrue(MeetingDetector.meetingAppCandidates(bundleIDs: [
+            (bundleID: "com.apple.Music", pid: 10),
+        ]).isEmpty)
+    }
 }

--- a/LokalBotTests/AudioSourceMonitorTests.swift
+++ b/LokalBotTests/AudioSourceMonitorTests.swift
@@ -105,6 +105,93 @@ final class AudioSourceMonitorTests: XCTestCase {
             helper.id)
     }
 
+    /// Electron meeting apps (Teams, Slack, Webex) emit call audio from a
+    /// helper process exactly as Chromium browsers do, and ``audioBundleID``
+    /// already models that `<host>.helper` relationship for every host — not
+    /// just the browser/Zoom special cases. The capture lookup must honour it
+    /// outside those branches too: when it does not, `hasOutputAudio` is false,
+    /// the detector never surfaces the app, and `RecordingController` skips the
+    /// process tap entirely — the meeting silently records mic-only.
+    func testNativeAppCaptureFallsBackToHelperProcess() {
+        let host = AudioProcess(id: 100,
+                                name: "Microsoft Teams",
+                                bundleID: "com.microsoft.teams2",
+                                objectID: AudioObjectID(100),
+                                isRunningOutput: false)
+        let helper = AudioProcess(id: 200,
+                                  name: "Microsoft Teams Helper",
+                                  bundleID: "com.microsoft.teams2.helper",
+                                  objectID: AudioObjectID(200),
+                                  isRunningOutput: true)
+        let app = MeetingDetector.DetectedApp(name: "Teams",
+                                              bundleID: "com.microsoft.teams2",
+                                              pid: host.id)
+
+        XCTAssertTrue(MeetingDetector.audioBundleID(
+            "com.microsoft.teams2.helper", belongsTo: "com.microsoft.teams2"))
+        XCTAssertEqual(MeetingDetector.bestOutputAudioProcess(for: app, in: [host, helper])?.id,
+                       helper.id)
+    }
+
+    /// Measured on a real Teams call: audio comes from `<host>.helper` (the
+    /// WebView) *and* `<host>.modulehost`, and the WebView is running output
+    /// only part of the time. Matching just `.helper` therefore still loses the
+    /// tap most of the time, so the whole `<host>.` namespace has to count —
+    /// the same rule the `us.zoom.xos.` branch already applies.
+    func testNativeAppCaptureAcceptsAnyBundleInTheHostNamespace() {
+        XCTAssertTrue(MeetingDetector.audioBundleID(
+            "com.microsoft.teams2.modulehost", belongsTo: "com.microsoft.teams2"))
+
+        let host = AudioProcess(id: 100,
+                                name: "Microsoft Teams",
+                                bundleID: "com.microsoft.teams2",
+                                objectID: AudioObjectID(100),
+                                isRunningOutput: false)
+        let moduleHost = AudioProcess(id: 300,
+                                      name: "Microsoft Teams ModuleHost",
+                                      bundleID: "com.microsoft.teams2.modulehost",
+                                      objectID: AudioObjectID(300),
+                                      isRunningOutput: true)
+        let app = MeetingDetector.DetectedApp(name: "Teams",
+                                              bundleID: "com.microsoft.teams2",
+                                              pid: host.id)
+
+        XCTAssertEqual(
+            MeetingDetector.bestOutputAudioProcess(for: app, in: [host, moduleHost])?.id,
+            moduleHost.id)
+    }
+
+    /// The namespace rule must not swallow a *different* app whose bundle id
+    /// merely starts with the same characters.
+    func testNamespaceMatchDoesNotSpanUnrelatedBundles() {
+        XCTAssertFalse(MeetingDetector.audioBundleID(
+            "com.microsoft.teams2evil", belongsTo: "com.microsoft.teams2"))
+        XCTAssertFalse(MeetingDetector.audioBundleID(
+            "com.microsoft.teamsother", belongsTo: "com.microsoft.teams2"))
+    }
+
+    /// The helper fallback must stay a *fallback*: when the host process itself
+    /// is producing output it remains the capture target, so apps that work
+    /// today are unaffected.
+    func testNativeAppCapturePrefersHostWhenItIsProducingOutput() {
+        let host = AudioProcess(id: 100,
+                                name: "Microsoft Teams",
+                                bundleID: "com.microsoft.teams2",
+                                objectID: AudioObjectID(100),
+                                isRunningOutput: true)
+        let helper = AudioProcess(id: 200,
+                                  name: "Microsoft Teams Helper",
+                                  bundleID: "com.microsoft.teams2.helper",
+                                  objectID: AudioObjectID(200),
+                                  isRunningOutput: true)
+        let app = MeetingDetector.DetectedApp(name: "Teams",
+                                              bundleID: "com.microsoft.teams2",
+                                              pid: host.id)
+
+        XCTAssertEqual(MeetingDetector.bestOutputAudioProcess(for: app, in: [host, helper])?.id,
+                       host.id)
+    }
+
     /// Unknown apps stay eligible so a genuinely-new meeting tool is still
     /// surfaced via the monitor's fallback candidate path.
     func testUnknownAppIsNotExcluded() {

--- a/LokalBotTests/AudioSourceMonitorTests.swift
+++ b/LokalBotTests/AudioSourceMonitorTests.swift
@@ -133,14 +133,14 @@ final class AudioSourceMonitorTests: XCTestCase {
                        helper.id)
     }
 
-    /// Measured on a real Teams call: audio comes from `<host>.helper` (the
-    /// WebView) *and* `<host>.modulehost`, and the WebView is running output
-    /// only part of the time. Matching just `.helper` therefore still loses the
-    /// tap most of the time, so the whole `<host>.` namespace has to count —
-    /// the same rule the `us.zoom.xos.` branch already applies.
-    func testNativeAppCaptureAcceptsAnyBundleInTheHostNamespace() {
+    /// Teams' modulehost keeps its stream open even while Teams is idle. That
+    /// makes it a useful tap target but unusable as evidence that a call exists.
+    func testAlwaysOpenNamespaceProcessIsCaptureOnly() {
+        MeetingDetector.resetCaptureTargetMemory()
         XCTAssertTrue(MeetingDetector.audioBundleID(
             "com.microsoft.teams2.modulehost", belongsTo: "com.microsoft.teams2"))
+        XCTAssertFalse(MeetingDetector.carriesMeetingSignal(
+            bundleID: "com.microsoft.teams2.modulehost"))
 
         let host = AudioProcess(id: 100,
                                 name: "Microsoft Teams",
@@ -156,9 +156,9 @@ final class AudioSourceMonitorTests: XCTestCase {
                                               bundleID: "com.microsoft.teams2",
                                               pid: host.id)
 
-        XCTAssertEqual(
-            MeetingDetector.bestOutputAudioProcess(for: app, in: [host, moduleHost])?.id,
-            moduleHost.id)
+        XCTAssertNil(MeetingDetector.bestOutputAudioProcess(for: app, in: [host, moduleHost]))
+        XCTAssertEqual(MeetingDetector.captureTargetProcess(
+            for: app, in: [host, moduleHost])?.id, moduleHost.id)
     }
 
     /// Measured on a real Teams call: `translatePIDToProcessObject` fails for
@@ -191,13 +191,14 @@ final class AudioSourceMonitorTests: XCTestCase {
             quietModuleHost.id)
     }
 
-    /// A process that *is* producing output still wins over a silent sibling.
+    /// A process carrying a real meeting signal still wins over an always-open
+    /// sibling that is valid for capture but ignored by detection.
     func testCaptureTargetPrefersTheProcessThatIsActuallyEmitting() {
-        let quiet = AudioProcess(id: 300,
-                                 name: "Microsoft Teams ModuleHost",
-                                 bundleID: "com.microsoft.teams2.modulehost",
-                                 objectID: AudioObjectID(300),
-                                 isRunningOutput: false)
+        let alwaysOpen = AudioProcess(id: 300,
+                                      name: "Microsoft Teams ModuleHost",
+                                      bundleID: "com.microsoft.teams2.modulehost",
+                                      objectID: AudioObjectID(300),
+                                      isRunningOutput: true)
         let emitting = AudioProcess(id: 400,
                                     name: "Microsoft Teams WebView",
                                     bundleID: "com.microsoft.teams2.helper",
@@ -208,7 +209,7 @@ final class AudioSourceMonitorTests: XCTestCase {
                                               pid: 100)
 
         XCTAssertEqual(
-            MeetingDetector.captureTargetProcess(for: app, in: [quiet, emitting])?.id,
+            MeetingDetector.captureTargetProcess(for: app, in: [alwaysOpen, emitting])?.id,
             emitting.id)
     }
 
@@ -225,6 +226,38 @@ final class AudioSourceMonitorTests: XCTestCase {
                                               pid: 100)
 
         XCTAssertNil(MeetingDetector.captureTargetProcess(for: app, in: [unrelated]))
+    }
+
+    /// A tap that delivered zero buffers must not be selected again on the
+    /// recovery pass; another process in the namespace gets a chance instead.
+    func testCaptureTargetCanExcludeADeadCurrentProcessForRecovery() {
+        MeetingDetector.resetCaptureTargetMemory()
+        let dead = AudioProcess(id: 200,
+                                name: "Microsoft Teams WebView",
+                                bundleID: "com.microsoft.teams2.helper",
+                                objectID: AudioObjectID(200),
+                                isRunningOutput: false)
+        let replacement = AudioProcess(id: 300,
+                                       name: "Microsoft Teams WebView",
+                                       bundleID: "com.microsoft.teams2.helper",
+                                       objectID: AudioObjectID(300),
+                                       isRunningOutput: false)
+        let app = MeetingDetector.DetectedApp(name: "Teams",
+                                              bundleID: "com.microsoft.teams2",
+                                              pid: 100)
+
+        XCTAssertEqual(MeetingDetector.captureTargetProcess(
+            for: app, in: [replacement, dead])?.id, dead.id)
+        XCTAssertEqual(MeetingDetector.captureTargetProcess(
+            for: app,
+            in: [replacement, dead],
+            excludingPID: dead.id)?.id, replacement.id)
+        XCTAssertNil(MeetingDetector.captureTargetProcess(
+            for: app,
+            in: [dead],
+            excludingPID: dead.id))
+        XCTAssertEqual(MeetingDetector.captureTargetProcess(
+            for: app, in: [dead])?.id, dead.id)
     }
 
     /// The namespace rule must not swallow a *different* app whose bundle id

--- a/LokalBotTests/RecordingControllerTests.swift
+++ b/LokalBotTests/RecordingControllerTests.swift
@@ -23,6 +23,13 @@ final class RecordingControllerTests: XCTestCase {
             onMeetingFinished: { _ in XCTFail("no meeting should finish") })
     }
 
+    private var teamsApp: MeetingDetector.DetectedApp {
+        MeetingDetector.DetectedApp(
+            name: "Teams",
+            bundleID: "com.microsoft.teams2",
+            pid: 100)
+    }
+
     func testStartsIdleWithZeroElapsedTimer() {
         let controller = makeController()
 
@@ -62,5 +69,58 @@ final class RecordingControllerTests: XCTestCase {
 
         XCTAssertFalse(controller.isRecording)
         XCTAssertNil(controller.currentMeeting)
+    }
+
+    func testMicrophoneOnlyPolicyNeverResolvesASystemAudioApp() {
+        var fallbackWasCalled = false
+
+        let app = RecordingSystemAudioPolicy.microphoneOnly.captureApp(
+            detectedApp: teamsApp,
+            fallback: {
+                fallbackWasCalled = true
+                return teamsApp
+            })
+
+        XCTAssertNil(app)
+        XCTAssertFalse(fallbackWasCalled)
+        XCTAssertEqual(HeadlessCommandRunner.recordSystemAudioPolicy, .microphoneOnly)
+    }
+
+    func testMeetingAudioPolicyUsesFallbackOnlyWhenNoAppWasDetected() {
+        var fallbackCalls = 0
+        let policy = RecordingSystemAudioPolicy.meetingAppWhenAvailable
+
+        XCTAssertEqual(policy.captureApp(
+            detectedApp: teamsApp,
+            fallback: {
+                fallbackCalls += 1
+                return nil
+            }), teamsApp)
+        XCTAssertEqual(fallbackCalls, 0)
+
+        XCTAssertEqual(policy.captureApp(
+            detectedApp: nil,
+            fallback: {
+                fallbackCalls += 1
+                return teamsApp
+            }), teamsApp)
+        XCTAssertEqual(fallbackCalls, 1)
+    }
+
+    func testZeroBufferAttachmentExcludesCurrentPIDFromRecovery() {
+        XCTAssertEqual(SystemAudioRecoveryCandidatePolicy.excludedPID(
+            currentPID: 200,
+            framesSinceAttach: 0), 200)
+        XCTAssertNil(SystemAudioRecoveryCandidatePolicy.excludedPID(
+            currentPID: 200,
+            framesSinceAttach: 1))
+        XCTAssertTrue(SystemAudioRecoveryCandidatePolicy.shouldRetrySamePID(
+            framesSinceAttach: 0,
+            audibleDuration: 30,
+            minimumAudibleDuration: 1))
+        XCTAssertFalse(SystemAudioRecoveryCandidatePolicy.shouldRetrySamePID(
+            framesSinceAttach: 1,
+            audibleDuration: 30,
+            minimumAudibleDuration: 1))
     }
 }


### PR DESCRIPTION
Fixes the Teams case reported in #40: no Core Audio process tap was ever created,
so every meeting recorded mic-only — silently, with no error and no log line.

### Why nothing was logged

`RecordingController.startRecording` reaches the tap only inside `if let detectedApp`,
and there is no `else`. The graceful-fallback warning lives in the `catch` around
`systemRecorder.start`, so it fires only when Core Audio or TCC rejects the tap.
When *detection* fails, nothing happens and nothing is logged — which is exactly
what the reporter observed.

### Why detection failed

During a call Teams emits output from bundle ids inside its own namespace, never
from `com.microsoft.teams2` itself:

```
com.microsoft.teams2.modulehost   (Microsoft Teams ModuleHost)  — emits continuously
com.microsoft.teams2.helper       (Microsoft Teams WebView)     — only intermittently
```

Outside the browser/Zoom branch, `bestOutputAudioProcess` matched only an exact
PID or an exact bundle id, so `hasOutputAudio` was false, `nativeMeetingApp(requireAudio: true)`
returned nil, and `detectedApp` stayed nil.

`audioBundleID(_:belongsTo:)` already modelled the `<host>.helper` relationship —
but the generic branch never consulted it. It was reachable only for browsers and Zoom.

### Change

- `audioBundleID`: widen the generic branch from the `.helper` suffix to the whole
  `<host>.` namespace, matching the `us.zoom.xos.` rule that already exists two
  lines above. Matching only `.helper` is not enough — `modulehost` is usually the
  process that is actually running.
- `bestOutputAudioProcess`: consult `audioBundleID` as a **last** fallback in the
  generic branch. The exact-PID and exact-bundle-id lookups keep precedence, so
  apps that work today are unaffected.

### Verification

Measured with a read-only Core Audio probe mirroring `bestOutputAudioProcess`,
20 samples over 20 s during an active Teams call:

| variant | detects Teams output |
|---|---|
| current code | 0/20 |
| `.helper` prefix only | 0/20 |
| whole `<host>.` namespace | 20/20 |

End-to-end on a real Teams call with the patched build:

```
startRecording source=detector app=Teams calendar=none
system audio tap started pid=87235 bundle=com.microsoft.teams2
recording stopped wall=22.57s recorded=22.02s mic=22.00s system=22.02s hasSystem=true
```

`source=detector` had never once appeared in this user's log before — automatic
meeting detection now works for Teams as well, not just the manual start. The
resulting transcript contains a correct `Them` track.

### Tests

4 added to `AudioSourceMonitorTests`, covering the modulehost case, the helper
fallback, host precedence when the main process is the emitter, and that a
lookalike bundle id (`com.microsoft.teams2evil`) does **not** match. The 8
existing tests are unchanged and still green.

Full unit suite: 1507 tests, 0 failures.

Tested on macOS 26.6.2, Apple Silicon, Microsoft Teams `com.microsoft.teams2`.
