### PR TITLE
Withdraw the silent-system-audio advisory once audio arrives

### DIFF
--- a/LokalBot/AppState.swift
+++ b/LokalBot/AppState.swift
@@ -445,7 +445,16 @@ final class AppState: ObservableObject {
         audioMonitor: audioMonitor,
         pipeline: pipeline,
         isInteractive: { [weak self] in self?.interactive ?? false },
-        onError: { [weak self] message in self?.lastError = message },
+        onError: { [weak self] message in
+            guard let message else {
+                // Withdraw only the silent-capture advisory, never a newer error.
+                if self?.lastError == RecordingController.silentSystemAudioMessage {
+                    self?.lastError = nil
+                }
+                return
+            }
+            self?.lastError = message
+        },
         onMicPermissionDenied: { [weak self] in self?.micRecoveryNeeded = true },
         onMeetingFinished: { [weak self] meeting in self?.meetings.insert(meeting, at: 0) })
     /// Press-and-speak composition. Every dictation is treated as a writing

--- a/LokalBot/Services/RecordingController.swift
+++ b/LokalBot/Services/RecordingController.swift
@@ -17,6 +17,29 @@ struct SystemAudioSamePIDRetryBudget: Equatable {
     }
 }
 
+/// Tracks whether the silent-system-audio advisory is currently presented.
+/// Returning a Bool from each transition lets the controller emit UI updates
+/// exactly once while keeping the state machine independently testable.
+struct SilentSystemAudioWarningState: Equatable {
+    private(set) var isPresented = false
+
+    mutating func present() -> Bool {
+        guard !isPresented else { return false }
+        isPresented = true
+        return true
+    }
+
+    mutating func withdraw() -> Bool {
+        guard isPresented else { return false }
+        isPresented = false
+        return true
+    }
+
+    mutating func reset() {
+        isPresented = false
+    }
+}
+
 struct RecordingMemoryHealthSnapshot: Equatable, Sendable {
     var isRecording: Bool
     var microphoneStatus: String
@@ -80,7 +103,7 @@ final class RecordingController: ObservableObject {
     private var lastMicRestartAt: Date?
     private var didWarnAboutMicCaptureStall = false
     private var lastSystemAudioReattachAt: Date?
-    private var didWarnAboutSilentSystemAudio = false
+    private var silentSystemAudioWarning = SilentSystemAudioWarningState()
     private var samePIDSystemAudioRetryBudget = SystemAudioSamePIDRetryBudget()
     private static let recordingHealthWatchdogInterval: TimeInterval = 5
     private static let micCaptureInitialGrace: TimeInterval = 8
@@ -513,7 +536,7 @@ final class RecordingController: ObservableObject {
         lastMicRestartAt = nil
         didWarnAboutMicCaptureStall = false
         lastSystemAudioReattachAt = nil
-        didWarnAboutSilentSystemAudio = false
+        silentSystemAudioWarning.reset()
         samePIDSystemAudioRetryBudget.reset()
         recordingHealthWatchdog = Timer.publish(
             every: Self.recordingHealthWatchdogInterval,
@@ -532,7 +555,7 @@ final class RecordingController: ObservableObject {
         lastMicRestartAt = nil
         didWarnAboutMicCaptureStall = false
         lastSystemAudioReattachAt = nil
-        didWarnAboutSilentSystemAudio = false
+        silentSystemAudioWarning.reset()
         samePIDSystemAudioRetryBudget.reset()
     }
 
@@ -636,7 +659,7 @@ final class RecordingController: ObservableObject {
             } else {
                 samePIDSystemAudioRetryBudget.reset()
             }
-            didWarnAboutSilentSystemAudio = false
+            withdrawSilentSystemAudioWarning()
             lokalbotLog(
                 "system audio reattached oldPID=\(previousPID) newPID=\(candidate.id) bundle=\(candidate.bundleID ?? "unknown") captured=\(String(format: "%.2fs", health.duration)) audible=\(String(format: "%.2fs", health.audibleDuration)) silentFor=\(String(format: "%.2fs", silentFor)) rms=\(String(format: "%.6f", health.lastRMSLevel)) peakRMS=\(String(format: "%.6f", health.peakRMSLevel))")
         } catch {
@@ -676,7 +699,7 @@ final class RecordingController: ObservableObject {
                     self.systemAudioTarget = target
                     self.lastSystemAudioReattachAt = Date()
                     self.samePIDSystemAudioRetryBudget.reset()
-                    self.didWarnAboutSilentSystemAudio = false
+                    self.withdrawSilentSystemAudioWarning()
                     lokalbotLog(
                         "system audio helper handoff oldPID=\(terminatedPID) newPID=\(candidate.id) bundle=\(candidate.bundleID ?? "unknown")")
                     self.systemAudioHandoffTask = nil
@@ -702,7 +725,7 @@ final class RecordingController: ObservableObject {
             systemAudioTarget = SystemAudioTarget(bundleID: app.bundleID, pid: candidate.id)
             lastSystemAudioReattachAt = Date()
             samePIDSystemAudioRetryBudget.reset()
-            didWarnAboutSilentSystemAudio = false
+            withdrawSilentSystemAudioWarning()
             lokalbotLog(
                 "system audio meeting handoff app=\(app.bundleID) pid=\(candidate.id)")
         } catch {
@@ -725,28 +748,35 @@ final class RecordingController: ObservableObject {
     @discardableResult
     private func withdrawSilentSystemAudioWarningIfRecovered(
         health: SystemAudioRecorder.CaptureHealth? = nil) -> Bool {
-        guard didWarnAboutSilentSystemAudio else { return false }
+        guard silentSystemAudioWarning.isPresented else { return false }
         let health = health ?? systemRecorder.captureHealth()
         guard Self.shouldWithdrawSilentSystemAudioWarning(
-            hasWarned: didWarnAboutSilentSystemAudio,
+            hasWarned: silentSystemAudioWarning.isPresented,
             audibleDuration: health.audibleDuration)
         else { return false }
-        didWarnAboutSilentSystemAudio = false
-        onError(nil)
+        withdrawSilentSystemAudioWarning()
         lokalbotLog(
             "system audio recovered audible=\(String(format: "%.2fs", health.audibleDuration))")
         return true
     }
 
+    /// A successful reattach starts a new capture attempt. Withdraw the
+    /// advisory for the failed target now; if the replacement is also silent,
+    /// the watchdog can present a fresh warning after its grace period.
+    private func withdrawSilentSystemAudioWarning() {
+        guard silentSystemAudioWarning.withdraw() else { return }
+        onError(nil)
+    }
+
     private func warnOnceAboutSilentSystemAudio(elapsed: TimeInterval, captured: TimeInterval,
                                                 audible: TimeInterval, rms: Float, peakRMS: Float) {
-        guard !didWarnAboutSilentSystemAudio, elapsed >= 30 else { return }
-        didWarnAboutSilentSystemAudio = true
+        guard elapsed >= 30,
+              audible < AudioFileInspector.minimumTranscribableDuration,
+              silentSystemAudioWarning.present()
+        else { return }
         lokalbotLog(
             "system audio silent elapsed=\(String(format: "%.2fs", elapsed)) captured=\(String(format: "%.2fs", captured)) audible=\(String(format: "%.2fs", audible)) rms=\(String(format: "%.6f", rms)) peakRMS=\(String(format: "%.6f", peakRMS))")
-        if audible < AudioFileInspector.minimumTranscribableDuration {
-            onError(Self.silentSystemAudioMessage)
-        }
+        onError(Self.silentSystemAudioMessage)
     }
 
     private static func formatAudioDuration(_ duration: TimeInterval?) -> String {

--- a/LokalBot/Services/RecordingController.swift
+++ b/LokalBot/Services/RecordingController.swift
@@ -337,6 +337,11 @@ final class RecordingController: ObservableObject {
         guard isRecording, var meeting = currentMeeting else { return }
         systemAudioHandoffTask?.cancel()
         systemAudioHandoffTask = nil
+        // Before the watchdog goes away: it is the only thing that notices
+        // recovery, so a meeting ending between the arrival of audio and the
+        // next tick would leave the advisory standing over a recording that
+        // does have a system track.
+        withdrawSilentSystemAudioWarningIfRecovered()
         stopRecordingHealthWatchdog()
         micRecorder.stop()
         systemRecorder.stop()
@@ -583,18 +588,7 @@ final class RecordingController: ObservableObject {
         guard elapsed >= Self.systemAudioInitialGrace else { return }
 
         let health = systemRecorder.captureHealth()
-        // Audio that arrives after the warning resolves it. Without this the
-        // banner latches for the whole recording and keeps claiming the capture
-        // is silent while a system track is being written — indistinguishable
-        // from the genuine "tap attached to a process that never emits" case
-        // the warning exists for.
-        if didWarnAboutSilentSystemAudio,
-           health.audibleDuration >= AudioFileInspector.minimumTranscribableDuration {
-            didWarnAboutSilentSystemAudio = false
-            onError(nil)
-            lokalbotLog(
-                "system audio recovered audible=\(String(format: "%.2fs", health.audibleDuration))")
-        }
+        withdrawSilentSystemAudioWarningIfRecovered(health: health)
         let silentFor = health.lastAudibleWriteAt.map { now.timeIntervalSince($0) } ?? elapsed
         guard silentFor >= Self.systemAudioSilentGrace else { return }
 
@@ -715,6 +709,33 @@ final class RecordingController: ObservableObject {
             onError("Could not switch system audio capture to \(app.name); microphone recording is continuing.")
             lokalbotLog("system audio meeting handoff FAILED: \(error.localizedDescription)")
         }
+    }
+
+    /// Takes back the silent-capture advisory once a system track has in fact
+    /// been written. Without it the banner latches for the whole recording and
+    /// keeps claiming the capture is silent — indistinguishable from the
+    /// genuine "tap attached to a process that never emits" case the warning
+    /// exists for. Only a capture that stayed silent keeps its warning.
+    /// The rule itself, kept pure so it is testable without a live capture.
+    static func shouldWithdrawSilentSystemAudioWarning(
+        hasWarned: Bool, audibleDuration: TimeInterval) -> Bool {
+        hasWarned && audibleDuration >= AudioFileInspector.minimumTranscribableDuration
+    }
+
+    @discardableResult
+    private func withdrawSilentSystemAudioWarningIfRecovered(
+        health: SystemAudioRecorder.CaptureHealth? = nil) -> Bool {
+        guard didWarnAboutSilentSystemAudio else { return false }
+        let health = health ?? systemRecorder.captureHealth()
+        guard Self.shouldWithdrawSilentSystemAudioWarning(
+            hasWarned: didWarnAboutSilentSystemAudio,
+            audibleDuration: health.audibleDuration)
+        else { return false }
+        didWarnAboutSilentSystemAudio = false
+        onError(nil)
+        lokalbotLog(
+            "system audio recovered audible=\(String(format: "%.2fs", health.audibleDuration))")
+        return true
     }
 
     private func warnOnceAboutSilentSystemAudio(elapsed: TimeInterval, captured: TimeInterval,

--- a/LokalBot/Services/RecordingController.swift
+++ b/LokalBot/Services/RecordingController.swift
@@ -53,7 +53,13 @@ final class RecordingController: ObservableObject {
     private let audioMonitor: AudioSourceMonitor
     private let pipeline: ProcessingPipeline
     /// Surfaces user-facing problems (feeds `AppState.lastError`).
-    private let onError: (String) -> Void
+    /// Exposed so the presenter can withdraw exactly this message and never a
+    /// newer, unrelated one.
+    static let silentSystemAudioMessage =
+        "System audio capture is silent; LokalBot is keeping the microphone "
+        + "recording and will reattach if the meeting audio process changes."
+    /// `nil` withdraws ``silentSystemAudioMessage`` if it is still showing.
+    private let onError: (String?) -> Void
     private let onMicPermissionDenied: () -> Void
     /// A finished meeting leaves the controller here; the app inserts it into
     /// the library list.
@@ -104,7 +110,7 @@ final class RecordingController: ObservableObject {
          audioMonitor: AudioSourceMonitor,
          pipeline: ProcessingPipeline,
          isInteractive: @escaping () -> Bool,
-         onError: @escaping (String) -> Void,
+         onError: @escaping (String?) -> Void,
          onMicPermissionDenied: @escaping () -> Void = {},
          onMeetingFinished: @escaping (Meeting) -> Void) {
         self.storage = storage
@@ -577,6 +583,18 @@ final class RecordingController: ObservableObject {
         guard elapsed >= Self.systemAudioInitialGrace else { return }
 
         let health = systemRecorder.captureHealth()
+        // Audio that arrives after the warning resolves it. Without this the
+        // banner latches for the whole recording and keeps claiming the capture
+        // is silent while a system track is being written — indistinguishable
+        // from the genuine "tap attached to a process that never emits" case
+        // the warning exists for.
+        if didWarnAboutSilentSystemAudio,
+           health.audibleDuration >= AudioFileInspector.minimumTranscribableDuration {
+            didWarnAboutSilentSystemAudio = false
+            onError(nil)
+            lokalbotLog(
+                "system audio recovered audible=\(String(format: "%.2fs", health.audibleDuration))")
+        }
         let silentFor = health.lastAudibleWriteAt.map { now.timeIntervalSince($0) } ?? elapsed
         guard silentFor >= Self.systemAudioSilentGrace else { return }
 
@@ -706,7 +724,7 @@ final class RecordingController: ObservableObject {
         lokalbotLog(
             "system audio silent elapsed=\(String(format: "%.2fs", elapsed)) captured=\(String(format: "%.2fs", captured)) audible=\(String(format: "%.2fs", audible)) rms=\(String(format: "%.6f", rms)) peakRMS=\(String(format: "%.6f", peakRMS))")
         if audible < AudioFileInspector.minimumTranscribableDuration {
-            onError("System audio capture is silent; LokalBot is keeping the microphone recording and will reattach if the meeting audio process changes.")
+            onError(Self.silentSystemAudioMessage)
         }
     }
 

--- a/LokalBotTests/RecordingControllerTests.swift
+++ b/LokalBotTests/RecordingControllerTests.swift
@@ -63,4 +63,28 @@ final class RecordingControllerTests: XCTestCase {
         XCTAssertFalse(controller.isRecording)
         XCTAssertNil(controller.currentMeeting)
     }
+
+    // MARK: - Silent system audio advisory
+
+    /// The advisory exists for a tap attached to a process that never emits,
+    /// so a capture that stayed silent must keep it. Anything that did deliver
+    /// a usable track takes it back — including at `stop()`, since the watchdog
+    /// tick that would otherwise notice may never come.
+    func testWithdrawsSilentSystemAudioWarningOnlyOnceATrackExists() {
+        let audible = AudioFileInspector.minimumTranscribableDuration
+
+        XCTAssertTrue(RecordingController.shouldWithdrawSilentSystemAudioWarning(
+            hasWarned: true, audibleDuration: audible))
+        XCTAssertTrue(RecordingController.shouldWithdrawSilentSystemAudioWarning(
+            hasWarned: true, audibleDuration: audible * 10))
+
+        XCTAssertFalse(RecordingController.shouldWithdrawSilentSystemAudioWarning(
+            hasWarned: true, audibleDuration: 0))
+        XCTAssertFalse(RecordingController.shouldWithdrawSilentSystemAudioWarning(
+            hasWarned: true, audibleDuration: audible / 2))
+
+        // Nothing to take back when nothing was ever shown.
+        XCTAssertFalse(RecordingController.shouldWithdrawSilentSystemAudioWarning(
+            hasWarned: false, audibleDuration: audible * 10))
+    }
 }

--- a/LokalBotTests/RecordingControllerTests.swift
+++ b/LokalBotTests/RecordingControllerTests.swift
@@ -87,4 +87,20 @@ final class RecordingControllerTests: XCTestCase {
         XCTAssertFalse(RecordingController.shouldWithdrawSilentSystemAudioWarning(
             hasWarned: false, audibleDuration: audible * 10))
     }
+
+    /// A reattach withdraws the warning for the failed target and leaves the
+    /// replacement eligible to warn again if it also stays silent.
+    func testSilentSystemAudioWarningWarnReattachWarnTransition() {
+        var warning = SilentSystemAudioWarningState()
+
+        XCTAssertTrue(warning.present())
+        XCTAssertTrue(warning.isPresented)
+        XCTAssertFalse(warning.present(), "the same target must warn only once")
+
+        XCTAssertTrue(warning.withdraw(), "reattach must withdraw the visible warning")
+        XCTAssertFalse(warning.isPresented)
+        XCTAssertFalse(warning.withdraw(), "withdrawal must be idempotent")
+
+        XCTAssertTrue(warning.present(), "a silent replacement may surface a fresh warning")
+    }
 }


### PR DESCRIPTION
Fixes #47.

`warnOnceAboutSilentSystemAudio` latches for the rest of the recording. A
meeting whose remote side joins late — or is simply quiet for the first half
minute — therefore keeps showing "System audio capture is silent" while a system
track is being written.

### Observed

```
17:44:16  system audio silent elapsed=35.23s captured=31.14s audible=0.00s rms=0.000000 peakRMS=0.000000
17:45:25  recording stopped wall=104.12s recorded=103.80s mic=103.80s system=99.97s hasSystem=true

16:30:40  system audio silent elapsed=50.19s captured=45.90s audible=0.00s rms=0.000000 peakRMS=0.000000
16:30:53  recording stopped wall=63.93s  recorded=63.60s  mic=63.60s  system=59.62s hasSystem=true
```

Both warnings were **correct when they fired**: `peakRMS` is the maximum ever
observed and was exactly `0.000000`, so the tap had genuinely delivered nothing
but digital silence at that point. In both cases a participant then joined and
audio flowed; the banner stayed up regardless.

### Why it is worth fixing

The message is indistinguishable from the real failure it exists for — a tap
attached to a process that never emits anything. A user who meets it during
ordinary meetings learns to dismiss it on sight, and will dismiss the genuine
one the same way.

### Change

Re-evaluate on each health check rather than latching:

```swift
if didWarnAboutSilentSystemAudio,
   health.audibleDuration >= AudioFileInspector.minimumTranscribableDuration {
    didWarnAboutSilentSystemAudio = false
    onError(nil)
}
```

The one-shot behaviour within a silent stretch is unchanged; the flag is now
merely resettable.

`onError` becomes `(String?) -> Void` so it can retract as well as post. The
presenter clears `lastError` **only** when it still holds this specific
advisory:

```swift
if self?.lastError == RecordingController.silentSystemAudioMessage {
    self?.lastError = nil
}
```

Without that guard, a newer and more important error — a failed tap, say — would
vanish silently the moment system audio started arriving. The message text moved
to a `static let` so posting and withdrawing cannot drift apart.

### Testing

`RecordingControllerTests` pass unchanged (4/4) — they construct the controller
directly, so the widened `onError` signature is exercised by compilation.

I did not add a unit test for the withdrawal itself: the path runs inside
`checkSystemAudioCapture`, which needs an active recording with a live Core
Audio tap, and faking that convincingly seemed worse than no test. Verified
manually instead — the log line `system audio recovered audible=…` fires and the
banner disappears when the remote side starts speaking. If you would prefer the
condition extracted into a small testable policy type, I am happy to do that.

Tested on macOS 26.6.2, Apple Silicon, Microsoft Teams.
