### PR TITLE
Drop microphone segments that are only speaker bleed

### DIFF
--- a/LokalBot/Engines/SpeechActivitySpans.swift
+++ b/LokalBot/Engines/SpeechActivitySpans.swift
@@ -8,6 +8,16 @@ import FluidAudio
 struct SpeechSpan: Sendable, Equatable {
     let start: TimeInterval
     let end: TimeInterval
+    /// Fallback windows are deliberately marked coarse so downstream code
+    /// cannot mistake a whole-track/fixed-window timestamp for an utterance.
+    let timingPrecision: Transcript.Segment.TimingPrecision
+
+    init(start: TimeInterval, end: TimeInterval,
+         timingPrecision: Transcript.Segment.TimingPrecision = .coarse) {
+        self.start = start
+        self.end = end
+        self.timingPrecision = timingPrecision
+    }
 }
 
 /// Shared VAD-split → timestamped-span pipeline for the engines that
@@ -42,7 +52,8 @@ extension SpeechActivity {
             guard segment.endTime > start else { continue }
             spans.append(contentsOf: Self.split(
                 start: start, end: segment.endTime,
-                maxSegmentSeconds: maxSegmentSeconds))
+                maxSegmentSeconds: maxSegmentSeconds,
+                timingPrecision: .span))
         }
         return spans.isEmpty ? nil : spans
     }
@@ -50,7 +61,9 @@ extension SpeechActivity {
     /// Pure ≤N-second splitting on the time axis. Internal (not private) so
     /// the boundary arithmetic is unit-testable without audio files.
     static func split(start: TimeInterval, end: TimeInterval,
-                      maxSegmentSeconds: Double?) -> [SpeechSpan] {
+                      maxSegmentSeconds: Double?,
+                      timingPrecision: Transcript.Segment.TimingPrecision = .coarse
+    ) -> [SpeechSpan] {
         guard end > start else { return [] }
         let minLength = 1.0 / Double(spanSampleRate)
         let maxLength = maxSegmentSeconds.map { max($0, minLength) } ?? (end - start)
@@ -58,7 +71,8 @@ extension SpeechActivity {
         var cursor = start
         while cursor < end {
             let next = min(cursor + maxLength, end)
-            spans.append(.init(start: cursor, end: next))
+            spans.append(.init(start: cursor, end: next,
+                               timingPrecision: timingPrecision))
             cursor = next
         }
         return spans
@@ -91,7 +105,8 @@ enum SpanTranscription {
             let normalized = Transcript.normalizedText(try await transcribe(samples, index))
             guard !normalized.isEmpty else { continue }
             segments.append(.init(start: span.start, end: span.end,
-                                  speaker: speaker, text: normalized, confidence: nil))
+                                  speaker: speaker, text: normalized, confidence: nil,
+                                  timingPrecision: span.timingPrecision))
         }
         return segments
     }
@@ -106,7 +121,8 @@ enum SpanTranscription {
             let normalized = Transcript.normalizedText(text)
             guard !normalized.isEmpty else { return nil }
             return .init(start: span.start, end: span.end,
-                         speaker: speaker, text: normalized, confidence: nil)
+                         speaker: speaker, text: normalized, confidence: nil,
+                         timingPrecision: span.timingPrecision)
         }
     }
 }

--- a/LokalBot/Engines/TranscriptionEngine.swift
+++ b/LokalBot/Engines/TranscriptionEngine.swift
@@ -306,7 +306,8 @@ actor ParakeetEngine: TranscriptionEngine {
         let trimmed = Transcript.normalizedText(text)
         guard !trimmed.isEmpty else { return [] }
         return [Transcript.Segment(start: 0, end: duration, speaker: speaker,
-                                   text: trimmed, confidence: nil)]
+                                   text: trimmed, confidence: nil,
+                                   timingPrecision: .coarse)]
     }
 
     /// Groups token timings into sentence-ish segments: split on silence
@@ -317,7 +318,8 @@ actor ParakeetEngine: TranscriptionEngine {
             let text = Transcript.normalizedText(result.text)
             guard !text.isEmpty else { return [] }
             return [Transcript.Segment(start: 0, end: result.duration, speaker: speaker,
-                                       text: text, confidence: Double(result.confidence))]
+                                       text: text, confidence: Double(result.confidence),
+                                       timingPrecision: .coarse)]
         }
 
         var out: [Transcript.Segment] = []
@@ -332,7 +334,8 @@ actor ParakeetEngine: TranscriptionEngine {
             if !text.isEmpty {
                 let conf = current.map { Double($0.confidence) }.reduce(0, +) / Double(current.count)
                 out.append(.init(start: first.startTime, end: last.endTime,
-                                 speaker: speaker, text: text, confidence: conf))
+                                 speaker: speaker, text: text, confidence: conf,
+                                 timingPrecision: .token))
             }
             current = []
             currentLength = 0
@@ -428,7 +431,8 @@ actor WhisperEngine: TranscriptionEngine {
             Transcript.Segment(start: TimeInterval(seg.start), end: TimeInterval(seg.end),
                                speaker: "speaker",
                                text: Transcript.normalizedText(seg.text),
-                               confidence: nil)
+                               confidence: nil,
+                               timingPrecision: .span)
         }.filter { !$0.text.isEmpty }
         return Transcript(segments: segments, engine: "whisper-large-v3-turbo (WhisperKit)")
     }

