### PR TITLE
Let an explicit Transcribe click turn summarization off

### DIFF
--- a/LokalBot/AppState.swift
+++ b/LokalBot/AppState.swift
@@ -1128,7 +1128,8 @@ final class AppState: ObservableObject {
     /// succeeded, Retry fixes only summarization; missing transcripts still run
     /// the complete pipeline. User-initiated work may download missing models.
     func retryProcessing(_ meeting: Meeting) {
-        let work = ProcessingPipeline.retryWork(for: meeting, storage: storage)
+        let work = ProcessingPipeline.retryWork(
+            for: meeting, storage: storage, autoSummarize: settings.autoSummarize)
         reprocess(meeting, transcribe: work.transcribe, summarize: work.summarize)
     }
 

--- a/LokalBot/Services/ProcessingPipeline.swift
+++ b/LokalBot/Services/ProcessingPipeline.swift
@@ -91,15 +91,26 @@ final class ProcessingPipeline: ObservableObject {
     /// A completed transcript is the durable boundary between the expensive
     /// ASR stage and summarization. Row-level Retry can safely resume after it
     /// instead of re-transcribing audio that already succeeded.
+    ///
+    /// Retry repeats the work the meeting was enqueued for, so it follows
+    /// `autoSummarize`: someone who records transcript-only never asked for a
+    /// summary, and Retry hardcoding one produced a surprise summarization run
+    /// after a failed transcribe-only attempt.
     nonisolated static func retryWork(
         for meeting: Meeting,
-        storage: StorageManager
+        storage: StorageManager,
+        autoSummarize: Bool
     ) -> RetryWork {
         let transcriptURL = meeting.folderURL(in: storage)
             .appendingPathComponent("transcript.json")
+        let needsTranscript = !FileManager.default.fileExists(atPath: transcriptURL.path)
+        // With summaries off and a transcript already on disk there is no
+        // later stage left to resume, and a Retry that requests nothing would
+        // just clear the badge. Re-run ASR — the only work such a library
+        // has — rather than quietly turning Retry into "summarize".
         return RetryWork(
-            transcribe: !FileManager.default.fileExists(atPath: transcriptURL.path),
-            summarize: true)
+            transcribe: needsTranscript || !autoSummarize,
+            summarize: autoSummarize)
     }
 
     /// Injectable model-readiness checks so unit tests can exercise the
@@ -153,21 +164,53 @@ final class ProcessingPipeline: ObservableObject {
         self.automationReadiness = automationReadiness
     }
 
+    /// One job's requested work, and how a fresh enqueue combines with work
+    /// already queued or parked for the same meeting.
+    struct Work: Equatable {
+        var transcribe: Bool
+        var summarize: Bool
+    }
+
+    /// Transcription merges by OR — it is the prerequisite for everything
+    /// downstream, so a pending one must never be dropped. Summarization does
+    /// not: it is the discretionary half, and OR-ing it let a queued job
+    /// silently upgrade an explicit "Transcribe" click into "Transcribe &
+    /// Summarize". A user-initiated enqueue states the summary intent
+    /// outright and the older job defers to it; automatic work still merges,
+    /// so a parked summary survives an auto re-enqueue. Pure, so the
+    /// escalation rule is testable without a live queue.
+    nonisolated static func merged(pending: Work, incoming: Work,
+                                   origin: JobOrigin) -> Work {
+        Work(
+            transcribe: pending.transcribe || incoming.transcribe,
+            summarize: origin == .userInitiated
+                ? incoming.summarize
+                : pending.summarize || incoming.summarize)
+    }
+
     func enqueue(_ meeting: Meeting, transcribe: Bool = true, summarize: Bool = true,
                  origin: JobOrigin = .userInitiated) {
         // A fresh enqueue supersedes a parked waiting-for-models job: merge its
         // requested work so the new attempt (and its origin) covers both.
-        var transcribe = transcribe
-        var summarize = summarize
+        var work = Work(transcribe: transcribe, summarize: summarize)
         if let waitingIndex = waitingForModelsJobs.firstIndex(
             where: { $0.meeting.id == meeting.id }) {
             let waiting = waitingForModelsJobs.remove(at: waitingIndex)
-            transcribe = transcribe || waiting.transcribe
-            summarize = summarize || waiting.summarize
+            work = Self.merged(
+                pending: .init(transcribe: waiting.transcribe, summarize: waiting.summarize),
+                incoming: work,
+                origin: origin)
         }
+        let transcribe = work.transcribe
+        let summarize = work.summarize
         if let index = queue.firstIndex(where: { $0.meeting.id == meeting.id }) {
-            let mergedTranscribe = queue[index].transcribe || transcribe
-            let mergedSummarize = queue[index].summarize || summarize
+            let coalesced = Self.merged(
+                pending: .init(transcribe: queue[index].transcribe,
+                               summarize: queue[index].summarize),
+                incoming: work,
+                origin: origin)
+            let mergedTranscribe = coalesced.transcribe
+            let mergedSummarize = coalesced.summarize
             if let jobStore,
                !jobStore.enqueue(
                     meetingID: meeting.id,
@@ -180,7 +223,9 @@ final class ProcessingPipeline: ObservableObject {
             queue[index].summarize = mergedSummarize
             queue[index].resumed = false
             if origin == .userInitiated { queue[index].origin = .userInitiated }
-            lokalbotLog("pipeline coalesced queued meeting=\(meeting.id)")
+            lokalbotLog(
+                "pipeline coalesced queued meeting=\(meeting.id) "
+                    + "transcribe=\(mergedTranscribe) summarize=\(mergedSummarize)")
             return
         }
         guard activeMeetingID != meeting.id else {
@@ -195,6 +240,9 @@ final class ProcessingPipeline: ObservableObject {
         }
         queue.append(Job(meeting: meeting, transcribe: transcribe, summarize: summarize,
                          origin: origin))
+        lokalbotLog(
+            "pipeline enqueued meeting=\(meeting.id) transcribe=\(transcribe) "
+                + "summarize=\(summarize) origin=\(origin == .userInitiated ? "user" : "auto")")
         stages[meeting.id] = .queued
         drain()
     }

--- a/LokalBotTests/ProcessingPipelineAutomationGateTests.swift
+++ b/LokalBotTests/ProcessingPipelineAutomationGateTests.swift
@@ -132,6 +132,42 @@ final class ProcessingPipelineAutomationGateTests: XCTestCase {
                        "the parked copy must not linger after an explicit retry")
     }
 
+    /// Pressing "Transcribe" must stay transcribe-only even when a job for the
+    /// same meeting is already queued or parked asking for a summary.
+    func testUserInitiatedEnqueueDoesNotInheritAQueuedSummary() {
+        let pending = ProcessingPipeline.Work(transcribe: true, summarize: true)
+
+        let user = ProcessingPipeline.merged(
+            pending: pending,
+            incoming: .init(transcribe: true, summarize: false),
+            origin: .userInitiated)
+
+        XCTAssertEqual(user, .init(transcribe: true, summarize: false))
+    }
+
+    /// The opposite direction still merges: automatic re-enqueues (launch
+    /// resume, a model finishing its download) must not drop a parked summary.
+    func testAutomaticEnqueueStillMergesPendingWork() {
+        let automatic = ProcessingPipeline.merged(
+            pending: .init(transcribe: false, summarize: true),
+            incoming: .init(transcribe: true, summarize: false),
+            origin: .automatic)
+
+        XCTAssertEqual(automatic, .init(transcribe: true, summarize: true))
+    }
+
+    /// Transcription is the prerequisite for everything downstream, so it
+    /// merges by OR regardless of who asked: "Re-summarize" on a meeting whose
+    /// transcript is still queued must not cancel that transcription.
+    func testTranscriptionIsNeverDroppedByAUserChoice() {
+        let work = ProcessingPipeline.merged(
+            pending: .init(transcribe: true, summarize: false),
+            incoming: .init(transcribe: false, summarize: true),
+            origin: .userInitiated)
+
+        XCTAssertEqual(work, .init(transcribe: true, summarize: true))
+    }
+
     func testRetryWorkResumesAfterExistingTranscript() throws {
         let root = try makeRoot()
         let storage = StorageManager(rootURL: root)
@@ -140,7 +176,8 @@ final class ProcessingPipelineAutomationGateTests: XCTestCase {
 
         let missingTranscript = ProcessingPipeline.retryWork(
             for: meeting,
-            storage: storage)
+            storage: storage,
+            autoSummarize: true)
         XCTAssertEqual(
             missingTranscript,
             .init(transcribe: true, summarize: true))
@@ -153,10 +190,32 @@ final class ProcessingPipelineAutomationGateTests: XCTestCase {
 
         let existingTranscript = ProcessingPipeline.retryWork(
             for: meeting,
-            storage: storage)
+            storage: storage,
+            autoSummarize: true)
         XCTAssertEqual(
             existingTranscript,
             .init(transcribe: false, summarize: true))
+    }
+
+    /// Retry must never invent a summarization run for a library that records
+    /// transcripts only — it re-runs ASR instead.
+    func testRetryWorkNeverSummarizesWhenAutoSummarizeIsOff() throws {
+        let root = try makeRoot()
+        let storage = StorageManager(rootURL: root)
+        let meeting = makeMeeting()
+        let folder = meeting.folderURL(in: storage)
+        try FileManager.default.createDirectory(
+            at: folder,
+            withIntermediateDirectories: true)
+        try Data("{}".utf8).write(
+            to: folder.appendingPathComponent("transcript.json"))
+
+        let work = ProcessingPipeline.retryWork(
+            for: meeting,
+            storage: storage,
+            autoSummarize: false)
+
+        XCTAssertEqual(work, .init(transcribe: true, summarize: false))
     }
 
     func testAutomaticSummaryParksButKeepsExistingTranscript() async throws {


### PR DESCRIPTION
Addresses the first of the three paths named in #46. **The issue should stay open** — see *Scope* below.

### The bug

`enqueue` coalesces pending and incoming work by OR-ing both flags:

```swift
let mergedSummarize = queue[index].summarize || summarize
```

That is right for `transcribe` — it is the prerequisite for everything downstream, so a pending one must never be dropped. It is wrong for `summarize`, the discretionary half: clicking **Transcribe** on a meeting that already had a summary job queued or parked produced a summary anyway, silently, and nothing in the UI said why. Summarization is expensive, so this is not a cosmetic surprise.

### The change

`merged(pending:incoming:origin:)` is a pure function, so the escalation rule is testable without a live queue:

- `transcribe` still merges by OR.
- `summarize` follows the newer intent **when the enqueue is user-initiated** — an explicit click states what it wants and the older job defers to it.
- Automatic work still merges as before, so a summary parked for a missing Think model survives an auto re-enqueue.

`retryWork` had the same shape at one remove: it asked for a summary regardless of `autoSummarize`, so a Retry could summarize for someone who had turned that off. It now takes the setting. With summaries off and a transcript already on disk there is no later stage to resume, so Retry re-runs ASR — the only work such a library has — rather than quietly becoming "summarize".

The two enqueue paths also log their resolved flags now; the report had to reach for `sqlite3` to see what the queue actually held.

### Scope — what this does *not* fix

The report names three paths, and this covers one. Deliberately not closing the issue:

1. ✅ **Queued / parked merge** — this PR.
2. ❌ **Dropped while active** — `guard activeMeetingID != meeting.id` still returns without applying the request or telling anyone. This is the path the reporter actually hit (`pipeline duplicate ignored while active` in their log), and fixing it means letting a user-initiated transcribe-only request reach a job that is already running, plus surfacing "already processing" in the UI.
3. ❌ **Resumed jobs** — a job restored from `pipeline_jobs` still carries the `summarize` flag it was stored with, so turning auto-summarize off does not affect pending work.

Happy to do 2 and 3 as a follow-up; 2 touches the active-job lifecycle and wants its own review.

### Tests

Full suite green: 1637 tests, 0 failures. 4 new, covering the user-initiated downgrade, the automatic merge that must still escalate, and both `retryWork` branches.
