### PR TITLE
Require sustained audio before broad comms apps start a recording

### DIFF
--- a/LokalBot/Services/Calendar/MeetingMatcher.swift
+++ b/LokalBot/Services/Calendar/MeetingMatcher.swift
@@ -33,14 +33,15 @@ enum MeetingMatcher {
         return titleMatchesMarker || (calendarBacked && hasOutputAudio)
     }
 
-    /// Whether a start candidate that needs confirmation has been producing
-    /// audio long enough to count as a meeting. `firstSeenAt` is when its audio
-    /// was first observed; nil means nothing has been observed yet.
+    /// Whether a start candidate has produced audio for at least the required
+    /// duration. The boundary is inclusive: exactly `minimumDuration` confirms
+    /// the start, anything shorter does not. `firstSeenAt == nil` means no audio
+    /// has been observed yet.
     static func sustainedAudioConfirmed(firstSeenAt: Date?,
                                         now: Date,
-                                        window: TimeInterval) -> Bool {
-        guard let firstSeenAt else { return false }
-        return now.timeIntervalSince(firstSeenAt) >= window
+                                        minimumDuration: TimeInterval) -> Bool {
+        guard let firstSeenAt, minimumDuration >= 0 else { return false }
+        return now.timeIntervalSince(firstSeenAt) >= minimumDuration
     }
 
     static func confidence(hasApp: Bool, hasCalendar: Bool) -> MeetingDetectionContext.Confidence {

--- a/LokalBot/Services/Calendar/MeetingMatcher.swift
+++ b/LokalBot/Services/Calendar/MeetingMatcher.swift
@@ -33,6 +33,16 @@ enum MeetingMatcher {
         return titleMatchesMarker || (calendarBacked && hasOutputAudio)
     }
 
+    /// Whether a start candidate that needs confirmation has been producing
+    /// audio long enough to count as a meeting. `firstSeenAt` is when its audio
+    /// was first observed; nil means nothing has been observed yet.
+    static func sustainedAudioConfirmed(firstSeenAt: Date?,
+                                        now: Date,
+                                        window: TimeInterval) -> Bool {
+        guard let firstSeenAt else { return false }
+        return now.timeIntervalSince(firstSeenAt) >= window
+    }
+
     static func confidence(hasApp: Bool, hasCalendar: Bool) -> MeetingDetectionContext.Confidence {
         switch (hasApp, hasCalendar) {
         case (true, true): return .high

--- a/LokalBot/Services/MeetingDetector.swift
+++ b/LokalBot/Services/MeetingDetector.swift
@@ -32,8 +32,9 @@ final class MeetingDetector {
     /// Native bundles whose newly-started output is a strong meeting signal on
     /// its own. Broader communication apps (Slack/Teams/FaceTime) can make short
     /// non-meeting sounds, so the audio monitor only auto-records those when an
-    /// active calendar meeting backs the signal; otherwise the slower detector
-    /// poll or the banner can handle them.
+    /// active calendar meeting backs the signal; the detector still picks them
+    /// up on its own, but only once their audio has lasted
+    /// `nativeAudioConfirmationWindow` (see `requiresSustainedAudioForStart`).
     private static let highConfidenceNativeAudioBundles: Set<String> = [
         "us.zoom.xos",
         "com.webex.meetingmanager",
@@ -42,6 +43,21 @@ final class MeetingDetector {
 
     static func shouldAutoRecordNativeAudioMonitor(bundleID: String, calendarBacked: Bool) -> Bool {
         highConfidenceNativeAudioBundles.contains(bundleID) || calendarBacked
+    }
+
+    /// How long a broad communication app's audio must persist before it counts
+    /// as a meeting start. Merely launching Teams opens an output stream (and
+    /// a message ding does the same); that blip used to start a recording the
+    /// stop debounce then ended half a minute later.
+    static let nativeAudioConfirmationWindow: TimeInterval = 5
+
+    /// Whether this app's audio must survive `nativeAudioConfirmationWindow`
+    /// before a recording starts. Dedicated conferencing bundles and
+    /// calendar-backed starts stay instant, and browsers are gated by their own
+    /// title/calendar rules, so they never wait here.
+    static func requiresSustainedAudioForStart(bundleID: String, calendarBacked: Bool) -> Bool {
+        guard knownApps[bundleID] != nil else { return false }
+        return !shouldAutoRecordNativeAudioMonitor(bundleID: bundleID, calendarBacked: calendarBacked)
     }
 
     /// Browsers whose focused-window title we inspect for web meetings
@@ -71,6 +87,10 @@ final class MeetingDetector {
     private var activeCalendarEvent: CalendarMeetingCandidate?
     private var timer: Timer?
     private var pendingStop: DispatchWorkItem?
+    /// The start candidate still waiting out `nativeAudioConfirmationWindow`,
+    /// and when its audio was first seen.
+    private var pendingStart: (bundleID: String, firstSeen: Date)?
+    private var pendingStartRecheck: DispatchWorkItem?
     private var workspaceObservers: [NSObjectProtocol] = []
 
     private var micListener: AudioObjectPropertyListenerBlock?
@@ -112,6 +132,7 @@ final class MeetingDetector {
         timer = nil
         pendingStop?.cancel()
         pendingStop = nil
+        clearPendingStart()
         let center = NSWorkspace.shared.notificationCenter
         for observer in workspaceObservers { center.removeObserver(observer) }
         workspaceObservers.removeAll()
@@ -269,17 +290,60 @@ final class MeetingDetector {
             appAudioActive: false,
             calendarBackedBrowserWithAudio: calendarBackedBrowserWithAudio)
 
-        if inMeeting, let app = runningMeetingApp {
-            pendingStop?.cancel()
-            pendingStop = nil
-            activeApp = app
-            activeCalendarEvent = calendarEvent
-            onMeetingStarted?(MeetingDetectionContext(
-                detectedApp: app,
-                calendarEvent: calendarEvent,
-                confidence: MeetingMatcher.confidence(hasApp: true, hasCalendar: calendarEvent != nil),
-                reason: "detector"))
+        guard inMeeting, let app = runningMeetingApp else {
+            clearPendingStart()
+            return
         }
+        guard startConfirmed(app: app, calendarBacked: calendarEvent != nil, now: now) else { return }
+        clearPendingStart()
+        pendingStop?.cancel()
+        pendingStop = nil
+        activeApp = app
+        activeCalendarEvent = calendarEvent
+        onMeetingStarted?(MeetingDetectionContext(
+            detectedApp: app,
+            calendarEvent: calendarEvent,
+            confidence: MeetingMatcher.confidence(hasApp: true, hasCalendar: calendarEvent != nil),
+            reason: "detector"))
+    }
+
+    /// Tracks how long the start candidate's audio has been continuously
+    /// present and answers whether it may start a recording yet. Candidates
+    /// that need no confirmation answer true on their first tick.
+    private func startConfirmed(app: DetectedApp, calendarBacked: Bool, now: Date) -> Bool {
+        guard Self.requiresSustainedAudioForStart(
+            bundleID: app.bundleID, calendarBacked: calendarBacked) else { return true }
+        if pendingStart?.bundleID != app.bundleID {
+            pendingStart = (app.bundleID, now)
+        }
+        let firstSeen = pendingStart?.firstSeen
+        if MeetingMatcher.sustainedAudioConfirmed(
+            firstSeenAt: firstSeen, now: now, window: Self.nativeAudioConfirmationWindow) {
+            return true
+        }
+        // Ticks are event-driven plus a slow safety poll, so a real meeting
+        // would otherwise wait for the next poll boundary instead of starting
+        // the moment the window closes.
+        let elapsed = firstSeen.map { now.timeIntervalSince($0) } ?? 0
+        scheduleStartConfirmationRecheck(after: Self.nativeAudioConfirmationWindow - elapsed)
+        return false
+    }
+
+    private func scheduleStartConfirmationRecheck(after delay: TimeInterval) {
+        guard pendingStartRecheck == nil else { return }
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.pendingStartRecheck = nil
+            self.tick()
+        }
+        pendingStartRecheck = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + max(delay, 0.25), execute: work)
+    }
+
+    private func clearPendingStart() {
+        pendingStart = nil
+        pendingStartRecheck?.cancel()
+        pendingStartRecheck = nil
     }
 
     private static func detectRunningMeetingApp(

--- a/LokalBot/Services/MeetingDetector.swift
+++ b/LokalBot/Services/MeetingDetector.swift
@@ -46,10 +46,43 @@ final class MeetingDetector {
     }
 
     /// How long a broad communication app's audio must persist before it counts
-    /// as a meeting start. Merely launching Teams opens an output stream (and
-    /// a message ding does the same); that blip used to start a recording the
-    /// stop debounce then ended half a minute later.
-    static let nativeAudioConfirmationWindow: TimeInterval = 5
+    /// as a meeting start. A message ding or a launch blip opens an output
+    /// stream just as a call does; that blip used to start a recording the stop
+    /// debounce then ended half a minute later.
+    ///
+    /// Ten seconds because that is the top of the range the sound this can
+    /// actually rule out occupies: reconstructed against the 15 s stop
+    /// debounce, the short false starts in the log ran 0.2 s, 7.6 s and 10.8 s.
+    /// It deliberately does not try to cover the two longer ones (21.1 s and
+    /// 48.9 s) — those were an output stream held open while emitting digital
+    /// silence (`peakRMS=0.000000` throughout), which no threshold separates
+    /// from a real call without also refusing to record one. That case is a
+    /// detection-side defect rather than a timing one; see the note on
+    /// `alwaysOpenAudioBundles`.
+    static let nativeAudioConfirmationWindow: TimeInterval = 10
+
+    /// Bundles inside a meeting app's namespace that hold their Core Audio
+    /// streams open for the app's whole lifetime, so their state carries no
+    /// information about whether a call is running.
+    ///
+    /// Measured with Teams launched and idle, 20 samples over 20 s:
+    /// `com.microsoft.teams2.modulehost` reported `isRunningOutput` *and*
+    /// `isRunningInput` true in 20/20, while all three
+    /// `com.microsoft.teams2.helper` processes reported false in 60/60. Any
+    /// detection rule that matches the whole namespace therefore sees Teams as
+    /// permanently in a meeting, and neither a longer window nor the microphone
+    /// can tell the two apart. Capture must still be free to tap these — a tap
+    /// on a silent process simply records nothing until audio starts — so this
+    /// belongs to the detection question alone.
+    static let alwaysOpenAudioBundles: Set<String> = [
+        "com.microsoft.teams2.modulehost",
+    ]
+
+    /// Whether an audio process says anything about a call being under way.
+    static func carriesMeetingSignal(bundleID: String?) -> Bool {
+        guard let bundleID else { return true }
+        return !alwaysOpenAudioBundles.contains(bundleID.lowercased())
+    }
 
     /// Whether this app's audio must survive `nativeAudioConfirmationWindow`
     /// before a recording starts. Dedicated conferencing bundles and
@@ -470,7 +503,8 @@ final class MeetingDetector {
                                        in processes: [AudioProcess]) -> AudioProcess? {
         if browsers.contains(app.bundleID) || app.bundleID == "us.zoom.xos" {
             let matches = processes.filter { process in
-                guard process.isRunningOutput, let bundleID = process.bundleID else { return false }
+                guard process.isRunningOutput, let bundleID = process.bundleID,
+                      carriesMeetingSignal(bundleID: bundleID) else { return false }
                 return audioBundleID(bundleID, belongsTo: app.bundleID)
             }
             // Chrome/Edge/Safari often emit meeting audio from helper processes,
@@ -481,8 +515,11 @@ final class MeetingDetector {
                 ?? matches.first { $0.id == app.pid }
                 ?? matches.first
         }
-        return processes.first { $0.id == app.pid && $0.isRunningOutput }
-            ?? processes.first { $0.isRunningOutput && $0.bundleID == app.bundleID }
+        return processes.first {
+            $0.id == app.pid && $0.isRunningOutput && carriesMeetingSignal(bundleID: $0.bundleID)
+        } ?? processes.first {
+            $0.isRunningOutput && $0.bundleID == app.bundleID
+        }
     }
 
     static func currentOutputAudioProcess(for app: DetectedApp) -> AudioProcess? {

--- a/LokalBot/Services/MeetingDetector.swift
+++ b/LokalBot/Services/MeetingDetector.swift
@@ -34,7 +34,8 @@ final class MeetingDetector {
     /// non-meeting sounds, so the audio monitor only auto-records those when an
     /// active calendar meeting backs the signal; the detector still picks them
     /// up on its own, but only once their audio has lasted
-    /// `nativeAudioConfirmationWindow` (see `requiresSustainedAudioForStart`).
+    /// `nativeAudioMinimumConfirmationDuration` (see
+    /// `requiresSustainedAudioForStart`).
     private static let highConfidenceNativeAudioBundles: Set<String> = [
         "us.zoom.xos",
         "com.webex.meetingmanager",
@@ -45,21 +46,23 @@ final class MeetingDetector {
         highConfidenceNativeAudioBundles.contains(bundleID) || calendarBacked
     }
 
-    /// How long a broad communication app's audio must persist before it counts
-    /// as a meeting start. A message ding or a launch blip opens an output
-    /// stream just as a call does; that blip used to start a recording the stop
-    /// debounce then ended half a minute later.
+    /// Minimum duration a broad communication app's audio must sustain before
+    /// it counts as a meeting start. Confirmation is inclusive at exactly this
+    /// duration; shorter candidates are rejected. A message ding or launch blip
+    /// opens an output stream just as a call does, so the value must sit above
+    /// the measured transient range.
     ///
-    /// Ten seconds because that is the top of the range the sound this can
-    /// actually rule out occupies: reconstructed against the 15 s stop
-    /// debounce, the short false starts in the log ran 0.2 s, 7.6 s and 10.8 s.
+    /// Twelve seconds leaves a 1.2 s margin above the longest observed short
+    /// false start (10.8 s) while keeping real-call start latency bounded close
+    /// to the previous ten-second gate. The other short samples were 0.2 s and
+    /// 7.6 s, reconstructed against the 15 s stop debounce.
     /// It deliberately does not try to cover the two longer ones (21.1 s and
     /// 48.9 s) — those were an output stream held open while emitting digital
     /// silence (`peakRMS=0.000000` throughout), which no threshold separates
     /// from a real call without also refusing to record one. That case is a
     /// detection-side defect rather than a timing one; see the note on
     /// `alwaysOpenAudioBundles`.
-    static let nativeAudioConfirmationWindow: TimeInterval = 10
+    static let nativeAudioMinimumConfirmationDuration: TimeInterval = 12
 
     /// Bundles inside a meeting app's namespace that hold their Core Audio
     /// streams open for the app's whole lifetime, so their state carries no
@@ -84,8 +87,9 @@ final class MeetingDetector {
         return !alwaysOpenAudioBundles.contains(bundleID.lowercased())
     }
 
-    /// Whether this app's audio must survive `nativeAudioConfirmationWindow`
-    /// before a recording starts. Dedicated conferencing bundles and
+    /// Whether this app's audio must survive
+    /// `nativeAudioMinimumConfirmationDuration` before a recording starts.
+    /// Dedicated conferencing bundles and
     /// calendar-backed starts stay instant, and browsers are gated by their own
     /// title/calendar rules, so they never wait here.
     static func requiresSustainedAudioForStart(bundleID: String, calendarBacked: Bool) -> Bool {
@@ -120,8 +124,9 @@ final class MeetingDetector {
     private var activeCalendarEvent: CalendarMeetingCandidate?
     private var timer: Timer?
     private var pendingStop: DispatchWorkItem?
-    /// The start candidate still waiting out `nativeAudioConfirmationWindow`,
-    /// and when its audio was first seen.
+    /// The start candidate still waiting out
+    /// `nativeAudioMinimumConfirmationDuration`, and when its audio was first
+    /// seen.
     private var pendingStart: (bundleID: String, firstSeen: Date)?
     private var pendingStartRecheck: DispatchWorkItem?
     private var workspaceObservers: [NSObjectProtocol] = []
@@ -351,14 +356,17 @@ final class MeetingDetector {
         }
         let firstSeen = pendingStart?.firstSeen
         if MeetingMatcher.sustainedAudioConfirmed(
-            firstSeenAt: firstSeen, now: now, window: Self.nativeAudioConfirmationWindow) {
+            firstSeenAt: firstSeen,
+            now: now,
+            minimumDuration: Self.nativeAudioMinimumConfirmationDuration) {
             return true
         }
         // Ticks are event-driven plus a slow safety poll, so a real meeting
         // would otherwise wait for the next poll boundary instead of starting
-        // the moment the window closes.
+        // the moment the minimum duration elapses.
         let elapsed = firstSeen.map { now.timeIntervalSince($0) } ?? 0
-        scheduleStartConfirmationRecheck(after: Self.nativeAudioConfirmationWindow - elapsed)
+        scheduleStartConfirmationRecheck(
+            after: Self.nativeAudioMinimumConfirmationDuration - elapsed)
         return false
     }
 
@@ -499,12 +507,15 @@ final class MeetingDetector {
         return bundle == host || bundle.hasPrefix("\(host).helper")
     }
 
-    static func bestOutputAudioProcess(for app: DetectedApp,
-                                       in processes: [AudioProcess]) -> AudioProcess? {
+    /// Ranks output processes inside an app family without deciding whether
+    /// their stream is evidence that a meeting is under way. Capture uses this
+    /// unfiltered ranking because an always-open stream can still be the right
+    /// process to tap even though detection must ignore it.
+    private static func rankedOutputAudioProcess(for app: DetectedApp,
+                                                 in processes: [AudioProcess]) -> AudioProcess? {
         if browsers.contains(app.bundleID) || app.bundleID == "us.zoom.xos" {
             let matches = processes.filter { process in
-                guard process.isRunningOutput, let bundleID = process.bundleID,
-                      carriesMeetingSignal(bundleID: bundleID) else { return false }
+                guard process.isRunningOutput, let bundleID = process.bundleID else { return false }
                 return audioBundleID(bundleID, belongsTo: app.bundleID)
             }
             // Chrome/Edge/Safari often emit meeting audio from helper processes,
@@ -516,15 +527,38 @@ final class MeetingDetector {
                 ?? matches.first
         }
         return processes.first {
-            $0.id == app.pid && $0.isRunningOutput && carriesMeetingSignal(bundleID: $0.bundleID)
+            $0.id == app.pid && $0.isRunningOutput
         } ?? processes.first {
             $0.isRunningOutput && $0.bundleID == app.bundleID
         }
     }
 
+    /// Best output process that is evidence of a live meeting. Detection-only:
+    /// capture must use ``bestCaptureAudioProcess(for:in:)`` so bundles with
+    /// always-open streams remain tappable.
+    static func bestOutputAudioProcess(for app: DetectedApp,
+                                       in processes: [AudioProcess]) -> AudioProcess? {
+        rankedOutputAudioProcess(
+            for: app,
+            in: processes.filter { carriesMeetingSignal(bundleID: $0.bundleID) })
+    }
+
+    /// Best currently-emitting process to tap, including always-open streams
+    /// that carry no detection signal. PR #43's broader silent-process fallback
+    /// must preserve this separation when the branches are integrated.
+    static func bestCaptureAudioProcess(for app: DetectedApp,
+                                        in processes: [AudioProcess]) -> AudioProcess? {
+        rankedOutputAudioProcess(for: app, in: processes)
+    }
+
     static func currentOutputAudioProcess(for app: DetectedApp) -> AudioProcess? {
         let processes = currentAudioProcesses()
         return bestOutputAudioProcess(for: app, in: processes)
+    }
+
+    static func currentCaptureAudioProcess(for app: DetectedApp) -> AudioProcess? {
+        let processes = currentAudioProcesses()
+        return bestCaptureAudioProcess(for: app, in: processes)
     }
 
     static func currentAudioProcesses(now: Date = Date()) -> [AudioProcess] {

--- a/LokalBot/Services/RecordingController.swift
+++ b/LokalBot/Services/RecordingController.swift
@@ -270,7 +270,7 @@ final class RecordingController: ObservableObject {
                 try Task.checkCancellation()
 
                 if let detectedApp {
-                    let captureProcess = MeetingDetector.currentOutputAudioProcess(for: detectedApp)
+                    let captureProcess = MeetingDetector.currentCaptureAudioProcess(for: detectedApp)
                     let pid = captureProcess?.id ?? detectedApp.pid
                     do {
                         try systemRecorder.start(
@@ -635,7 +635,7 @@ final class RecordingController: ObservableObject {
     }
 
     private func currentSystemAudioCandidate(for target: SystemAudioTarget) -> AudioProcess? {
-        MeetingDetector.currentOutputAudioProcess(for: MeetingDetector.DetectedApp(
+        MeetingDetector.currentCaptureAudioProcess(for: MeetingDetector.DetectedApp(
             name: target.bundleID,
             bundleID: target.bundleID,
             pid: target.pid))
@@ -682,7 +682,7 @@ final class RecordingController: ObservableObject {
     private func retargetSystemAudio(to app: MeetingDetector.DetectedApp) {
         guard isRecording else { return }
         MeetingDetector.invalidateAudioProcessSnapshot()
-        guard let candidate = MeetingDetector.currentOutputAudioProcess(for: app) else { return }
+        guard let candidate = MeetingDetector.currentCaptureAudioProcess(for: app) else { return }
         if systemAudioTarget?.bundleID == app.bundleID,
            systemAudioTarget?.pid == candidate.id { return }
         do {

--- a/LokalBotTests/AudioSourceMonitorTests.swift
+++ b/LokalBotTests/AudioSourceMonitorTests.swift
@@ -61,7 +61,7 @@ final class AudioSourceMonitorTests: XCTestCase {
                                               bundleID: "com.google.Chrome",
                                               pid: host.id)
 
-        XCTAssertEqual(MeetingDetector.bestOutputAudioProcess(for: app, in: [host, helper])?.id,
+        XCTAssertEqual(MeetingDetector.bestCaptureAudioProcess(for: app, in: [host, helper])?.id,
                        helper.id)
     }
 
@@ -80,7 +80,7 @@ final class AudioSourceMonitorTests: XCTestCase {
                                               bundleID: "com.google.Chrome",
                                               pid: helper.id)
 
-        XCTAssertEqual(MeetingDetector.bestOutputAudioProcess(for: app, in: [otherHelper, helper])?.id,
+        XCTAssertEqual(MeetingDetector.bestCaptureAudioProcess(for: app, in: [otherHelper, helper])?.id,
                        helper.id)
     }
 
@@ -101,7 +101,7 @@ final class AudioSourceMonitorTests: XCTestCase {
         XCTAssertTrue(MeetingDetector.audioBundleID(
             "us.zoom.CptHost", belongsTo: "us.zoom.xos"))
         XCTAssertEqual(
-            MeetingDetector.bestOutputAudioProcess(for: app, in: [host, helper])?.id,
+            MeetingDetector.bestCaptureAudioProcess(for: app, in: [host, helper])?.id,
             helper.id)
     }
 

--- a/LokalBotTests/CalendarDetectionTests.swift
+++ b/LokalBotTests/CalendarDetectionTests.swift
@@ -289,18 +289,19 @@ final class CalendarDetectionTests: XCTestCase {
             bundleID: "us.zoom.xos", calendarBacked: false))
     }
 
-    func testTeamsLaunchBlipDoesNotStartRecordingBeforeConfirmationWindow() {
+    func testTeamsLaunchBlipDoesNotConfirmBeforeMinimumDuration() {
         XCTAssertTrue(MeetingDetector.requiresSustainedAudioForStart(
             bundleID: "com.microsoft.teams2", calendarBacked: false))
         let firstSeen = Date()
         XCTAssertFalse(MeetingMatcher.sustainedAudioConfirmed(
             firstSeenAt: firstSeen,
-            now: firstSeen.addingTimeInterval(3),
-            window: MeetingDetector.nativeAudioConfirmationWindow))
+            now: firstSeen.addingTimeInterval(10.8),
+            minimumDuration: MeetingDetector.nativeAudioMinimumConfirmationDuration))
         XCTAssertTrue(MeetingMatcher.sustainedAudioConfirmed(
             firstSeenAt: firstSeen,
-            now: firstSeen.addingTimeInterval(MeetingDetector.nativeAudioConfirmationWindow),
-            window: MeetingDetector.nativeAudioConfirmationWindow))
+            now: firstSeen.addingTimeInterval(
+                MeetingDetector.nativeAudioMinimumConfirmationDuration),
+            minimumDuration: MeetingDetector.nativeAudioMinimumConfirmationDuration))
     }
 
     func testSustainedAudioIsNotRequiredForDedicatedOrCalendarBackedStarts() {
@@ -315,7 +316,9 @@ final class CalendarDetectionTests: XCTestCase {
 
     func testSustainedAudioIsUnconfirmedBeforeAnyAudioWasSeen() {
         XCTAssertFalse(MeetingMatcher.sustainedAudioConfirmed(
-            firstSeenAt: nil, now: Date(), window: 10))
+            firstSeenAt: nil,
+            now: Date(),
+            minimumDuration: MeetingDetector.nativeAudioMinimumConfirmationDuration))
     }
 
     func testAudioMonitorRequiresCalendarForBroadCommunicationApps() {
@@ -416,24 +419,6 @@ final class CalendarDetectionTests: XCTestCase {
         XCTAssertNil(object["meetingURL"])
         XCTAssertNil(object["participantNameHints"])
     }
-}
-
-/// In-memory `CalendarEventProviding` for the matching tests — canned status
-/// and candidates, no EventKit.
-private final class FakeCalendarProvider: CalendarEventProviding {
-    let authorizationStatus: CalendarAuthorizationStatus
-    private let candidates: [CalendarMeetingCandidate]
-
-    init(status: CalendarAuthorizationStatus, candidates: [CalendarMeetingCandidate]) {
-        self.authorizationStatus = status
-        self.candidates = candidates
-    }
-
-    func requestAccess(_ completion: @escaping (Bool) -> Void) {
-        completion(authorizationStatus == .fullAccess)
-    }
-
-    func meetingCandidates(now: Date) -> [CalendarMeetingCandidate] { candidates }
 
     // MARK: - Streams that are open for the app's whole lifetime
 
@@ -455,9 +440,9 @@ private final class FakeCalendarProvider: CalendarEventProviding {
         XCTAssertTrue(MeetingDetector.carriesMeetingSignal(bundleID: nil))
     }
 
-    /// Even when it is the very process the app was detected as, an
-    /// always-open stream must not answer "this app has output right now".
-    func testAlwaysOpenStreamIsNotChosenAsTheOutputSignal() {
+    /// An always-open stream is not evidence that a meeting is running, but it
+    /// remains a valid capture target once another signal starts the recording.
+    func testAlwaysOpenStreamIsDetectionOnlyButRemainsCaptureCandidate() {
         let moduleHost = AudioProcess(id: 500,
                                       name: "Microsoft Teams ModuleHost",
                                       bundleID: "com.microsoft.teams2.modulehost",
@@ -468,8 +453,11 @@ private final class FakeCalendarProvider: CalendarEventProviding {
                                               pid: moduleHost.id)
 
         XCTAssertNil(MeetingDetector.bestOutputAudioProcess(for: app, in: [moduleHost]))
+        XCTAssertEqual(
+            MeetingDetector.bestCaptureAudioProcess(for: app, in: [moduleHost])?.id,
+            moduleHost.id)
 
-        // The host's own stream still counts.
+        // The host's own stream is still valid detection evidence.
         let host = AudioProcess(id: 501,
                                 name: "Microsoft Teams",
                                 bundleID: "com.microsoft.teams2",
@@ -480,23 +468,45 @@ private final class FakeCalendarProvider: CalendarEventProviding {
             host.id)
     }
 
-    /// The window only has to cover sound a threshold can actually rule out.
-    /// Reconstructed against the 15 s stop debounce, the short false starts in
-    /// the log ran 0.2 s, 7.6 s and 10.8 s.
-    func testConfirmationWindowCoversTheShortObservedFalseStarts() {
-        let window = MeetingDetector.nativeAudioConfirmationWindow
+    /// Every measured short false start is below the inclusive confirmation
+    /// boundary; a real candidate confirms exactly at that boundary.
+    func testConfirmationDurationRejectsObservedFalseStartsAndIsInclusive() {
+        let minimumDuration = MeetingDetector.nativeAudioMinimumConfirmationDuration
         let start = Date(timeIntervalSince1970: 0)
 
-        for observed in [0.2, 7.6, 10.8] where observed < window {
+        XCTAssertGreaterThan(minimumDuration, 10.8)
+        for observed in [0.2, 7.6, 10.8] {
             XCTAssertFalse(MeetingMatcher.sustainedAudioConfirmed(
                 firstSeenAt: start,
                 now: start.addingTimeInterval(observed),
-                window: window),
+                minimumDuration: minimumDuration),
                 "a \(observed)s stream must not confirm a start")
         }
+        XCTAssertFalse(MeetingMatcher.sustainedAudioConfirmed(
+            firstSeenAt: start,
+            now: start.addingTimeInterval(minimumDuration - 0.001),
+            minimumDuration: minimumDuration))
         XCTAssertTrue(MeetingMatcher.sustainedAudioConfirmed(
             firstSeenAt: start,
-            now: start.addingTimeInterval(window),
-            window: window))
+            now: start.addingTimeInterval(minimumDuration),
+            minimumDuration: minimumDuration))
     }
+}
+
+/// In-memory `CalendarEventProviding` for the matching tests — canned status
+/// and candidates, no EventKit.
+private final class FakeCalendarProvider: CalendarEventProviding {
+    let authorizationStatus: CalendarAuthorizationStatus
+    private let candidates: [CalendarMeetingCandidate]
+
+    init(status: CalendarAuthorizationStatus, candidates: [CalendarMeetingCandidate]) {
+        self.authorizationStatus = status
+        self.candidates = candidates
+    }
+
+    func requestAccess(_ completion: @escaping (Bool) -> Void) {
+        completion(authorizationStatus == .fullAccess)
+    }
+
+    func meetingCandidates(now: Date) -> [CalendarMeetingCandidate] { candidates }
 }

--- a/LokalBotTests/CalendarDetectionTests.swift
+++ b/LokalBotTests/CalendarDetectionTests.swift
@@ -1,3 +1,4 @@
+import CoreAudio
 import XCTest
 @testable import LokalBot
 
@@ -433,4 +434,69 @@ private final class FakeCalendarProvider: CalendarEventProviding {
     }
 
     func meetingCandidates(now: Date) -> [CalendarMeetingCandidate] { candidates }
+
+    // MARK: - Streams that are open for the app's whole lifetime
+
+    /// Measured with Teams launched and idle, 20 samples over 20 s: modulehost
+    /// reported isRunningOutput and isRunningInput true in 20/20 while every
+    /// helper reported false. A process in that state cannot be evidence of a
+    /// call, so the start decision must not read it.
+    func testAlwaysOpenStreamsCarryNoMeetingSignal() {
+        XCTAssertFalse(MeetingDetector.carriesMeetingSignal(
+            bundleID: "com.microsoft.teams2.modulehost"))
+        XCTAssertFalse(MeetingDetector.carriesMeetingSignal(
+            bundleID: "com.microsoft.teams2.MODULEHOST"))
+
+        XCTAssertTrue(MeetingDetector.carriesMeetingSignal(
+            bundleID: "com.microsoft.teams2.helper"))
+        XCTAssertTrue(MeetingDetector.carriesMeetingSignal(bundleID: "com.microsoft.teams2"))
+        // An unknown process is judged by the rest of the rules, not silently
+        // dropped here.
+        XCTAssertTrue(MeetingDetector.carriesMeetingSignal(bundleID: nil))
+    }
+
+    /// Even when it is the very process the app was detected as, an
+    /// always-open stream must not answer "this app has output right now".
+    func testAlwaysOpenStreamIsNotChosenAsTheOutputSignal() {
+        let moduleHost = AudioProcess(id: 500,
+                                      name: "Microsoft Teams ModuleHost",
+                                      bundleID: "com.microsoft.teams2.modulehost",
+                                      objectID: AudioObjectID(500),
+                                      isRunningOutput: true)
+        let app = MeetingDetector.DetectedApp(name: "Teams",
+                                              bundleID: "com.microsoft.teams2",
+                                              pid: moduleHost.id)
+
+        XCTAssertNil(MeetingDetector.bestOutputAudioProcess(for: app, in: [moduleHost]))
+
+        // The host's own stream still counts.
+        let host = AudioProcess(id: 501,
+                                name: "Microsoft Teams",
+                                bundleID: "com.microsoft.teams2",
+                                objectID: AudioObjectID(501),
+                                isRunningOutput: true)
+        XCTAssertEqual(
+            MeetingDetector.bestOutputAudioProcess(for: app, in: [moduleHost, host])?.id,
+            host.id)
+    }
+
+    /// The window only has to cover sound a threshold can actually rule out.
+    /// Reconstructed against the 15 s stop debounce, the short false starts in
+    /// the log ran 0.2 s, 7.6 s and 10.8 s.
+    func testConfirmationWindowCoversTheShortObservedFalseStarts() {
+        let window = MeetingDetector.nativeAudioConfirmationWindow
+        let start = Date(timeIntervalSince1970: 0)
+
+        for observed in [0.2, 7.6, 10.8] where observed < window {
+            XCTAssertFalse(MeetingMatcher.sustainedAudioConfirmed(
+                firstSeenAt: start,
+                now: start.addingTimeInterval(observed),
+                window: window),
+                "a \(observed)s stream must not confirm a start")
+        }
+        XCTAssertTrue(MeetingMatcher.sustainedAudioConfirmed(
+            firstSeenAt: start,
+            now: start.addingTimeInterval(window),
+            window: window))
+    }
 }

--- a/LokalBotTests/CalendarDetectionTests.swift
+++ b/LokalBotTests/CalendarDetectionTests.swift
@@ -288,6 +288,35 @@ final class CalendarDetectionTests: XCTestCase {
             bundleID: "us.zoom.xos", calendarBacked: false))
     }
 
+    func testTeamsLaunchBlipDoesNotStartRecordingBeforeConfirmationWindow() {
+        XCTAssertTrue(MeetingDetector.requiresSustainedAudioForStart(
+            bundleID: "com.microsoft.teams2", calendarBacked: false))
+        let firstSeen = Date()
+        XCTAssertFalse(MeetingMatcher.sustainedAudioConfirmed(
+            firstSeenAt: firstSeen,
+            now: firstSeen.addingTimeInterval(3),
+            window: MeetingDetector.nativeAudioConfirmationWindow))
+        XCTAssertTrue(MeetingMatcher.sustainedAudioConfirmed(
+            firstSeenAt: firstSeen,
+            now: firstSeen.addingTimeInterval(MeetingDetector.nativeAudioConfirmationWindow),
+            window: MeetingDetector.nativeAudioConfirmationWindow))
+    }
+
+    func testSustainedAudioIsNotRequiredForDedicatedOrCalendarBackedStarts() {
+        XCTAssertFalse(MeetingDetector.requiresSustainedAudioForStart(
+            bundleID: "us.zoom.xos", calendarBacked: false))
+        XCTAssertFalse(MeetingDetector.requiresSustainedAudioForStart(
+            bundleID: "com.microsoft.teams2", calendarBacked: true))
+        // Browsers carry their own title/calendar gate and never wait here.
+        XCTAssertFalse(MeetingDetector.requiresSustainedAudioForStart(
+            bundleID: "com.google.Chrome", calendarBacked: false))
+    }
+
+    func testSustainedAudioIsUnconfirmedBeforeAnyAudioWasSeen() {
+        XCTAssertFalse(MeetingMatcher.sustainedAudioConfirmed(
+            firstSeenAt: nil, now: Date(), window: 10))
+    }
+
     func testAudioMonitorRequiresCalendarForBroadCommunicationApps() {
         XCTAssertFalse(MeetingDetector.shouldAutoRecordNativeAudioMonitor(
             bundleID: "com.tinyspeck.slackmacgap", calendarBacked: false))


### PR DESCRIPTION
## Summary

Launching Teams is enough to start — and 25 s later end — a complete recording. The Teams helper opens an output stream on launch, so `hasAudio` is true on the tick that follows and `detectRunningMeetingApp(requireAudio: true)` cannot tell that blip apart from a call. This makes broad communication apps prove their audio lasts before the detector starts a recording, reusing the confidence split that already exists for the audio monitor.

Observed seven times over two days on this machine, every one transcribing to nothing:

```
07:01:30  startRecording source=detector app=Teams calendar=none
07:01:33  system audio capture resolved capturePID=40597 captureBundle=com.microsoft.teams2.helper
07:01:56  recording stopped wall=25.79s ... transcription track skipped reason=no-speech
```

The distinction was already modelled, but only on the other path: `shouldAutoRecordNativeAudioMonitor` classes Teams/Slack/FaceTime as apps that make short non-meeting sounds and lets `AudioSourceMonitor` record them only with calendar backing. `MeetingDetector.tick()` never knew about it.

Rather than block those bundles outright — a Teams meeting without a calendar entry is exactly the case this app exists for — `requiresSustainedAudioForStart` derives from that same high-confidence set. Zoom/Webex and anything calendar-backed still start instantly, browsers keep their own title/calendar gate, and only the broad bundles wait out a 5 s window. Audio that stops in between drops the candidate.

Ticks are event-driven plus a 10 s safety poll, so a confirmed candidate would otherwise wait for the next poll boundary; `pendingStartRecheck` schedules the tick for the moment the window closes instead. The timing rule itself lives in `MeetingMatcher` as pure policy, testable without Core Audio.

## Validation

```
xcodegen generate
xcodebuild -project LokalBot.xcodeproj -scheme LokalBot -destination 'platform=macOS' test \
  -only-testing:LokalBotTests/CalendarDetectionTests CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED **  44 tests, 0 failures
```

Three new cases in `CalendarDetectionTests` cover the Teams blip, the exemptions (Zoom, calendar-backed Teams, browsers), and the "no audio seen yet" state.

Run on this branch, i.e. against current `master` — not only on my local stack of other fixes. SwiftLint was not run; it is not installed on this machine.

Not verified end-to-end: reproducing the original false start means launching Teams and waiting for the blip, which I have not done since the change. The unit coverage is on the policy, not on Core Audio.

## Risk / rollout notes

- **A real Teams/Slack/FaceTime meeting without a calendar entry now starts 5 s later**, and those seconds are not captured — there is no pre-roll buffer. Deliberate trade for not recording launch chimes. Joining muted is the worst case: no mic event fires, so the detector's 10 s poll has to notice the audio first, putting the start at up to ~15 s.
- The window is a constant, not a setting. 5 s is a judgement call: my log bounds the observed blip only to somewhere between ~1 and ~10 s, so a longer chime could still slip through. A recurrence is visible as another `source=detector app=Teams` start that transcribes to `no-speech`. Happy to raise it if you would rather bias the other way.
- Confirmation is sampled at ticks, not continuous — audio present at t0 and again at t0+5 s passes even if it stopped in between, unless an intervening tick observes the gap.
- No changes to `project.yml`, settings, storage schema, or TCC.

Refs #43