--- a/LokalBot/Models/SpeakerBleedFilter.swift
+++ b/LokalBot/Models/SpeakerBleedFilter.swift
@@ -43,6 +43,12 @@ enum SpeakerBleedFilter {
     /// Words a shared run needs before it counts as echo rather than as two
     /// people reaching for the same common phrase.
     static let minimumRunLength = 3
+    /// The same bar for scripts written without spaces, where a token is one
+    /// character rather than one word. Chinese averages well under two
+    /// characters per word, so this is about as much language as
+    /// `minimumRunLength` words are — three characters would be a single word
+    /// and would collide by chance far too often.
+    static let minimumIdeographicRunLength = 6
     /// A segment trimmed below this is echo throughout and is dropped.
     static let minimumRemainder = 3
     /// Echo can sit at both ends of one segment, and ASR splits a run around a
@@ -134,7 +140,7 @@ enum SpeakerBleedFilter {
                 let run = longestSharedRun(words, source)
                 if run.length > best.length { best = run }
             }
-            guard best.length >= minimumRunLength else { break }
+            guard best.length >= requiredRunLength(for: current, run: best) else { break }
             // Only edge runs are cut. An echo in the middle of a segment would
             // mean the user spoke both before and after it, and stitching the
             // two halves together would invent a sentence neither said.
@@ -188,6 +194,18 @@ enum SpeakerBleedFilter {
         return best
     }
 
+    /// How long `run` must be to count as echo: runs written in an unspaced
+    /// script are measured in characters, everything else in words. Decided by
+    /// majority so a run that mixes the two (a Latin product name inside a
+    /// Chinese sentence) still uses the threshold of the script it mostly is.
+    static func requiredRunLength(for tokens: [Token], run: SharedRun) -> Int {
+        guard run.length > 0, run.end <= tokens.count else { return minimumRunLength }
+        let ideographic = tokens[run.start..<run.end].reduce(into: 0) { count, token in
+            if token.isIdeographic { count += 1 }
+        }
+        return ideographic * 2 >= run.length ? minimumIdeographicRunLength : minimumRunLength
+    }
+
     /// Whether two words are the same word. The tracks are transcribed by two
     /// independent passes over different audio, so the same spoken word comes
     /// back slightly different — "Wim"/"Bim", "reinbasta"/"reinbasteln" — and
@@ -225,6 +243,26 @@ enum SpeakerBleedFilter {
     struct Token: Equatable {
         var word: String
         var range: Range<String.Index>
+        /// Set for tokens that are a single character of an unspaced script.
+        var isIdeographic = false
+    }
+
+    /// Chinese and Japanese are written without spaces between words. Whether a
+    /// character belongs to one of those scripts decides how the text is cut
+    /// into tokens — Korean is deliberately absent, because Hangul is spaced
+    /// and tokenizes like a Latin script.
+    static func isIdeographic(_ character: Character) -> Bool {
+        guard let scalar = character.unicodeScalars.first else { return false }
+        switch scalar.value {
+        case 0x3040...0x30FF,    // Hiragana and Katakana
+             0x3400...0x4DBF,    // CJK Unified Ideographs Extension A
+             0x4E00...0x9FFF,    // CJK Unified Ideographs
+             0xF900...0xFAFF,    // CJK Compatibility Ideographs
+             0x20000...0x2FA1F:  // Extension B and beyond
+            return true
+        default:
+            return false
+        }
     }
 
     /// Words with their place in the original text, so a trimmed segment can be
@@ -237,8 +275,23 @@ enum SpeakerBleedFilter {
                 index = text.index(after: index)
                 continue
             }
+            // An unspaced script has no word boundaries to split on, so a whole
+            // Mandarin sentence would arrive as one token and no run could ever
+            // reach `minimumRunLength`. Emitting each character separately makes
+            // the run search a character n-gram match, which is the comparison
+            // those scripts need.
+            if isIdeographic(text[index]) {
+                let next = text.index(after: index)
+                tokens.append(Token(word: String(text[index]).lowercased(),
+                                    range: index..<next,
+                                    isIdeographic: true))
+                index = next
+                continue
+            }
             let start = index
-            while index < text.endIndex, text[index].isLetter || text[index].isNumber {
+            while index < text.endIndex,
+                  text[index].isLetter || text[index].isNumber,
+                  !isIdeographic(text[index]) {
                 index = text.index(after: index)
             }
             tokens.append(Token(word: text[start..<index].lowercased(), range: start..<index))

--- a/LokalBot/Models/SpeakerBleedFilter.swift
+++ b/LokalBot/Models/SpeakerBleedFilter.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Drops microphone segments that are only the *other* side of the call leaking
+/// back in through the speakers.
+///
+/// LokalBot records the raw input device, so the meeting app's own echo
+/// cancellation never applies to our mic track: whenever the user is on
+/// speakers rather than headphones, the remote voice lands on both tracks and
+/// is transcribed twice — once correctly as `them`, once wrongly as `me`.
+///
+/// The discriminator is timing, not text alone. Acoustic echo is effectively
+/// simultaneous with the sound that caused it, while a person genuinely
+/// repeating what was just said speaks *afterwards*. Requiring a large temporal
+/// overlap therefore separates the two cases that similar wording alone cannot,
+/// which is what keeps a real "yes, exactly what you said" from being deleted.
+///
+/// Runs before diarization, while speakers are still the raw track labels.
+enum SpeakerBleedFilter {
+
+    struct Result {
+        var transcript: Transcript
+        var removedSegments: Int
+
+        var changed: Bool { removedSegments > 0 }
+    }
+
+    /// Fraction of the shorter segment that must overlap in time.
+    static let minimumTimeOverlap = 0.5
+    /// Fraction of the shorter segment's words that must also appear in the other.
+    static let minimumTextSimilarity = 0.8
+    /// Below this, wording is too generic to judge ("ja", "genau", "okay").
+    static let minimumWordCount = 4
+
+    static func filter(_ transcript: Transcript) -> Result {
+        let remote = transcript.segments.filter { canonical($0.speaker) == "them" }
+        guard !remote.isEmpty else { return Result(transcript: transcript, removedSegments: 0) }
+
+        var kept: [Transcript.Segment] = []
+        var removed = 0
+        for segment in transcript.segments {
+            if canonical(segment.speaker) == "me",
+               remote.contains(where: { isEcho(of: $0, in: segment) }) {
+                removed += 1
+                continue
+            }
+            kept.append(segment)
+        }
+        guard removed > 0 else { return Result(transcript: transcript, removedSegments: 0) }
+        var cleaned = transcript
+        cleaned.segments = kept
+        return Result(transcript: cleaned, removedSegments: removed)
+    }
+
+    /// Whether `candidate` (a mic segment) is the speaker bleed of `source`
+    /// (a system segment): overlapping in time *and* saying the same thing.
+    private static func isEcho(of source: Transcript.Segment,
+                               in candidate: Transcript.Segment) -> Bool {
+        let candidateWords = words(in: candidate.text)
+        let sourceWords = words(in: source.text)
+        guard candidateWords.count >= minimumWordCount,
+              sourceWords.count >= minimumWordCount,
+              timeOverlap(candidate, source) >= minimumTimeOverlap,
+              textSimilarity(candidateWords, sourceWords) >= minimumTextSimilarity
+        else { return false }
+        return true
+    }
+
+    /// Overlap as a fraction of the shorter segment, so a brief echo inside a
+    /// long remote turn still counts.
+    static func timeOverlap(_ lhs: Transcript.Segment, _ rhs: Transcript.Segment) -> Double {
+        let overlap = Swift.min(lhs.end, rhs.end) - Swift.max(lhs.start, rhs.start)
+        guard overlap > 0 else { return 0 }
+        let shorter = Swift.min(lhs.end - lhs.start, rhs.end - rhs.start)
+        guard shorter > 0 else { return 0 }
+        return Swift.min(1, overlap / shorter)
+    }
+
+    /// Multiset word overlap against the shorter side. Echo is rarely a
+    /// character-perfect copy — ASR clips the start, adds stray punctuation —
+    /// so this tolerates partial capture without matching unrelated sentences.
+    static func textSimilarity(_ lhs: [String], _ rhs: [String]) -> Double {
+        guard !lhs.isEmpty, !rhs.isEmpty else { return 0 }
+        var remaining: [String: Int] = [:]
+        for word in rhs { remaining[word, default: 0] += 1 }
+        var shared = 0
+        for word in lhs where (remaining[word] ?? 0) > 0 {
+            remaining[word]! -= 1
+            shared += 1
+        }
+        return Double(shared) / Double(Swift.min(lhs.count, rhs.count))
+    }
+
+    static func words(in text: String) -> [String] {
+        text.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+    }
+
+    private static func canonical(_ speaker: String) -> String {
+        speaker.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/LokalBot/Models/SpeakerBleedFilter.swift
+++ b/LokalBot/Models/SpeakerBleedFilter.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Drops microphone segments that are only the *other* side of the call leaking
-/// back in through the speakers.
+/// Removes the *other* side of the call where it leaks back into the
+/// microphone through the speakers.
 ///
 /// LokalBot records the raw input device, so the meeting app's own echo
 /// cancellation never applies to our mic track: whenever the user is on
@@ -10,9 +10,19 @@ import Foundation
 ///
 /// The discriminator is timing, not text alone. Acoustic echo is effectively
 /// simultaneous with the sound that caused it, while a person genuinely
-/// repeating what was just said speaks *afterwards*. Requiring a large temporal
-/// overlap therefore separates the two cases that similar wording alone cannot,
-/// which is what keeps a real "yes, exactly what you said" from being deleted.
+/// repeating what was just said speaks *afterwards*. Requiring temporal
+/// overlap therefore separates the two cases that similar wording alone
+/// cannot, which is what keeps a real "yes, exactly what you said" alive.
+///
+/// Echo rarely fills a whole mic segment, though. The two tracks are
+/// transcribed independently, so their segment boundaries fall in different
+/// places and a single mic segment routinely carries an echoed opening
+/// followed by the user's own words — measured on a real 49-minute meeting,
+/// mixed segments outnumbered pure ones. Dropping whole segments therefore
+/// either loses real speech or keeps the echo. This filter instead locates the
+/// longest run of words the remote side said at the same moment and trims just
+/// that run when it sits at a segment edge; a segment left with nothing is
+/// dropped, which is the pure-echo case falling out of the same rule.
 ///
 /// Runs before diarization, while speakers are still the raw track labels.
 enum SpeakerBleedFilter {
@@ -20,49 +30,220 @@ enum SpeakerBleedFilter {
     struct Result {
         var transcript: Transcript
         var removedSegments: Int
+        var trimmedSegments: Int
+        var removedWords: Int
 
-        var changed: Bool { removedSegments > 0 }
+        var changed: Bool { removedSegments > 0 || trimmedSegments > 0 }
     }
 
-    /// Fraction of the shorter segment that must overlap in time.
-    static let minimumTimeOverlap = 0.5
-    /// Fraction of the shorter segment's words that must also appear in the other.
-    static let minimumTextSimilarity = 0.8
-    /// Below this, wording is too generic to judge ("ja", "genau", "okay").
-    static let minimumWordCount = 4
+    /// Fraction of the shorter segment that must overlap in time before the
+    /// two are compared at all. Lower than a "same utterance" test would need
+    /// because a long remote turn overlaps only part of a short mic segment.
+    static let minimumTimeOverlap = 0.3
+    /// Words a shared run needs before it counts as echo rather than as two
+    /// people reaching for the same common phrase.
+    static let minimumRunLength = 3
+    /// A segment trimmed below this is echo throughout and is dropped.
+    static let minimumRemainder = 3
+    /// Echo can sit at both ends of one segment, and ASR splits a run around a
+    /// misheard word; a few passes catch those without unbounded chewing.
+    static let maximumTrimPasses = 3
+    /// Stray words the ASR tacks onto an echo ("ja", a clipped article) may
+    /// precede or follow the run and are trimmed with it.
+    static let edgeSlack = 1
 
     static func filter(_ transcript: Transcript) -> Result {
         let remote = transcript.segments.filter { canonical($0.speaker) == "them" }
-        guard !remote.isEmpty else { return Result(transcript: transcript, removedSegments: 0) }
+        guard !remote.isEmpty else {
+            return Result(transcript: transcript, removedSegments: 0,
+                          trimmedSegments: 0, removedWords: 0)
+        }
 
         var kept: [Transcript.Segment] = []
         var removed = 0
+        var trimmed = 0
+        var removedWords = 0
+
         for segment in transcript.segments {
-            if canonical(segment.speaker) == "me",
-               remote.contains(where: { isEcho(of: $0, in: segment) }) {
-                removed += 1
+            guard canonical(segment.speaker) == "me" else {
+                kept.append(segment)
                 continue
             }
-            kept.append(segment)
+            let partners = remote.filter { timeOverlap(segment, $0) >= minimumTimeOverlap }
+            guard !partners.isEmpty else {
+                kept.append(segment)
+                continue
+            }
+            let outcome = stripEcho(from: segment.text,
+                                    heardIn: partners.map(\.text))
+            removedWords += outcome.removedWords
+            switch outcome.remainder {
+            case .none:
+                removed += 1
+            case .unchanged:
+                kept.append(segment)
+            case .trimmed(let text):
+                var cleaned = segment
+                cleaned.text = text
+                kept.append(cleaned)
+                trimmed += 1
+            }
         }
-        guard removed > 0 else { return Result(transcript: transcript, removedSegments: 0) }
+
+        guard removed > 0 || trimmed > 0 else {
+            return Result(transcript: transcript, removedSegments: 0,
+                          trimmedSegments: 0, removedWords: 0)
+        }
         var cleaned = transcript
         cleaned.segments = kept
-        return Result(transcript: cleaned, removedSegments: removed)
+        return Result(transcript: cleaned, removedSegments: removed,
+                      trimmedSegments: trimmed, removedWords: removedWords)
     }
 
-    /// Whether `candidate` (a mic segment) is the speaker bleed of `source`
-    /// (a system segment): overlapping in time *and* saying the same thing.
-    private static func isEcho(of source: Transcript.Segment,
-                               in candidate: Transcript.Segment) -> Bool {
-        let candidateWords = words(in: candidate.text)
-        let sourceWords = words(in: source.text)
-        guard candidateWords.count >= minimumWordCount,
-              sourceWords.count >= minimumWordCount,
-              timeOverlap(candidate, source) >= minimumTimeOverlap,
-              textSimilarity(candidateWords, sourceWords) >= minimumTextSimilarity
-        else { return false }
+    // MARK: - Trimming
+
+    enum Remainder: Equatable {
+        /// Nothing of the segment survives — it was echo throughout.
+        case none
+        /// No echo run found at an edge; the segment stands as recorded.
+        case unchanged
+        /// What is left after the echoed edges were cut away.
+        case trimmed(String)
+    }
+
+    struct StripOutcome: Equatable {
+        var remainder: Remainder
+        var removedWords: Int
+    }
+
+    /// Cuts the runs of `text` that one of `sources` said at the same time.
+    /// Pure, so the edge rules are testable without segments or timings.
+    static func stripEcho(from text: String, heardIn sources: [String]) -> StripOutcome {
+        let original = tokens(in: text)
+        guard !original.isEmpty else {
+            return StripOutcome(remainder: .unchanged, removedWords: 0)
+        }
+        let sourceWords = sources.map { tokens(in: $0).map(\.word) }
+        var current = original
+        var removedWords = 0
+
+        for _ in 0..<maximumTrimPasses {
+            let words = current.map(\.word)
+            var best = SharedRun(length: 0, start: 0, end: 0)
+            for source in sourceWords {
+                let run = longestSharedRun(words, source)
+                if run.length > best.length { best = run }
+            }
+            guard best.length >= minimumRunLength else { break }
+            // Only edge runs are cut. An echo in the middle of a segment would
+            // mean the user spoke both before and after it, and stitching the
+            // two halves together would invent a sentence neither said.
+            if best.start <= edgeSlack {
+                current = Array(current[best.end...])
+            } else if best.end >= current.count - edgeSlack {
+                current = Array(current[..<best.start])
+            } else {
+                break
+            }
+            removedWords += best.length
+            if current.isEmpty { break }
+        }
+
+        if current.count == original.count {
+            return StripOutcome(remainder: .unchanged, removedWords: 0)
+        }
+        guard current.count >= minimumRemainder,
+              let first = current.first, let last = current.last else {
+            return StripOutcome(remainder: .none, removedWords: removedWords)
+        }
+        let slice = String(text[first.range.lowerBound..<last.range.upperBound])
+        return StripOutcome(remainder: .trimmed(Transcript.normalizedText(slice)),
+                            removedWords: removedWords)
+    }
+
+    struct SharedRun: Equatable {
+        var length: Int
+        /// Index of the first shared word in the left-hand side.
+        var start: Int
+        /// One past the last shared word in the left-hand side.
+        var end: Int
+    }
+
+    /// Longest run of consecutive words both sides share, comparing words
+    /// loosely (see `wordsMatch`). Positions refer to `lhs`.
+    static func longestSharedRun(_ lhs: [String], _ rhs: [String]) -> SharedRun {
+        var best = SharedRun(length: 0, start: 0, end: 0)
+        guard !lhs.isEmpty, !rhs.isEmpty else { return best }
+        var previous = [Int](repeating: 0, count: rhs.count + 1)
+        for i in 1...lhs.count {
+            var current = [Int](repeating: 0, count: rhs.count + 1)
+            for j in 1...rhs.count where wordsMatch(lhs[i - 1], rhs[j - 1]) {
+                current[j] = previous[j - 1] + 1
+                if current[j] > best.length {
+                    best = SharedRun(length: current[j], start: i - current[j], end: i)
+                }
+            }
+            previous = current
+        }
+        return best
+    }
+
+    /// Whether two words are the same word. The tracks are transcribed by two
+    /// independent passes over different audio, so the same spoken word comes
+    /// back slightly different — "Wim"/"Bim", "reinbasta"/"reinbasteln" — and
+    /// exact equality misses most real echo. One edit is allowed from three
+    /// characters up, where a single letter no longer changes the word.
+    static func wordsMatch(_ lhs: String, _ rhs: String) -> Bool {
+        if lhs == rhs { return true }
+        let left = Array(lhs), right = Array(rhs)
+        guard Swift.min(left.count, right.count) >= 3,
+              abs(left.count - right.count) <= 1 else { return false }
+        return differsByAtMostOneEdit(left, right)
+    }
+
+    /// Single-edit check by walking both sides once, rather than a full edit
+    /// distance we would immediately threshold anyway.
+    private static func differsByAtMostOneEdit(_ lhs: [Character], _ rhs: [Character]) -> Bool {
+        let (shorter, longer) = lhs.count <= rhs.count ? (lhs, rhs) : (rhs, lhs)
+        var i = 0, j = 0
+        var edited = false
+        while i < shorter.count, j < longer.count {
+            if shorter[i] == longer[j] {
+                i += 1; j += 1
+                continue
+            }
+            if edited { return false }
+            edited = true
+            if shorter.count == longer.count { i += 1 }
+            j += 1
+        }
         return true
+    }
+
+    // MARK: - Tokens, timing
+
+    struct Token: Equatable {
+        var word: String
+        var range: Range<String.Index>
+    }
+
+    /// Words with their place in the original text, so a trimmed segment can be
+    /// sliced out of it and keep its punctuation and capitalization.
+    static func tokens(in text: String) -> [Token] {
+        var tokens: [Token] = []
+        var index = text.startIndex
+        while index < text.endIndex {
+            guard text[index].isLetter || text[index].isNumber else {
+                index = text.index(after: index)
+                continue
+            }
+            let start = index
+            while index < text.endIndex, text[index].isLetter || text[index].isNumber {
+                index = text.index(after: index)
+            }
+            tokens.append(Token(word: text[start..<index].lowercased(), range: start..<index))
+        }
+        return tokens
     }
 
     /// Overlap as a fraction of the shorter segment, so a brief echo inside a
@@ -75,25 +256,8 @@ enum SpeakerBleedFilter {
         return Swift.min(1, overlap / shorter)
     }
 
-    /// Multiset word overlap against the shorter side. Echo is rarely a
-    /// character-perfect copy — ASR clips the start, adds stray punctuation —
-    /// so this tolerates partial capture without matching unrelated sentences.
-    static func textSimilarity(_ lhs: [String], _ rhs: [String]) -> Double {
-        guard !lhs.isEmpty, !rhs.isEmpty else { return 0 }
-        var remaining: [String: Int] = [:]
-        for word in rhs { remaining[word, default: 0] += 1 }
-        var shared = 0
-        for word in lhs where (remaining[word] ?? 0) > 0 {
-            remaining[word]! -= 1
-            shared += 1
-        }
-        return Double(shared) / Double(Swift.min(lhs.count, rhs.count))
-    }
-
     static func words(in text: String) -> [String] {
-        text.lowercased()
-            .components(separatedBy: CharacterSet.alphanumerics.inverted)
-            .filter { !$0.isEmpty }
+        tokens(in: text).map(\.word)
     }
 
     private static func canonical(_ speaker: String) -> String {

--- a/LokalBot/Models/SpeakerBleedFilter.swift
+++ b/LokalBot/Models/SpeakerBleedFilter.swift
@@ -1,316 +1,227 @@
 import Foundation
 
-/// Removes the *other* side of the call where it leaks back into the
-/// microphone through the speakers.
+/// Removes a microphone segment only when a complete, precisely timed remote
+/// segment carries the same utterance at the same time.
 ///
-/// LokalBot records the raw input device, so the meeting app's own echo
-/// cancellation never applies to our mic track: whenever the user is on
-/// speakers rather than headphones, the remote voice lands on both tracks and
-/// is transcribed twice — once correctly as `them`, once wrongly as `me`.
-///
-/// The discriminator is timing, not text alone. Acoustic echo is effectively
-/// simultaneous with the sound that caused it, while a person genuinely
-/// repeating what was just said speaks *afterwards*. Requiring temporal
-/// overlap therefore separates the two cases that similar wording alone
-/// cannot, which is what keeps a real "yes, exactly what you said" alive.
-///
-/// Echo rarely fills a whole mic segment, though. The two tracks are
-/// transcribed independently, so their segment boundaries fall in different
-/// places and a single mic segment routinely carries an echoed opening
-/// followed by the user's own words — measured on a real 49-minute meeting,
-/// mixed segments outnumbered pure ones. Dropping whole segments therefore
-/// either loses real speech or keeps the echo. This filter instead locates the
-/// longest run of words the remote side said at the same moment and trims just
-/// that run when it sits at a segment edge; a segment left with nothing is
-/// dropped, which is the pure-echo case falling out of the same rule.
-///
-/// Runs before diarization, while speakers are still the raw track labels.
+/// This is intentionally conservative. Segment overlap cannot localize a phrase
+/// within a long ASR block, and partially trimming text without word timestamps
+/// would leave the surviving words attached to false evidence timestamps. An
+/// ambiguous segment therefore survives unchanged; the raw system track remains
+/// the clean source when a whole mic span is proven to be speaker bleed.
 enum SpeakerBleedFilter {
 
     struct Result {
         var transcript: Transcript
         var removedSegments: Int
-        var trimmedSegments: Int
         var removedWords: Int
 
-        var changed: Bool { removedSegments > 0 || trimmedSegments > 0 }
+        var changed: Bool { removedSegments > 0 }
     }
 
-    /// Fraction of the shorter segment that must overlap in time before the
-    /// two are compared at all. Lower than a "same utterance" test would need
-    /// because a long remote turn overlaps only part of a short mic segment.
-    static let minimumTimeOverlap = 0.3
-    /// Words a shared run needs before it counts as echo rather than as two
-    /// people reaching for the same common phrase.
-    static let minimumRunLength = 3
-    /// The same bar for scripts written without spaces, where a token is one
-    /// character rather than one word. Chinese averages well under two
-    /// characters per word, so this is about as much language as
-    /// `minimumRunLength` words are — three characters would be a single word
-    /// and would collide by chance far too often.
-    static let minimumIdeographicRunLength = 6
-    /// A segment trimmed below this is echo throughout and is dropped.
-    static let minimumRemainder = 3
-    /// Echo can sit at both ends of one segment, and ASR splits a run around a
-    /// misheard word; a few passes catch those without unbounded chewing.
-    static let maximumTrimPasses = 3
-    /// Stray words the ASR tacks onto an echo ("ja", a clipped article) may
-    /// precede or follow the run and are trimmed with it.
-    static let edgeSlack = 1
-
-    static func filter(_ transcript: Transcript) -> Result {
-        let remote = transcript.segments.filter { canonical($0.speaker) == "them" }
-        guard !remote.isEmpty else {
-            return Result(transcript: transcript, removedSegments: 0,
-                          trimmedSegments: 0, removedWords: 0)
-        }
-
-        var kept: [Transcript.Segment] = []
-        var removed = 0
-        var trimmed = 0
-        var removedWords = 0
-
-        for segment in transcript.segments {
-            guard canonical(segment.speaker) == "me" else {
-                kept.append(segment)
-                continue
-            }
-            let partners = remote.filter { timeOverlap(segment, $0) >= minimumTimeOverlap }
-            guard !partners.isEmpty else {
-                kept.append(segment)
-                continue
-            }
-            let outcome = stripEcho(from: segment.text,
-                                    heardIn: partners.map(\.text))
-            removedWords += outcome.removedWords
-            switch outcome.remainder {
-            case .none:
-                removed += 1
-            case .unchanged:
-                kept.append(segment)
-            case .trimmed(let text):
-                var cleaned = segment
-                cleaned.text = text
-                kept.append(cleaned)
-                trimmed += 1
-            }
-        }
-
-        guard removed > 0 || trimmed > 0 else {
-            return Result(transcript: transcript, removedSegments: 0,
-                          trimmedSegments: 0, removedWords: 0)
-        }
-        var cleaned = transcript
-        cleaned.segments = kept
-        return Result(transcript: cleaned, removedSegments: removed,
-                      trimmedSegments: trimmed, removedWords: removedWords)
-    }
-
-    // MARK: - Trimming
-
-    enum Remainder: Equatable {
-        /// Nothing of the segment survives — it was echo throughout.
-        case none
-        /// No echo run found at an edge; the segment stands as recorded.
-        case unchanged
-        /// What is left after the echoed edges were cut away.
-        case trimmed(String)
-    }
-
-    struct StripOutcome: Equatable {
-        var remainder: Remainder
-        var removedWords: Int
-    }
-
-    /// Cuts the runs of `text` that one of `sources` said at the same time.
-    /// Pure, so the edge rules are testable without segments or timings.
-    static func stripEcho(from text: String, heardIn sources: [String]) -> StripOutcome {
-        let original = tokens(in: text)
-        guard !original.isEmpty else {
-            return StripOutcome(remainder: .unchanged, removedWords: 0)
-        }
-        let sourceWords = sources.map { tokens(in: $0).map(\.word) }
-        var current = original
-        var removedWords = 0
-
-        for _ in 0..<maximumTrimPasses {
-            let words = current.map(\.word)
-            var best = SharedRun(length: 0, start: 0, end: 0)
-            for source in sourceWords {
-                let run = longestSharedRun(words, source)
-                if run.length > best.length { best = run }
-            }
-            guard best.length >= requiredRunLength(for: current, run: best) else { break }
-            // Only edge runs are cut. An echo in the middle of a segment would
-            // mean the user spoke both before and after it, and stitching the
-            // two halves together would invent a sentence neither said.
-            if best.start <= edgeSlack {
-                current = Array(current[best.end...])
-            } else if best.end >= current.count - edgeSlack {
-                current = Array(current[..<best.start])
-            } else {
-                break
-            }
-            removedWords += best.length
-            if current.isEmpty { break }
-        }
-
-        if current.count == original.count {
-            return StripOutcome(remainder: .unchanged, removedWords: 0)
-        }
-        guard current.count >= minimumRemainder,
-              let first = current.first, let last = current.last else {
-            return StripOutcome(remainder: .none, removedWords: removedWords)
-        }
-        let slice = String(text[first.range.lowerBound..<last.range.upperBound])
-        return StripOutcome(remainder: .trimmed(Transcript.normalizedText(slice)),
-                            removedWords: removedWords)
-    }
-
-    struct SharedRun: Equatable {
-        var length: Int
-        /// Index of the first shared word in the left-hand side.
-        var start: Int
-        /// One past the last shared word in the left-hand side.
-        var end: Int
-    }
-
-    /// Longest run of consecutive words both sides share, comparing words
-    /// loosely (see `wordsMatch`). Positions refer to `lhs`.
-    static func longestSharedRun(_ lhs: [String], _ rhs: [String]) -> SharedRun {
-        var best = SharedRun(length: 0, start: 0, end: 0)
-        guard !lhs.isEmpty, !rhs.isEmpty else { return best }
-        var previous = [Int](repeating: 0, count: rhs.count + 1)
-        for i in 1...lhs.count {
-            var current = [Int](repeating: 0, count: rhs.count + 1)
-            for j in 1...rhs.count where wordsMatch(lhs[i - 1], rhs[j - 1]) {
-                current[j] = previous[j - 1] + 1
-                if current[j] > best.length {
-                    best = SharedRun(length: current[j], start: i - current[j], end: i)
-                }
-            }
-            previous = current
-        }
-        return best
-    }
-
-    /// How long `run` must be to count as echo: runs written in an unspaced
-    /// script are measured in characters, everything else in words. Decided by
-    /// majority so a run that mixes the two (a Latin product name inside a
-    /// Chinese sentence) still uses the threshold of the script it mostly is.
-    static func requiredRunLength(for tokens: [Token], run: SharedRun) -> Int {
-        guard run.length > 0, run.end <= tokens.count else { return minimumRunLength }
-        let ideographic = tokens[run.start..<run.end].reduce(into: 0) { count, token in
-            if token.isIdeographic { count += 1 }
-        }
-        return ideographic * 2 >= run.length ? minimumIdeographicRunLength : minimumRunLength
-    }
-
-    /// Whether two words are the same word. The tracks are transcribed by two
-    /// independent passes over different audio, so the same spoken word comes
-    /// back slightly different — "Wim"/"Bim", "reinbasta"/"reinbasteln" — and
-    /// exact equality misses most real echo. One edit is allowed from three
-    /// characters up, where a single letter no longer changes the word.
-    static func wordsMatch(_ lhs: String, _ rhs: String) -> Bool {
-        if lhs == rhs { return true }
-        let left = Array(lhs), right = Array(rhs)
-        guard Swift.min(left.count, right.count) >= 3,
-              abs(left.count - right.count) <= 1 else { return false }
-        return differsByAtMostOneEdit(left, right)
-    }
-
-    /// Single-edit check by walking both sides once, rather than a full edit
-    /// distance we would immediately threshold anyway.
-    private static func differsByAtMostOneEdit(_ lhs: [Character], _ rhs: [Character]) -> Bool {
-        let (shorter, longer) = lhs.count <= rhs.count ? (lhs, rhs) : (rhs, lhs)
-        var i = 0, j = 0
-        var edited = false
-        while i < shorter.count, j < longer.count {
-            if shorter[i] == longer[j] {
-                i += 1; j += 1
-                continue
-            }
-            if edited { return false }
-            edited = true
-            if shorter.count == longer.count { i += 1 }
-            j += 1
-        }
-        return true
-    }
-
-    // MARK: - Tokens, timing
+    /// Longer blocks may be whole-track or fixed-window fallbacks even when
+    /// their outer timestamps are known. Do not make destructive decisions on
+    /// text whose words could be far apart inside the block.
+    static let maximumComparableSpanDuration: TimeInterval = 15
+    /// Independent ASR passes can place the same utterance boundary slightly
+    /// differently, but both edges must still describe the same short span.
+    static let maximumBoundaryDrift: TimeInterval = 0.75
+    static let minimumAlignedCoverage = 0.85
+    /// A few generic words are plausible simultaneous speech, not proof of echo.
+    static let minimumWordTokenCount = 4
+    /// Ideographic tokens are characters and carry less evidence than words.
+    static let minimumIdeographicTokenCount = 8
+    /// Hard bounds keep this synchronous pipeline step linear and predictable on
+    /// the main actor, including for malformed or legacy transcript content.
+    static let maximumComparableTextBytes = 4_096
+    static let maximumComparableTokenCount = 256
+    static let maximumCandidateSegments = 8
 
     struct Token: Equatable {
         var word: String
-        var range: Range<String.Index>
-        /// Set for tokens that are a single character of an unspaced script.
-        var isIdeographic = false
+        var isIdeographic: Bool
     }
 
-    /// Chinese and Japanese are written without spaces between words. Whether a
-    /// character belongs to one of those scripts decides how the text is cut
-    /// into tokens — Korean is deliberately absent, because Hangul is spaced
-    /// and tokenizes like a Latin script.
+    private struct IndexedRemote {
+        var segment: Transcript.Segment
+        var tokens: [Token]
+    }
+
+    static func filter(_ transcript: Transcript) -> Result {
+        let remote = transcript.segments.compactMap { segment -> IndexedRemote? in
+            guard canonical(segment.speaker) == "them",
+                  isComparableSpan(segment),
+                  let tokens = evidenceTokens(in: segment.text) else { return nil }
+            return IndexedRemote(segment: segment, tokens: tokens)
+        }.sorted {
+            if $0.segment.start == $1.segment.start {
+                return $0.segment.end < $1.segment.end
+            }
+            return $0.segment.start < $1.segment.start
+        }
+
+        guard !remote.isEmpty else {
+            return Result(transcript: transcript, removedSegments: 0, removedWords: 0)
+        }
+
+        var kept: [Transcript.Segment] = []
+        kept.reserveCapacity(transcript.segments.count)
+        var removedSegments = 0
+        var removedWords = 0
+
+        for segment in transcript.segments {
+            guard canonical(segment.speaker) == "me",
+                  isComparableSpan(segment),
+                  let tokens = evidenceTokens(in: segment.text),
+                  hasMatchingRemote(segment: segment, tokens: tokens, remote: remote) else {
+                kept.append(segment)
+                continue
+            }
+            removedSegments += 1
+            removedWords += tokens.count
+        }
+
+        guard removedSegments > 0 else {
+            return Result(transcript: transcript, removedSegments: 0, removedWords: 0)
+        }
+        var cleaned = transcript
+        cleaned.segments = kept
+        return Result(transcript: cleaned,
+                      removedSegments: removedSegments,
+                      removedWords: removedWords)
+    }
+
+    private static func hasMatchingRemote(
+        segment: Transcript.Segment,
+        tokens: [Token],
+        remote: [IndexedRemote]
+    ) -> Bool {
+        let earliestStart = segment.start - maximumBoundaryDrift
+        let latestStart = segment.start + maximumBoundaryDrift
+        var index = lowerBound(in: remote, start: earliestStart)
+        var scanned = 0
+        var foundMatch = false
+
+        while index < remote.count, remote[index].segment.start <= latestStart {
+            scanned += 1
+            // Crowded or pathological timing is ambiguous. Stop before work can
+            // grow with an unbounded same-timestamp segment set.
+            guard scanned <= maximumCandidateSegments else { return false }
+            let candidate = remote[index]
+            if spansAreAligned(segment, candidate.segment), candidate.tokens == tokens {
+                foundMatch = true
+            }
+            index += 1
+        }
+        return foundMatch
+    }
+
+    private static func lowerBound(in segments: [IndexedRemote], start: TimeInterval) -> Int {
+        var lower = 0
+        var upper = segments.count
+        while lower < upper {
+            let middle = lower + (upper - lower) / 2
+            if segments[middle].segment.start < start {
+                lower = middle + 1
+            } else {
+                upper = middle
+            }
+        }
+        return lower
+    }
+
+    static func isComparableSpan(_ segment: Transcript.Segment) -> Bool {
+        guard segment.timingPrecision?.isBleedFilterSafe == true,
+              segment.start.isFinite, segment.end.isFinite else { return false }
+        let duration = segment.end - segment.start
+        return duration > 0 && duration <= maximumComparableSpanDuration
+    }
+
+    static func spansAreAligned(
+        _ lhs: Transcript.Segment,
+        _ rhs: Transcript.Segment
+    ) -> Bool {
+        guard isComparableSpan(lhs), isComparableSpan(rhs),
+              abs(lhs.start - rhs.start) <= maximumBoundaryDrift,
+              abs(lhs.end - rhs.end) <= maximumBoundaryDrift else { return false }
+        let overlap = min(lhs.end, rhs.end) - max(lhs.start, rhs.start)
+        let longest = max(lhs.end - lhs.start, rhs.end - rhs.start)
+        return overlap > 0 && overlap / longest >= minimumAlignedCoverage
+    }
+
+    static func evidenceTokens(in text: String) -> [Token]? {
+        guard let tokens = comparisonTokens(in: text) else { return nil }
+        let ideographic = tokens.reduce(into: 0) { count, token in
+            if token.isIdeographic { count += 1 }
+        }
+        let minimum = ideographic * 2 >= tokens.count
+            ? minimumIdeographicTokenCount
+            : minimumWordTokenCount
+        return tokens.count >= minimum ? tokens : nil
+    }
+
+    /// Case- and punctuation-insensitive lexical tokens for whole-span equality.
+    /// Apostrophes inside a word stay inside it, so short contractions cannot
+    /// manufacture enough tokens to bypass the generic-utterance guard.
+    static func comparisonTokens(in text: String) -> [Token]? {
+        guard text.utf8.prefix(maximumComparableTextBytes + 1).count
+                <= maximumComparableTextBytes else { return nil }
+
+        var tokens: [Token] = []
+        var currentWord = ""
+
+        func flushWord() {
+            guard !currentWord.isEmpty else { return }
+            tokens.append(Token(word: currentWord.lowercased(), isIdeographic: false))
+            currentWord.removeAll(keepingCapacity: true)
+        }
+
+        var index = text.startIndex
+        while index < text.endIndex {
+            let character = text[index]
+            if isIdeographic(character) {
+                flushWord()
+                tokens.append(Token(word: String(character).lowercased(), isIdeographic: true))
+            } else if character.isLetter || character.isNumber {
+                currentWord.append(character)
+            } else if isApostrophe(character), !currentWord.isEmpty {
+                let next = text.index(after: index)
+                if next < text.endIndex,
+                   text[next].isLetter || text[next].isNumber,
+                   !isIdeographic(text[next]) {
+                    currentWord.append("'")
+                } else {
+                    flushWord()
+                }
+            } else {
+                flushWord()
+            }
+            guard tokens.count <= maximumComparableTokenCount else { return nil }
+            index = text.index(after: index)
+        }
+        flushWord()
+        guard tokens.count <= maximumComparableTokenCount else { return nil }
+        return tokens
+    }
+
     static func isIdeographic(_ character: Character) -> Bool {
         guard let scalar = character.unicodeScalars.first else { return false }
         switch scalar.value {
         case 0x3040...0x30FF,    // Hiragana and Katakana
+             0x31F0...0x31FF,    // Katakana phonetic extensions
              0x3400...0x4DBF,    // CJK Unified Ideographs Extension A
              0x4E00...0x9FFF,    // CJK Unified Ideographs
              0xF900...0xFAFF,    // CJK Compatibility Ideographs
-             0x20000...0x2FA1F:  // Extension B and beyond
+             0xFF66...0xFF9D,    // Halfwidth Katakana
+             0x20000...0x2FA1F,  // Extensions B-F/I + compatibility supplement
+             0x30000...0x323AF:  // Extensions G and H
             return true
         default:
             return false
         }
     }
 
-    /// Words with their place in the original text, so a trimmed segment can be
-    /// sliced out of it and keep its punctuation and capitalization.
-    static func tokens(in text: String) -> [Token] {
-        var tokens: [Token] = []
-        var index = text.startIndex
-        while index < text.endIndex {
-            guard text[index].isLetter || text[index].isNumber else {
-                index = text.index(after: index)
-                continue
-            }
-            // An unspaced script has no word boundaries to split on, so a whole
-            // Mandarin sentence would arrive as one token and no run could ever
-            // reach `minimumRunLength`. Emitting each character separately makes
-            // the run search a character n-gram match, which is the comparison
-            // those scripts need.
-            if isIdeographic(text[index]) {
-                let next = text.index(after: index)
-                tokens.append(Token(word: String(text[index]).lowercased(),
-                                    range: index..<next,
-                                    isIdeographic: true))
-                index = next
-                continue
-            }
-            let start = index
-            while index < text.endIndex,
-                  text[index].isLetter || text[index].isNumber,
-                  !isIdeographic(text[index]) {
-                index = text.index(after: index)
-            }
-            tokens.append(Token(word: text[start..<index].lowercased(), range: start..<index))
-        }
-        return tokens
-    }
-
-    /// Overlap as a fraction of the shorter segment, so a brief echo inside a
-    /// long remote turn still counts.
-    static func timeOverlap(_ lhs: Transcript.Segment, _ rhs: Transcript.Segment) -> Double {
-        let overlap = Swift.min(lhs.end, rhs.end) - Swift.max(lhs.start, rhs.start)
-        guard overlap > 0 else { return 0 }
-        let shorter = Swift.min(lhs.end - lhs.start, rhs.end - rhs.start)
-        guard shorter > 0 else { return 0 }
-        return Swift.min(1, overlap / shorter)
-    }
-
-    static func words(in text: String) -> [String] {
-        tokens(in: text).map(\.word)
+    private static func isApostrophe(_ character: Character) -> Bool {
+        character == "'" || character == "’"
     }
 
     private static func canonical(_ speaker: String) -> String {

--- a/LokalBot/Models/Transcript.swift
+++ b/LokalBot/Models/Transcript.swift
@@ -8,11 +8,27 @@ import Foundation
 /// fill it in, but it's just a data shape — no engine dependency.
 struct Transcript: Codable {
     struct Segment: Codable, Equatable {
+        enum TimingPrecision: String, Codable, Sendable {
+            /// The text covers a fallback window or whole track; its words are
+            /// not localized closely enough to support destructive filtering.
+            case coarse
+            /// The text was transcribed from a VAD/ASR speech span with real
+            /// start and end boundaries.
+            case span
+            /// The boundaries were derived from timestamped ASR tokens.
+            case token
+
+            var isBleedFilterSafe: Bool { self == .span || self == .token }
+        }
+
         var start: TimeInterval
         var end: TimeInterval
         var speaker: String      // "me" | "them" | diarized label
         var text: String
         var confidence: Double?
+        /// Optional keeps older persisted transcripts source-compatible. A
+        /// missing value is unknown and therefore never used for deletion.
+        var timingPrecision: TimingPrecision?
     }
 
     /// A compact, timestamp-anchored turn used only for model prompts. The

--- a/LokalBot/Services/ProcessingPipeline.swift
+++ b/LokalBot/Services/ProcessingPipeline.swift
@@ -333,7 +333,6 @@ final class ProcessingPipeline: ObservableObject {
                 if bleed.changed {
                     lokalbotLog(
                         "transcript speaker bleed removedSegments=\(bleed.removedSegments) "
-                            + "trimmedSegments=\(bleed.trimmedSegments) "
                             + "removedWords=\(bleed.removedWords)")
                 }
                 if config.multiSpeakerDiarization,

--- a/LokalBot/Services/ProcessingPipeline.swift
+++ b/LokalBot/Services/ProcessingPipeline.swift
@@ -325,6 +325,14 @@ final class ProcessingPipeline: ObservableObject {
                 stages[meeting.id] = .transcribing
                 var transcript = try await transcribeTracks(meeting: meeting, folder: folder,
                                                             engine: engine, config: config)
+                // Before diarization, while speakers are still the raw track
+                // labels: drop mic segments that are only the remote voice
+                // leaking back in through the speakers.
+                let bleed = SpeakerBleedFilter.filter(transcript)
+                transcript = bleed.transcript
+                if bleed.changed {
+                    lokalbotLog("transcript speaker bleed removedSegments=\(bleed.removedSegments)")
+                }
                 if config.multiSpeakerDiarization,
                    MeetingAudioFiles.transcribableURL(for: .system, in: folder) != nil {
                     stages[meeting.id] = .preparingDiarizationModel

--- a/LokalBot/Services/ProcessingPipeline.swift
+++ b/LokalBot/Services/ProcessingPipeline.swift
@@ -331,7 +331,10 @@ final class ProcessingPipeline: ObservableObject {
                 let bleed = SpeakerBleedFilter.filter(transcript)
                 transcript = bleed.transcript
                 if bleed.changed {
-                    lokalbotLog("transcript speaker bleed removedSegments=\(bleed.removedSegments)")
+                    lokalbotLog(
+                        "transcript speaker bleed removedSegments=\(bleed.removedSegments) "
+                            + "trimmedSegments=\(bleed.trimmedSegments) "
+                            + "removedWords=\(bleed.removedWords)")
                 }
                 if config.multiSpeakerDiarization,
                    MeetingAudioFiles.transcribableURL(for: .system, in: folder) != nil {

--- a/LokalBotTests/SpanAudioReaderTests.swift
+++ b/LokalBotTests/SpanAudioReaderTests.swift
@@ -97,6 +97,16 @@ final class SpanAudioReaderTests: XCTestCase {
                        [SpeechSpan(start: 3, end: 90)])
     }
 
+    func testSplitPreservesTimingPrecision() {
+        let spans = SpeechActivity.split(
+            start: 3,
+            end: 8,
+            maxSegmentSeconds: nil,
+            timingPrecision: .span)
+
+        XCTAssertEqual(spans, [SpeechSpan(start: 3, end: 8, timingPrecision: .span)])
+    }
+
     func testSplitOfEmptyOrInvertedRangeIsEmpty() {
         XCTAssertTrue(SpeechActivity.split(start: 5, end: 5, maxSegmentSeconds: 14).isEmpty)
         XCTAssertTrue(SpeechActivity.split(start: 9, end: 5, maxSegmentSeconds: nil).isEmpty)
@@ -110,9 +120,9 @@ final class SpanAudioReaderTests: XCTestCase {
         try OnnxTranscriptionEngine.writeWav([Float](repeating: 0.1, count: rate), to: url)
 
         let spans = [
-            SpeechSpan(start: 0.0, end: 0.25),
-            SpeechSpan(start: 0.25, end: 0.5),
-            SpeechSpan(start: 0.5, end: 0.5),
+            SpeechSpan(start: 0.0, end: 0.25, timingPrecision: .span),
+            SpeechSpan(start: 0.25, end: 0.5, timingPrecision: .span),
+            SpeechSpan(start: 0.5, end: 0.5, timingPrecision: .span),
         ]
         var transcribedIndexes: [Int] = []
         let segments = try await SpanTranscription.segments(in: url, spans: spans) { samples, index in
@@ -125,7 +135,8 @@ final class SpanAudioReaderTests: XCTestCase {
                        "the zero-width span must be skipped without calling the engine")
         XCTAssertEqual(segments, [
             Transcript.Segment(start: 0.0, end: 0.25, speaker: "speaker",
-                               text: "hello there", confidence: nil),
+                               text: "hello there", confidence: nil,
+                               timingPrecision: .span),
         ], "whitespace-only text must not become a segment; kept text is normalized")
     }
 
@@ -136,7 +147,8 @@ final class SpanAudioReaderTests: XCTestCase {
         let segments = SpanTranscription.segments(pairing: spans, with: ["one", "   "])
         XCTAssertEqual(segments, [
             Transcript.Segment(start: 0, end: 1, speaker: "speaker",
-                               text: "one", confidence: nil),
+                               text: "one", confidence: nil,
+                               timingPrecision: .coarse),
         ], "empty texts and spans past the batch's result count are dropped")
     }
 }

--- a/LokalBotTests/SpeakerBleedFilterTests.swift
+++ b/LokalBotTests/SpeakerBleedFilterTests.swift
@@ -1,163 +1,169 @@
 import XCTest
 @testable import LokalBot
 
-/// Speaker bleed: with the user on speakers rather than headphones, the remote
-/// voice reaches the microphone too and is transcribed a second time as `me`.
-/// The filter must remove those echoes without touching a real reply — the
-/// separating signal is timing, since an echo is simultaneous with its source
-/// while a person repeating something speaks afterwards.
 final class SpeakerBleedFilterTests: XCTestCase {
 
-    private func segment(_ speaker: String, _ start: TimeInterval, _ end: TimeInterval,
-                         _ text: String) -> Transcript.Segment {
-        Transcript.Segment(start: start, end: end, speaker: speaker, text: text, confidence: nil)
+    private func segment(
+        _ speaker: String,
+        _ start: TimeInterval,
+        _ end: TimeInterval,
+        _ text: String,
+        confidence: Double? = nil,
+        timing: Transcript.Segment.TimingPrecision? = .span
+    ) -> Transcript.Segment {
+        Transcript.Segment(
+            start: start,
+            end: end,
+            speaker: speaker,
+            text: text,
+            confidence: confidence,
+            timingPrecision: timing)
     }
 
     private func transcript(_ segments: [Transcript.Segment]) -> Transcript {
         Transcript(segments: segments, engine: "test")
     }
 
-    /// Verbatim from a real Teams test call recorded on built-in speakers: the
-    /// bot's prompt appears once as `them` and once as `me`, the latter with the
-    /// leading-punctuation artifact ASR tends to add to clipped echo.
-    func testRemovesRealWorldSpeakerBleed() {
+    func testRemovesOnlyACompleteCotimedSpeakerBleedSpan() {
         let prompt = "Wenn Sie mit der Qualität der Nachricht zufrieden sind, haben Sie Teams "
             + "richtig konfiguriert. Wenn nicht, überprüfen Sie die Einstellung Ihres Gerätes "
             + "und versuchen Sie es erneut"
         let input = transcript([
-            segment("me", 1.0, 4.0, "1, 2, 5, 5"),
-            segment("me", 5.0, 17.0, ". " + prompt + "."),
-            segment("them", 5.0, 17.0, prompt),
+            segment("me", 1, 4, "1, 2, 5, 5"),
+            segment("me", 5, 17, ". " + prompt + "."),
+            segment("them", 5, 17, prompt),
         ])
 
         let result = SpeakerBleedFilter.filter(input)
 
         XCTAssertEqual(result.removedSegments, 1)
-        XCTAssertEqual(result.transcript.segments.count, 2)
         XCTAssertEqual(result.transcript.segments.map(\.speaker), ["me", "them"])
-        // The user's own words survive.
         XCTAssertEqual(result.transcript.segments.first?.text, "1, 2, 5, 5")
+        XCTAssertEqual(result.transcript.segments.last?.text, prompt)
     }
 
-    /// The case the filter must never break: agreeing by repeating what was
-    /// just said. Same words, but *after* the remote turn rather than during it.
-    /// The common shape on a real call: the mic segment opens with echo of the
-    /// remote turn and continues with the user's own words. Dropping it loses
-    /// real speech, keeping it doubles the remote voice — only the echoed part
-    /// may go.
-    func testTrimsEchoedOpeningAndKeepsTheUsersOwnWords() {
+    func testPreservesMixedEchoAndReplyExactlyInsteadOfPartiallyTrimming() {
+        let remote = segment(
+            "them", 10, 20,
+            "aber ich weiß nicht ob das für heute angedacht war")
+        let mic = segment(
+            "me", 11, 22,
+            "aber ich weiß nicht ob das für heute angedacht war. "
+                + "Das sollte mit denen abgestimmt sein die gefehlt haben",
+            confidence: 0.73)
+        let input = transcript([remote, mic])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments, input.segments)
+        XCTAssertEqual(result.transcript.segments.last?.start, 11)
+        XCTAssertEqual(result.transcript.segments.last?.end, 22)
+        XCTAssertEqual(result.transcript.segments.last?.confidence, 0.73)
+    }
+
+    func testPreservesShortGenuineReplyAfterEcho() {
+        let echoed = "we will move the release to Thursday"
+        let mic = segment("me", 10, 22, echoed + " yes absolutely")
         let input = transcript([
-            segment("them", 10.0, 20.0,
-                    "aber ich weiß nicht ob das für heute angedacht war"),
-            segment("me", 11.0, 22.0,
-                    "aber ich weiß nicht ob das für heute angedacht war. "
-                        + "Das sollte mit denen abgestimmt sein die gefehlt haben"),
+            segment("them", 10, 20, echoed),
+            mic,
         ])
 
         let result = SpeakerBleedFilter.filter(input)
 
-        XCTAssertEqual(result.removedSegments, 0)
-        XCTAssertEqual(result.trimmedSegments, 1)
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments.last, mic)
+    }
+
+    func testPreservesLegitimateOneWordPrefix() {
+        let echoed = "we should postpone the product launch"
+        let mic = segment("me", 10, 20, "Absolutely " + echoed)
+        let input = transcript([
+            segment("them", 10, 20, echoed),
+            mic,
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments.last, mic)
+    }
+
+    func testPreservesPhraseRepeatedLaterInsideOverlappingLongSegments() {
+        let phrase = "we should postpone the product launch"
+        let remote = phrase + " while we review the remaining engineering and legal risks"
+        let mic = segment("me", 18, 22, phrase)
+        let input = transcript([
+            // The shared phrase is at the beginning of this long remote span.
+            segment("them", 0, 20, remote),
+            // The local speaker genuinely repeats it near the end.
+            mic,
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments.last, mic)
+    }
+
+    func testPreservesIdenticalTextWhenOnlyCoarseTimingExists() {
+        let line = "we will review the launch plan tomorrow"
+        let input = transcript([
+            segment("them", 0, 10, line, timing: .coarse),
+            segment("me", 0, 10, line, timing: .coarse),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments, input.segments)
+    }
+
+    func testPreservesLegacySegmentsWithUnknownTimingPrecision() {
+        let line = "we will review the launch plan tomorrow"
+        let input = transcript([
+            segment("them", 0, 10, line, timing: nil),
+            segment("me", 0, 10, line, timing: nil),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments, input.segments)
+    }
+
+    func testSegmentOverlapAloneDoesNotProveCotiming() {
+        let line = "we should postpone the product launch"
+        let mic = segment("me", 8, 12, line)
+        let input = transcript([
+            segment("them", 0, 10, line),
+            mic,
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments.last, mic)
+    }
+
+    func testPreservesShortContractionAcknowledgement() {
+        let input = transcript([
+            segment("them", 3, 6, "That's right"),
+            segment("me", 3.1, 5.9, "That's right"),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertFalse(result.changed)
         XCTAssertEqual(result.transcript.segments.count, 2)
-        XCTAssertEqual(result.transcript.segments.first(where: { $0.speaker == "me" })?.text,
-                       "Das sollte mit denen abgestimmt sein die gefehlt haben")
+        XCTAssertEqual(SpeakerBleedFilter.comparisonTokens(in: "That's right")?.count, 2)
     }
 
-    /// Echo at the tail is the mirror case and must trim the same way.
-    func testTrimsEchoedEnding() {
+    func testPreservesSemanticallyDifferentOneEditWord() {
         let input = transcript([
-            segment("me", 5.0, 12.0,
-                    "das kann ich noch nicht sagen, wir verschieben das Release auf Donnerstag"),
-            segment("them", 6.0, 12.0, "wir verschieben das Release auf Donnerstag"),
-        ])
-
-        let result = SpeakerBleedFilter.filter(input)
-
-        XCTAssertEqual(result.trimmedSegments, 1)
-        XCTAssertEqual(result.transcript.segments.first?.text, "das kann ich noch nicht sagen")
-    }
-
-    /// Two independent ASR passes over different audio spell the same word
-    /// differently. Exact word equality missed most real echo, so a single
-    /// edit still counts as the same word.
-    func testMatchesWordsTheTwoTracksTranscribedDifferently() {
-        XCTAssertTrue(SpeakerBleedFilter.wordsMatch("wim", "bim"))
-        XCTAssertTrue(SpeakerBleedFilter.wordsMatch("nachmittags", "nachmittag"))
-        XCTAssertFalse(SpeakerBleedFilter.wordsMatch("und", "an"))
-        XCTAssertFalse(SpeakerBleedFilter.wordsMatch("budget", "termin"))
-    }
-
-    /// Echo in the middle would mean the user spoke both before and after it;
-    /// stitching the halves together would invent a sentence neither said.
-    func testKeepsSegmentWhoseSharedRunSitsInTheMiddle() {
-        let input = transcript([
-            segment("them", 0.0, 10.0, "auf nächsten Donnerstag verschoben"),
-            segment("me", 0.0, 10.0,
-                    "ich hatte das anders verstanden auf nächsten Donnerstag verschoben "
-                        + "steht so aber nicht im Protokoll drin"),
-        ])
-
-        let result = SpeakerBleedFilter.filter(input)
-
-        XCTAssertEqual(result.trimmedSegments, 0)
-        XCTAssertEqual(result.removedSegments, 0)
-    }
-
-    func testLongestSharedRunReportsItsPositionInTheLeftHandSide() {
-        let run = SpeakerBleedFilter.longestSharedRun(
-            ["also", "wir", "treffen", "uns", "am", "montag"],
-            ["wir", "treffen", "uns", "später"])
-
-        XCTAssertEqual(run, .init(length: 3, start: 1, end: 4))
-    }
-
-    func testKeepsGenuineRepetitionThatFollowsTheRemoteTurn() {
-        let line = "wir verschieben das Release auf nächsten Donnerstag"
-        let input = transcript([
-            segment("them", 10.0, 14.0, line),
-            segment("me", 14.5, 18.0, line + ", genau"),
-        ])
-
-        let result = SpeakerBleedFilter.filter(input)
-
-        XCTAssertEqual(result.removedSegments, 0)
-        XCTAssertEqual(result.transcript.segments.count, 2)
-    }
-
-    /// Short generic utterances are too common to judge by wording, so they are
-    /// never removed even when they overlap.
-    func testKeepsShortOverlappingAcknowledgements() {
-        let input = transcript([
-            segment("them", 3.0, 6.0, "ja genau"),
-            segment("me", 3.2, 5.8, "ja genau"),
-        ])
-
-        let result = SpeakerBleedFilter.filter(input)
-
-        XCTAssertEqual(result.removedSegments, 0)
-    }
-
-    /// Overlapping in time but saying something different — both people talking
-    /// at once — must survive.
-    func testKeepsSimultaneousButDifferentSpeech() {
-        let input = transcript([
-            segment("them", 20.0, 26.0,
-                    "ich schicke dir die Auswertung nachher noch per Mail zu"),
-            segment("me", 20.5, 25.0,
-                    "können wir den Termin am Freitag um eine Stunde vorziehen"),
-        ])
-
-        let result = SpeakerBleedFilter.filter(input)
-
-        XCTAssertEqual(result.removedSegments, 0)
-    }
-
-    /// A mic-only recording (no system track) must pass through untouched —
-    /// with nothing to compare against, nothing can be an echo.
-    func testMicOnlyTranscriptIsUnchanged() {
-        let input = transcript([
-            segment("me", 0.0, 4.0, "das hier ist eine ganz normale Aufnahme ohne Gegenstelle"),
-            segment("me", 4.0, 8.0, "das hier ist eine ganz normale Aufnahme ohne Gegenstelle"),
+            segment("them", 3, 8, "we can ship the build"),
+            segment("me", 3, 8, "we can skip the build"),
         ])
 
         let result = SpeakerBleedFilter.filter(input)
@@ -166,67 +172,87 @@ final class SpeakerBleedFilterTests: XCTestCase {
         XCTAssertEqual(result.transcript.segments.count, 2)
     }
 
-    /// Only the microphone side is ever dropped: the system track is the clean
-    /// source of the remote voice and must survive intact.
-    func testNeverRemovesTheRemoteTrack() {
-        let line = "das Protokoll liegt im geteilten Ordner bereit für alle"
+    func testKeepsGenuineRepetitionAfterTheRemoteTurn() {
+        let line = "we will move the release to next Thursday"
         let input = transcript([
-            segment("me", 2.0, 8.0, line),
-            segment("them", 2.0, 8.0, line),
+            segment("them", 10, 14, line),
+            segment("me", 14.5, 18.5, line),
         ])
 
         let result = SpeakerBleedFilter.filter(input)
 
-        XCTAssertEqual(result.transcript.segments.map(\.speaker), ["them"])
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments.count, 2)
     }
 
-    func testTimeOverlapIsMeasuredAgainstTheShorterSegment() {
-        let long = segment("them", 0.0, 20.0, "x")
-        let short = segment("me", 9.0, 11.0, "x")
-        XCTAssertEqual(SpeakerBleedFilter.timeOverlap(short, long), 1.0, accuracy: 0.001)
+    func testNeverRemovesTheRemoteTrack() {
+        let line = "the protocol is ready in the shared folder"
+        let remote = segment("them", 2, 8, line, confidence: 0.91, timing: .token)
+        let input = transcript([
+            segment("me", 2, 8, line, timing: .token),
+            remote,
+        ])
 
-        let disjoint = segment("me", 30.0, 32.0, "x")
-        XCTAssertEqual(SpeakerBleedFilter.timeOverlap(disjoint, long), 0)
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertEqual(result.removedSegments, 1)
+        XCTAssertEqual(result.transcript.segments, [remote])
     }
 
-    /// ASR clips the start and end of an echo, so the mic side is usually a
-    /// fragment of the remote turn rather than a copy of it.
-    func testRecognizesAPartiallyCapturedEcho() {
-        let full = SpeakerBleedFilter.words(in: "wir treffen uns morgen um zehn im großen Raum")
-        let clipped = SpeakerBleedFilter.words(in: "uns morgen um zehn im großen")
-        XCTAssertEqual(SpeakerBleedFilter.longestSharedRun(clipped, full).length, clipped.count)
+    func testMicOnlyTranscriptIsUnchanged() {
+        let input = transcript([
+            segment("me", 0, 4, "this is a normal recording with no remote track"),
+            segment("me", 4, 8, "this remains completely local microphone speech"),
+        ])
 
-        let unrelated = SpeakerBleedFilter.words(in: "das Budget ist bereits vollständig verplant")
-        XCTAssertLessThan(SpeakerBleedFilter.longestSharedRun(unrelated, full).length,
-                          SpeakerBleedFilter.minimumRunLength)
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments, input.segments)
     }
 
-    // MARK: - Scripts written without spaces
+    func testRequiresBothSpanBoundariesToAlign() {
+        let line = "we should postpone the product launch"
+        let remote = segment("them", 10, 20, line)
+        let aligned = segment("me", 10.2, 20.2, line)
+        let shiftedEnd = segment("me", 10.2, 22, line)
 
-    /// Chinese and Japanese put no spaces between words, so splitting on
-    /// non-alphanumerics alone would hand the filter one token per sentence and
-    /// no run could ever be long enough to judge. Korean is spaced and must
-    /// keep word tokens.
-    func testTokenizesUnspacedScriptsPerCharacter() {
-        let mandarin = SpeakerBleedFilter.tokens(in: "我们下周开会")
-        XCTAssertEqual(mandarin.count, 6)
-        XCTAssertTrue(mandarin.allSatisfy(\.isIdeographic))
-
-        let japanese = SpeakerBleedFilter.tokens(in: "会議は月曜日です")
-        XCTAssertEqual(japanese.count, 8)
-
-        let korean = SpeakerBleedFilter.tokens(in: "우리는 다음 주에 만나기로")
-        XCTAssertEqual(korean.count, 4)
-        XCTAssertFalse(korean.contains { $0.isIdeographic })
+        XCTAssertTrue(SpeakerBleedFilter.spansAreAligned(aligned, remote))
+        XCTAssertFalse(SpeakerBleedFilter.spansAreAligned(shiftedEnd, remote))
     }
 
-    /// The case that fails without per-character tokens: two tracks carrying
-    /// the identical Mandarin sentence at the identical moment.
-    func testRemovesMandarinEchoOfTheRemoteTurn() {
+    func testLongPreciselyLabelledSpanIsStillTooCoarseForDeletion() {
+        let line = "we should postpone the product launch"
+        let input = transcript([
+            segment("them", 0, 30, line, timing: .token),
+            segment("me", 0, 30, line, timing: .token),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments, input.segments)
+    }
+
+    // MARK: - Unicode and work bounds
+
+    func testTokenizesUnspacedScriptsPerCharacterAndCoversModernRanges() {
+        let mandarin = SpeakerBleedFilter.comparisonTokens(in: "我们下周开会")
+        XCTAssertEqual(mandarin?.count, 6)
+        XCTAssertTrue(mandarin?.allSatisfy(\.isIdeographic) == true)
+
+        let japanese = SpeakerBleedFilter.comparisonTokens(in: "会議は月曜日です")
+        XCTAssertEqual(japanese?.count, 8)
+
+        XCTAssertTrue(SpeakerBleedFilter.isIdeographic("𰀀")) // Extension G
+        XCTAssertTrue(SpeakerBleedFilter.isIdeographic("ｶ")) // Halfwidth Katakana
+    }
+
+    func testRemovesCompleteCotimedMandarinEcho() {
         let line = "我们下周一开会讨论这个项目的进度"
         let input = transcript([
-            segment("them", 10.0, 20.0, line),
-            segment("me", 10.0, 20.0, line),
+            segment("them", 10, 20, line, timing: .token),
+            segment("me", 10, 20, line, timing: .token),
         ])
 
         let result = SpeakerBleedFilter.filter(input)
@@ -235,48 +261,91 @@ final class SpeakerBleedFilterTests: XCTestCase {
         XCTAssertEqual(result.transcript.segments.map(\.speaker), ["them"])
     }
 
-    /// Trimming works the same way in an unspaced script: the echoed opening
-    /// goes, the user's own reply stays.
-    func testTrimsMandarinEchoAndKeepsTheReply() {
+    func testPreservesMandarinEchoPlusReplyWithOriginalTimestamps() {
         let echoed = "我们下周一开会讨论这个项目的进度"
+        let mic = segment("me", 10, 22, echoed + "，好的我知道了", confidence: 0.81)
         let input = transcript([
-            segment("them", 10.0, 20.0, echoed),
-            segment("me", 10.0, 22.0, echoed + "，好的我知道了"),
+            segment("them", 10, 20, echoed),
+            mic,
         ])
 
         let result = SpeakerBleedFilter.filter(input)
 
-        XCTAssertEqual(result.removedSegments, 0)
-        XCTAssertEqual(result.trimmedSegments, 1)
-        XCTAssertEqual(result.transcript.segments.last?.text, "好的我知道了")
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments.last, mic)
     }
 
-    /// A character token carries far less meaning than a word, so the run bar
-    /// is higher — a four-character courtesy overlapping in time is not echo
-    /// evidence, exactly as "ja genau" is not.
     func testKeepsShortMandarinOverlap() {
         let input = transcript([
-            segment("them", 3.0, 6.0, "好的谢谢"),
-            segment("me", 3.2, 5.8, "好的谢谢"),
+            segment("them", 3, 6, "好的谢谢"),
+            segment("me", 3, 6, "好的谢谢"),
         ])
 
         let result = SpeakerBleedFilter.filter(input)
 
-        XCTAssertEqual(result.removedSegments, 0)
-        XCTAssertEqual(result.trimmedSegments, 0)
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments.count, 2)
     }
 
-    func testRunLengthBarFollowsTheScriptTheRunIsWrittenIn() {
-        let mandarin = SpeakerBleedFilter.tokens(in: "我们下周开会")
-        XCTAssertEqual(
-            SpeakerBleedFilter.requiredRunLength(
-                for: mandarin, run: .init(length: 6, start: 0, end: 6)),
-            SpeakerBleedFilter.minimumIdeographicRunLength)
+    func testOversizedCJKInputIsSkippedBeforeComparisonCanGrow() {
+        let line = String(
+            repeating: "会",
+            count: SpeakerBleedFilter.maximumComparableTokenCount + 1)
+        XCTAssertNil(SpeakerBleedFilter.comparisonTokens(in: line))
+        let input = transcript([
+            segment("them", 0, 10, line, timing: .token),
+            segment("me", 0, 10, line, timing: .token),
+        ])
 
-        let german = SpeakerBleedFilter.tokens(in: "wir treffen uns am Montag")
-        XCTAssertEqual(
-            SpeakerBleedFilter.requiredRunLength(
-                for: german, run: .init(length: 3, start: 0, end: 3)),
-            SpeakerBleedFilter.minimumRunLength)
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments, input.segments)
+    }
+
+    func testOversizedTextIsSkippedAfterOnlyABoundedPrefix() {
+        let line = String(
+            repeating: "a",
+            count: SpeakerBleedFilter.maximumComparableTextBytes + 1)
+        XCTAssertNil(SpeakerBleedFilter.comparisonTokens(in: line))
+    }
+
+    func testCrowdedCandidateWindowIsConservativelySkipped() {
+        let matching = "we should postpone the product launch"
+        var segments = (0...SpeakerBleedFilter.maximumCandidateSegments).map { index in
+            segment("them", 10, 20, index == 0
+                    ? matching
+                    : "remote alternative number \(index) has enough words")
+        }
+        let mic = segment("me", 10, 20, matching)
+        segments.append(mic)
+
+        let result = SpeakerBleedFilter.filter(transcript(segments))
+
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments.last, mic)
+    }
+
+    // MARK: - Persistence compatibility
+
+    func testLegacySegmentWithoutTimingMetadataDecodesAsUnknown() throws {
+        let data = Data(
+            #"{"start":1,"end":2,"speaker":"me","text":"hello","confidence":null}"#.utf8)
+
+        let decoded = try JSONDecoder().decode(Transcript.Segment.self, from: data)
+
+        XCTAssertNil(decoded.timingPrecision)
+    }
+
+    func testTimingPrecisionRoundTrips() throws {
+        let original = segment(
+            "me", 1, 2, "four words with timing", timing: .token)
+
+        let decoded = try JSONDecoder().decode(
+            Transcript.Segment.self,
+            from: JSONEncoder().encode(original))
+
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.timingPrecision, .token)
     }
 }

--- a/LokalBotTests/SpeakerBleedFilterTests.swift
+++ b/LokalBotTests/SpeakerBleedFilterTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import LokalBot
+
+/// Speaker bleed: with the user on speakers rather than headphones, the remote
+/// voice reaches the microphone too and is transcribed a second time as `me`.
+/// The filter must remove those echoes without touching a real reply — the
+/// separating signal is timing, since an echo is simultaneous with its source
+/// while a person repeating something speaks afterwards.
+final class SpeakerBleedFilterTests: XCTestCase {
+
+    private func segment(_ speaker: String, _ start: TimeInterval, _ end: TimeInterval,
+                         _ text: String) -> Transcript.Segment {
+        Transcript.Segment(start: start, end: end, speaker: speaker, text: text, confidence: nil)
+    }
+
+    private func transcript(_ segments: [Transcript.Segment]) -> Transcript {
+        Transcript(segments: segments, engine: "test")
+    }
+
+    /// Verbatim from a real Teams test call recorded on built-in speakers: the
+    /// bot's prompt appears once as `them` and once as `me`, the latter with the
+    /// leading-punctuation artifact ASR tends to add to clipped echo.
+    func testRemovesRealWorldSpeakerBleed() {
+        let prompt = "Wenn Sie mit der Qualität der Nachricht zufrieden sind, haben Sie Teams "
+            + "richtig konfiguriert. Wenn nicht, überprüfen Sie die Einstellung Ihres Gerätes "
+            + "und versuchen Sie es erneut"
+        let input = transcript([
+            segment("me", 1.0, 4.0, "1, 2, 5, 5"),
+            segment("me", 5.0, 17.0, ". " + prompt + "."),
+            segment("them", 5.0, 17.0, prompt),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertEqual(result.removedSegments, 1)
+        XCTAssertEqual(result.transcript.segments.count, 2)
+        XCTAssertEqual(result.transcript.segments.map(\.speaker), ["me", "them"])
+        // The user's own words survive.
+        XCTAssertEqual(result.transcript.segments.first?.text, "1, 2, 5, 5")
+    }
+
+    /// The case the filter must never break: agreeing by repeating what was
+    /// just said. Same words, but *after* the remote turn rather than during it.
+    func testKeepsGenuineRepetitionThatFollowsTheRemoteTurn() {
+        let line = "wir verschieben das Release auf nächsten Donnerstag"
+        let input = transcript([
+            segment("them", 10.0, 14.0, line),
+            segment("me", 14.5, 18.0, line + ", genau"),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertEqual(result.removedSegments, 0)
+        XCTAssertEqual(result.transcript.segments.count, 2)
+    }
+
+    /// Short generic utterances are too common to judge by wording, so they are
+    /// never removed even when they overlap.
+    func testKeepsShortOverlappingAcknowledgements() {
+        let input = transcript([
+            segment("them", 3.0, 6.0, "ja genau"),
+            segment("me", 3.2, 5.8, "ja genau"),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertEqual(result.removedSegments, 0)
+    }
+
+    /// Overlapping in time but saying something different — both people talking
+    /// at once — must survive.
+    func testKeepsSimultaneousButDifferentSpeech() {
+        let input = transcript([
+            segment("them", 20.0, 26.0,
+                    "ich schicke dir die Auswertung nachher noch per Mail zu"),
+            segment("me", 20.5, 25.0,
+                    "können wir den Termin am Freitag um eine Stunde vorziehen"),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertEqual(result.removedSegments, 0)
+    }
+
+    /// A mic-only recording (no system track) must pass through untouched —
+    /// with nothing to compare against, nothing can be an echo.
+    func testMicOnlyTranscriptIsUnchanged() {
+        let input = transcript([
+            segment("me", 0.0, 4.0, "das hier ist eine ganz normale Aufnahme ohne Gegenstelle"),
+            segment("me", 4.0, 8.0, "das hier ist eine ganz normale Aufnahme ohne Gegenstelle"),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.transcript.segments.count, 2)
+    }
+
+    /// Only the microphone side is ever dropped: the system track is the clean
+    /// source of the remote voice and must survive intact.
+    func testNeverRemovesTheRemoteTrack() {
+        let line = "das Protokoll liegt im geteilten Ordner bereit für alle"
+        let input = transcript([
+            segment("me", 2.0, 8.0, line),
+            segment("them", 2.0, 8.0, line),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertEqual(result.transcript.segments.map(\.speaker), ["them"])
+    }
+
+    func testTimeOverlapIsMeasuredAgainstTheShorterSegment() {
+        let long = segment("them", 0.0, 20.0, "x")
+        let short = segment("me", 9.0, 11.0, "x")
+        XCTAssertEqual(SpeakerBleedFilter.timeOverlap(short, long), 1.0, accuracy: 0.001)
+
+        let disjoint = segment("me", 30.0, 32.0, "x")
+        XCTAssertEqual(SpeakerBleedFilter.timeOverlap(disjoint, long), 0)
+    }
+
+    func testTextSimilarityToleratesPartialCapture() {
+        let full = SpeakerBleedFilter.words(in: "wir treffen uns morgen um zehn im großen Raum")
+        let clipped = SpeakerBleedFilter.words(in: "uns morgen um zehn im großen")
+        XCTAssertEqual(SpeakerBleedFilter.textSimilarity(clipped, full), 1.0, accuracy: 0.001)
+
+        let unrelated = SpeakerBleedFilter.words(in: "das Budget ist bereits vollständig verplant")
+        XCTAssertLessThan(SpeakerBleedFilter.textSimilarity(unrelated, full), 0.3)
+    }
+}

--- a/LokalBotTests/SpeakerBleedFilterTests.swift
+++ b/LokalBotTests/SpeakerBleedFilterTests.swift
@@ -41,6 +41,76 @@ final class SpeakerBleedFilterTests: XCTestCase {
 
     /// The case the filter must never break: agreeing by repeating what was
     /// just said. Same words, but *after* the remote turn rather than during it.
+    /// The common shape on a real call: the mic segment opens with echo of the
+    /// remote turn and continues with the user's own words. Dropping it loses
+    /// real speech, keeping it doubles the remote voice — only the echoed part
+    /// may go.
+    func testTrimsEchoedOpeningAndKeepsTheUsersOwnWords() {
+        let input = transcript([
+            segment("them", 10.0, 20.0,
+                    "aber ich weiß nicht ob das für heute angedacht war"),
+            segment("me", 11.0, 22.0,
+                    "aber ich weiß nicht ob das für heute angedacht war. "
+                        + "Das sollte mit denen abgestimmt sein die gefehlt haben"),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertEqual(result.removedSegments, 0)
+        XCTAssertEqual(result.trimmedSegments, 1)
+        XCTAssertEqual(result.transcript.segments.count, 2)
+        XCTAssertEqual(result.transcript.segments.first(where: { $0.speaker == "me" })?.text,
+                       "Das sollte mit denen abgestimmt sein die gefehlt haben")
+    }
+
+    /// Echo at the tail is the mirror case and must trim the same way.
+    func testTrimsEchoedEnding() {
+        let input = transcript([
+            segment("me", 5.0, 12.0,
+                    "das kann ich noch nicht sagen, wir verschieben das Release auf Donnerstag"),
+            segment("them", 6.0, 12.0, "wir verschieben das Release auf Donnerstag"),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertEqual(result.trimmedSegments, 1)
+        XCTAssertEqual(result.transcript.segments.first?.text, "das kann ich noch nicht sagen")
+    }
+
+    /// Two independent ASR passes over different audio spell the same word
+    /// differently. Exact word equality missed most real echo, so a single
+    /// edit still counts as the same word.
+    func testMatchesWordsTheTwoTracksTranscribedDifferently() {
+        XCTAssertTrue(SpeakerBleedFilter.wordsMatch("wim", "bim"))
+        XCTAssertTrue(SpeakerBleedFilter.wordsMatch("nachmittags", "nachmittag"))
+        XCTAssertFalse(SpeakerBleedFilter.wordsMatch("und", "an"))
+        XCTAssertFalse(SpeakerBleedFilter.wordsMatch("budget", "termin"))
+    }
+
+    /// Echo in the middle would mean the user spoke both before and after it;
+    /// stitching the halves together would invent a sentence neither said.
+    func testKeepsSegmentWhoseSharedRunSitsInTheMiddle() {
+        let input = transcript([
+            segment("them", 0.0, 10.0, "auf nächsten Donnerstag verschoben"),
+            segment("me", 0.0, 10.0,
+                    "ich hatte das anders verstanden auf nächsten Donnerstag verschoben "
+                        + "steht so aber nicht im Protokoll drin"),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertEqual(result.trimmedSegments, 0)
+        XCTAssertEqual(result.removedSegments, 0)
+    }
+
+    func testLongestSharedRunReportsItsPositionInTheLeftHandSide() {
+        let run = SpeakerBleedFilter.longestSharedRun(
+            ["also", "wir", "treffen", "uns", "am", "montag"],
+            ["wir", "treffen", "uns", "später"])
+
+        XCTAssertEqual(run, .init(length: 3, start: 1, end: 4))
+    }
+
     func testKeepsGenuineRepetitionThatFollowsTheRemoteTurn() {
         let line = "wir verschieben das Release auf nächsten Donnerstag"
         let input = transcript([
@@ -119,12 +189,15 @@ final class SpeakerBleedFilterTests: XCTestCase {
         XCTAssertEqual(SpeakerBleedFilter.timeOverlap(disjoint, long), 0)
     }
 
-    func testTextSimilarityToleratesPartialCapture() {
+    /// ASR clips the start and end of an echo, so the mic side is usually a
+    /// fragment of the remote turn rather than a copy of it.
+    func testRecognizesAPartiallyCapturedEcho() {
         let full = SpeakerBleedFilter.words(in: "wir treffen uns morgen um zehn im großen Raum")
         let clipped = SpeakerBleedFilter.words(in: "uns morgen um zehn im großen")
-        XCTAssertEqual(SpeakerBleedFilter.textSimilarity(clipped, full), 1.0, accuracy: 0.001)
+        XCTAssertEqual(SpeakerBleedFilter.longestSharedRun(clipped, full).length, clipped.count)
 
         let unrelated = SpeakerBleedFilter.words(in: "das Budget ist bereits vollständig verplant")
-        XCTAssertLessThan(SpeakerBleedFilter.textSimilarity(unrelated, full), 0.3)
+        XCTAssertLessThan(SpeakerBleedFilter.longestSharedRun(unrelated, full).length,
+                          SpeakerBleedFilter.minimumRunLength)
     }
 }

--- a/LokalBotTests/SpeakerBleedFilterTests.swift
+++ b/LokalBotTests/SpeakerBleedFilterTests.swift
@@ -200,4 +200,83 @@ final class SpeakerBleedFilterTests: XCTestCase {
         XCTAssertLessThan(SpeakerBleedFilter.longestSharedRun(unrelated, full).length,
                           SpeakerBleedFilter.minimumRunLength)
     }
+
+    // MARK: - Scripts written without spaces
+
+    /// Chinese and Japanese put no spaces between words, so splitting on
+    /// non-alphanumerics alone would hand the filter one token per sentence and
+    /// no run could ever be long enough to judge. Korean is spaced and must
+    /// keep word tokens.
+    func testTokenizesUnspacedScriptsPerCharacter() {
+        let mandarin = SpeakerBleedFilter.tokens(in: "我们下周开会")
+        XCTAssertEqual(mandarin.count, 6)
+        XCTAssertTrue(mandarin.allSatisfy(\.isIdeographic))
+
+        let japanese = SpeakerBleedFilter.tokens(in: "会議は月曜日です")
+        XCTAssertEqual(japanese.count, 8)
+
+        let korean = SpeakerBleedFilter.tokens(in: "우리는 다음 주에 만나기로")
+        XCTAssertEqual(korean.count, 4)
+        XCTAssertFalse(korean.contains { $0.isIdeographic })
+    }
+
+    /// The case that fails without per-character tokens: two tracks carrying
+    /// the identical Mandarin sentence at the identical moment.
+    func testRemovesMandarinEchoOfTheRemoteTurn() {
+        let line = "我们下周一开会讨论这个项目的进度"
+        let input = transcript([
+            segment("them", 10.0, 20.0, line),
+            segment("me", 10.0, 20.0, line),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertEqual(result.removedSegments, 1)
+        XCTAssertEqual(result.transcript.segments.map(\.speaker), ["them"])
+    }
+
+    /// Trimming works the same way in an unspaced script: the echoed opening
+    /// goes, the user's own reply stays.
+    func testTrimsMandarinEchoAndKeepsTheReply() {
+        let echoed = "我们下周一开会讨论这个项目的进度"
+        let input = transcript([
+            segment("them", 10.0, 20.0, echoed),
+            segment("me", 10.0, 22.0, echoed + "，好的我知道了"),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertEqual(result.removedSegments, 0)
+        XCTAssertEqual(result.trimmedSegments, 1)
+        XCTAssertEqual(result.transcript.segments.last?.text, "好的我知道了")
+    }
+
+    /// A character token carries far less meaning than a word, so the run bar
+    /// is higher — a four-character courtesy overlapping in time is not echo
+    /// evidence, exactly as "ja genau" is not.
+    func testKeepsShortMandarinOverlap() {
+        let input = transcript([
+            segment("them", 3.0, 6.0, "好的谢谢"),
+            segment("me", 3.2, 5.8, "好的谢谢"),
+        ])
+
+        let result = SpeakerBleedFilter.filter(input)
+
+        XCTAssertEqual(result.removedSegments, 0)
+        XCTAssertEqual(result.trimmedSegments, 0)
+    }
+
+    func testRunLengthBarFollowsTheScriptTheRunIsWrittenIn() {
+        let mandarin = SpeakerBleedFilter.tokens(in: "我们下周开会")
+        XCTAssertEqual(
+            SpeakerBleedFilter.requiredRunLength(
+                for: mandarin, run: .init(length: 6, start: 0, end: 6)),
+            SpeakerBleedFilter.minimumIdeographicRunLength)
+
+        let german = SpeakerBleedFilter.tokens(in: "wir treffen uns am Montag")
+        XCTAssertEqual(
+            SpeakerBleedFilter.requiredRunLength(
+                for: german, run: .init(length: 3, start: 0, end: 3)),
+            SpeakerBleedFilter.minimumRunLength)
+    }
 }


### PR DESCRIPTION
Addresses #42.

LokalBot records the raw input device, so the meeting app's own echo
cancellation never applies to our mic track. With the user on speakers rather
than headphones, the remote voice reaches the microphone as well — and because
the two tracks are transcribed separately, the same utterance is transcribed
twice: once correctly as `them`, once wrongly as `me`. The error then flows on
into diarization, summaries and recall.

`MeetingAudioAsset.existingSources` already compensates for bleed when mixing
playback and export ("The mic track can contain speaker bleed…"), but nothing
did so for the transcript.

### Approach

The discriminator is **timing**, not wording. Acoustic echo is effectively
simultaneous with the sound that caused it; someone genuinely repeating what was
just said speaks *afterwards*. Text similarity alone cannot tell those apart —
requiring a large temporal overlap as well can.

A mic segment is dropped only when all of the following hold against some
`them` segment:

- temporal overlap ≥ 50 % of the shorter segment
- word overlap ≥ 80 % of the shorter side (multiset, so partial capture and ASR
  artifacts are tolerated — echo is rarely a character-perfect copy)
- both sides have ≥ 4 words, so generic acknowledgements ("ja", "genau") are
  never judged by wording

Only the mic side is ever removed; the system track is the clean source of the
remote voice and is left intact. The filter runs directly after track merge,
while speakers are still the raw track labels and before diarization can
relabel them.

### Verification on a real recording

Teams call recorded on built-in speakers, re-processed with `--process`:

```
transcription track done track=mic    … segments=3
transcription track done track=system … segments=3
transcript speaker bleed removedSegments=2
```

Resulting transcript:

```
 0.00-10.58  them   Wenn Sie mit der Qualität der Nachricht zufrieden sind, haben Sie Teams richtig…
10.96-15.66  them   Wenn nicht, überprüfen Sie die Einstellung Ihres Gerätes und versuchen Sie es…
15.66-15.76  them   Vielen Dank.
19.72-20.40  me     Ja.
```

Both mic-side echoes of the remote turn are gone; the user's own "Ja." survives
— it is below the word floor and overlaps nothing.

### Tests

8 added. Four of them assert that the filter does **nothing**: genuine
repetition that follows the remote turn, simultaneous but different speech,
short overlapping acknowledgements, and mic-only recordings. For a filter that
deletes user content, those matter more than the positive case. The real-world
transcript above is included verbatim as a test case, including the leading
punctuation artifact ASR added to the clipped echo.

Full unit suite: 1511 tests, 0 failures.

### Caveats worth your judgement

- The thresholds are calibrated on **one** recording (a Teams test call), not on
  a sample. They are exposed as `static let` so they are easy to tune.
- A test call is a favourable case: one voice, speaking continuously. Real
  meetings with cross-talk are harder. The negative cases are covered by tests,
  but synthetically rather than from real recordings.
- This cleans the transcript, not the audio. Playback still contains the echo,
  where the existing gain balancing already attenuates it.

An alternative would be `setVoiceProcessingEnabled(true)` on the input node,
fixing it at the source. I did not go that route here: it also brings AGC and
noise suppression that may affect ASR quality, the meeting app is already
running its own voice processing on the same device, and the effect cannot be
unit-tested. That seems like a call for you rather than something to slip into
this PR.

Tested on macOS 26.6.2, Apple Silicon, Whisper large-v3 turbo.
