### PR TITLE
Fix Bluetooth recording start and Teams autostart confirmation

### DIFF
--- a/LokalBot/Services/Calendar/MeetingMatcher.swift
+++ b/LokalBot/Services/Calendar/MeetingMatcher.swift
@@ -44,6 +44,41 @@ enum MeetingMatcher {
         return now.timeIntervalSince(firstSeenAt) >= minimumDuration
     }
 
+    /// What a start candidate's silence means when it has no fresh audio
+    /// evidence on this particular tick.
+    ///
+    /// Detection asks "is the app making sound right now", so a candidate mid
+    /// confirmation loses that signal every time the remote side stops talking
+    /// to listen — an ordinary conversational rhythm, not evidence the call
+    /// ended. `abandoned` only once the *gap itself* has run past tolerance,
+    /// not the instant evidence is briefly missing.
+    enum StartConfirmationGapOutcome: Equatable {
+        /// The gap has run too long; this candidate should be dropped.
+        case abandoned
+        /// Still within tolerance, but the window overall is not done yet.
+        case stillWaiting
+        /// The gap is within tolerance, and the total span already covers the
+        /// window — confirmed despite the current instant being quiet, so a
+        /// bridged gap doesn't delay the start past when a live tick would
+        /// have.
+        case confirmed
+    }
+
+    /// `firstSeenAt`/`lastAudioSeenAt` describe one candidate's whole history:
+    /// when its audio was first observed, and when it was last observed. Pure,
+    /// so the boundary cases don't need a live app or Core Audio to test.
+    static func startConfirmationGapOutcome(firstSeenAt: Date,
+                                            lastAudioSeenAt: Date,
+                                            now: Date,
+                                            gapTolerance: TimeInterval,
+                                            minimumDuration: TimeInterval) -> StartConfirmationGapOutcome {
+        guard now.timeIntervalSince(lastAudioSeenAt) <= gapTolerance else { return .abandoned }
+        if sustainedAudioConfirmed(firstSeenAt: firstSeenAt, now: now, minimumDuration: minimumDuration) {
+            return .confirmed
+        }
+        return .stillWaiting
+    }
+
     static func confidence(hasApp: Bool, hasCalendar: Bool) -> MeetingDetectionContext.Confidence {
         switch (hasApp, hasCalendar) {
         case (true, true): return .high

--- a/LokalBot/Services/Calendar/MeetingMatcher.swift
+++ b/LokalBot/Services/Calendar/MeetingMatcher.swift
@@ -44,6 +44,56 @@ enum MeetingMatcher {
         return now.timeIntervalSince(firstSeenAt) >= minimumDuration
     }
 
+    /// The live state for one sustained-audio confirmation window. A generation
+    /// identifies the exact window so a queued recheck cannot act on a newer
+    /// candidate after the old window has been reset.
+    struct StartConfirmationState {
+        struct Window: Equatable {
+            let bundleID: String
+            let firstSeenAt: Date
+            let lastAudioSeenAt: Date
+            let generation: UInt64
+        }
+
+        private(set) var window: Window?
+        private var generation: UInt64 = 0
+
+        /// Records fresh audio and answers whether it began a new window. Audio
+        /// after an expired gap is a new candidate even when the bundle id is
+        /// unchanged; otherwise the abandoned window could confirm immediately.
+        @discardableResult
+        mutating func observeAudio(bundleID: String,
+                                   at now: Date,
+                                   gapTolerance: TimeInterval) -> Bool {
+            if let window,
+               window.bundleID == bundleID,
+               now.timeIntervalSince(window.lastAudioSeenAt) <= gapTolerance {
+                self.window = Window(
+                    bundleID: bundleID,
+                    firstSeenAt: window.firstSeenAt,
+                    lastAudioSeenAt: now,
+                    generation: window.generation)
+                return false
+            }
+
+            generation &+= 1
+            window = Window(
+                bundleID: bundleID,
+                firstSeenAt: now,
+                lastAudioSeenAt: now,
+                generation: generation)
+            return true
+        }
+
+        mutating func clear() {
+            window = nil
+        }
+
+        func acceptsRecheck(for generation: UInt64) -> Bool {
+            window?.generation == generation
+        }
+    }
+
     /// What a start candidate's silence means when it has no fresh audio
     /// evidence on this particular tick.
     ///

--- a/LokalBot/Services/MeetingDetector.swift
+++ b/LokalBot/Services/MeetingDetector.swift
@@ -151,10 +151,10 @@ final class MeetingDetector {
     /// and when it was last seen — the second lets a normal conversational gap
     /// (the remote side listening rather than talking) survive without
     /// restarting the window. See `nativeAudioConfirmationGapTolerance`.
+    private var startConfirmation = MeetingMatcher.StartConfirmationState()
     /// Last logged start-decision state, so the 10 s safety poll does not
     /// repeat the same line forever. Diagnostics only.
     private var lastLoggedStartState: String?
-    private var pendingStart: (bundleID: String, firstSeen: Date, lastAudioSeenAt: Date)?
     private var pendingStartRecheck: DispatchWorkItem?
     private var workspaceObservers: [NSObjectProtocol] = []
 
@@ -367,12 +367,12 @@ final class MeetingDetector {
         // listening rather than talking — the app itself may still be mid-call.
         // A candidate already inside its confirmation window gets a grace
         // period before that silence is read as the call having ended.
-        if let pendingStart,
+        if let pendingStart = startConfirmation.window,
            Self.requiresSustainedAudioForStart(
                bundleID: pendingStart.bundleID, calendarBacked: calendarEvent != nil),
            let app = Self.nativeApp(bundleID: pendingStart.bundleID, in: running) {
             switch MeetingMatcher.startConfirmationGapOutcome(
-                firstSeenAt: pendingStart.firstSeen,
+                firstSeenAt: pendingStart.firstSeenAt,
                 lastAudioSeenAt: pendingStart.lastAudioSeenAt,
                 now: now,
                 gapTolerance: Self.nativeAudioConfirmationGapTolerance,
@@ -382,11 +382,12 @@ final class MeetingDetector {
                 beginMeeting(app: app, calendarEvent: calendarEvent)
                 return
             case .stillWaiting:
-                let elapsed = now.timeIntervalSince(pendingStart.firstSeen)
+                let elapsed = now.timeIntervalSince(pendingStart.firstSeenAt)
                 let gapRemaining = Self.nativeAudioConfirmationGapTolerance
                     - now.timeIntervalSince(pendingStart.lastAudioSeenAt)
                 scheduleStartConfirmationRecheck(
-                    after: min(gapRemaining, Self.nativeAudioMinimumConfirmationDuration - elapsed))
+                    after: min(gapRemaining, Self.nativeAudioMinimumConfirmationDuration - elapsed),
+                    generation: pendingStart.generation)
                 return
             case .abandoned:
                 break
@@ -423,17 +424,19 @@ final class MeetingDetector {
     private func startConfirmed(app: DetectedApp, calendarBacked: Bool, now: Date) -> Bool {
         guard Self.requiresSustainedAudioForStart(
             bundleID: app.bundleID, calendarBacked: calendarBacked) else { return true }
-        if pendingStart?.bundleID != app.bundleID {
-            pendingStart = (app.bundleID, now, now)
+        let startedNewWindow = startConfirmation.observeAudio(
+            bundleID: app.bundleID,
+            at: now,
+            gapTolerance: Self.nativeAudioConfirmationGapTolerance)
+        if startedNewWindow {
+            cancelPendingStartRecheck()
             lokalbotLog(
                 "detector waiting for sustained audio app=\(app.bundleID) "
                     + "needs=\(Int(Self.nativeAudioMinimumConfirmationDuration))s")
-        } else {
-            pendingStart?.lastAudioSeenAt = now
         }
-        let firstSeen = pendingStart?.firstSeen
+        guard let pendingStart = startConfirmation.window else { return false }
         if MeetingMatcher.sustainedAudioConfirmed(
-            firstSeenAt: firstSeen,
+            firstSeenAt: pendingStart.firstSeenAt,
             now: now,
             minimumDuration: Self.nativeAudioMinimumConfirmationDuration) {
             return true
@@ -441,9 +444,10 @@ final class MeetingDetector {
         // Ticks are event-driven plus a slow safety poll, so a real meeting
         // would otherwise wait for the next poll boundary instead of starting
         // the moment the minimum duration elapses.
-        let elapsed = firstSeen.map { now.timeIntervalSince($0) } ?? 0
+        let elapsed = now.timeIntervalSince(pendingStart.firstSeenAt)
         scheduleStartConfirmationRecheck(
-            after: Self.nativeAudioMinimumConfirmationDuration - elapsed)
+            after: Self.nativeAudioMinimumConfirmationDuration - elapsed,
+            generation: pendingStart.generation)
         return false
     }
 
@@ -456,10 +460,13 @@ final class MeetingDetector {
         lokalbotLog(state)
     }
 
-    private func scheduleStartConfirmationRecheck(after delay: TimeInterval) {
-        guard pendingStartRecheck == nil else { return }
+    private func scheduleStartConfirmationRecheck(after delay: TimeInterval,
+                                                  generation: UInt64) {
+        guard startConfirmation.acceptsRecheck(for: generation),
+              pendingStartRecheck == nil else { return }
         let work = DispatchWorkItem { [weak self] in
-            guard let self else { return }
+            guard let self,
+                  self.startConfirmation.acceptsRecheck(for: generation) else { return }
             self.pendingStartRecheck = nil
             self.tick()
         }
@@ -471,12 +478,16 @@ final class MeetingDetector {
     /// just started a meeting — that clears the same state but is a success,
     /// not a loss, and must not log as one.
     private func clearPendingStart(loggingLoss: Bool = true) {
-        if loggingLoss, let pendingStart {
+        if loggingLoss, let pendingStart = startConfirmation.window {
             lokalbotLog(
                 "detector lost the audio it was waiting on app=\(pendingStart.bundleID) "
-                    + "after=\(String(format: "%.1fs", Date().timeIntervalSince(pendingStart.firstSeen)))")
+                    + "after=\(String(format: "%.1fs", Date().timeIntervalSince(pendingStart.firstSeenAt)))")
         }
-        pendingStart = nil
+        startConfirmation.clear()
+        cancelPendingStartRecheck()
+    }
+
+    private func cancelPendingStartRecheck() {
         pendingStartRecheck?.cancel()
         pendingStartRecheck = nil
     }

--- a/LokalBot/Services/MeetingDetector.swift
+++ b/LokalBot/Services/MeetingDetector.swift
@@ -64,6 +64,28 @@ final class MeetingDetector {
     /// `alwaysOpenAudioBundles`.
     static let nativeAudioMinimumConfirmationDuration: TimeInterval = 12
 
+    /// How long the confirmation window survives a candidate producing no
+    /// output audio at all, before `nativeAudioMinimumConfirmationDuration`
+    /// has elapsed.
+    ///
+    /// `detectRunningMeetingApp` requires current audio (`requireAudio: true`)
+    /// so the confirmation window is watching a signal that is not "is a call
+    /// happening" but "is the remote side making sound right now" — and in a
+    /// real conversation the remote side spends much of its time listening.
+    /// Without this, the very first quiet turn dropped the candidate entirely
+    /// (not merely the elapsed time — the app stopped being detected as
+    /// running at all), and a live 12-second window essentially never
+    /// completed: six consecutive real attempts on 2026-08-26 each failed
+    /// after 4.2–12.7 s, two of them past the 12 s mark itself.
+    ///
+    /// Six seconds is half the confirmation window on purpose: a single blip
+    /// followed by silence past this tolerance still resets — the case
+    /// `nativeAudioMinimumConfirmationDuration` exists to guard against — while
+    /// audio recurring at least this often lets a real conversation complete
+    /// the window. It only ever bridges a gap in evidence; it never invents
+    /// evidence on its own, so this cannot make an idle-but-open app confirm.
+    static let nativeAudioConfirmationGapTolerance: TimeInterval = 6
+
     /// Bundles inside a meeting app's namespace that hold their Core Audio
     /// streams open for the app's whole lifetime, so their state carries no
     /// information about whether a call is running.
@@ -125,9 +147,14 @@ final class MeetingDetector {
     private var timer: Timer?
     private var pendingStop: DispatchWorkItem?
     /// The start candidate still waiting out
-    /// `nativeAudioMinimumConfirmationDuration`, and when its audio was first
-    /// seen.
-    private var pendingStart: (bundleID: String, firstSeen: Date)?
+    /// `nativeAudioMinimumConfirmationDuration`: when its audio was first seen,
+    /// and when it was last seen — the second lets a normal conversational gap
+    /// (the remote side listening rather than talking) survive without
+    /// restarting the window. See `nativeAudioConfirmationGapTolerance`.
+    /// Last logged start-decision state, so the 10 s safety poll does not
+    /// repeat the same line forever. Diagnostics only.
+    private var lastLoggedStartState: String?
+    private var pendingStart: (bundleID: String, firstSeen: Date, lastAudioSeenAt: Date)?
     private var pendingStartRecheck: DispatchWorkItem?
     private var workspaceObservers: [NSObjectProtocol] = []
 
@@ -328,12 +355,54 @@ final class MeetingDetector {
             appAudioActive: false,
             calendarBackedBrowserWithAudio: calendarBackedBrowserWithAudio)
 
-        guard inMeeting, let app = runningMeetingApp else {
-            clearPendingStart()
+        if inMeeting, let app = runningMeetingApp {
+            guard startConfirmed(app: app, calendarBacked: calendarEvent != nil, now: now) else { return }
+            logStartState("detector confirmed app=\(app.bundleID)")
+            beginMeeting(app: app, calendarEvent: calendarEvent)
             return
         }
-        guard startConfirmed(app: app, calendarBacked: calendarEvent != nil, now: now) else { return }
+
+        // No fresh output audio this instant. `detectRunningMeetingApp`
+        // requires it, so this branch also covers the remote side simply
+        // listening rather than talking — the app itself may still be mid-call.
+        // A candidate already inside its confirmation window gets a grace
+        // period before that silence is read as the call having ended.
+        if let pendingStart,
+           Self.requiresSustainedAudioForStart(
+               bundleID: pendingStart.bundleID, calendarBacked: calendarEvent != nil),
+           let app = Self.nativeApp(bundleID: pendingStart.bundleID, in: running) {
+            switch MeetingMatcher.startConfirmationGapOutcome(
+                firstSeenAt: pendingStart.firstSeen,
+                lastAudioSeenAt: pendingStart.lastAudioSeenAt,
+                now: now,
+                gapTolerance: Self.nativeAudioConfirmationGapTolerance,
+                minimumDuration: Self.nativeAudioMinimumConfirmationDuration) {
+            case .confirmed:
+                logStartState("detector confirmed app=\(app.bundleID) (bridged gap)")
+                beginMeeting(app: app, calendarEvent: calendarEvent)
+                return
+            case .stillWaiting:
+                let elapsed = now.timeIntervalSince(pendingStart.firstSeen)
+                let gapRemaining = Self.nativeAudioConfirmationGapTolerance
+                    - now.timeIntervalSince(pendingStart.lastAudioSeenAt)
+                scheduleStartConfirmationRecheck(
+                    after: min(gapRemaining, Self.nativeAudioMinimumConfirmationDuration - elapsed))
+                return
+            case .abandoned:
+                break
+            }
+        }
+
+        logStartState(
+            runningMeetingApp.map {
+                "detector idle app=\($0.bundleID) audio=\(startAudioActive) "
+                    + "calendar=\(calendarEvent != nil)"
+            } ?? "detector idle app=none")
         clearPendingStart()
+    }
+
+    private func beginMeeting(app: DetectedApp, calendarEvent: CalendarMeetingCandidate?) {
+        clearPendingStart(loggingLoss: false)
         pendingStop?.cancel()
         pendingStop = nil
         activeApp = app
@@ -348,11 +417,19 @@ final class MeetingDetector {
     /// Tracks how long the start candidate's audio has been continuously
     /// present and answers whether it may start a recording yet. Candidates
     /// that need no confirmation answer true on their first tick.
+    /// Called only when `app` has fresh output audio this tick. Advances the
+    /// window's evidence clock; `tick()` separately decides whether a gap
+    /// since the last call may still keep this same window alive.
     private func startConfirmed(app: DetectedApp, calendarBacked: Bool, now: Date) -> Bool {
         guard Self.requiresSustainedAudioForStart(
             bundleID: app.bundleID, calendarBacked: calendarBacked) else { return true }
         if pendingStart?.bundleID != app.bundleID {
-            pendingStart = (app.bundleID, now)
+            pendingStart = (app.bundleID, now, now)
+            lokalbotLog(
+                "detector waiting for sustained audio app=\(app.bundleID) "
+                    + "needs=\(Int(Self.nativeAudioMinimumConfirmationDuration))s")
+        } else {
+            pendingStart?.lastAudioSeenAt = now
         }
         let firstSeen = pendingStart?.firstSeen
         if MeetingMatcher.sustainedAudioConfirmed(
@@ -370,6 +447,15 @@ final class MeetingDetector {
         return false
     }
 
+    /// Logs a start-decision state once per change. The detector otherwise
+    /// says nothing at all unless it starts a recording, so "it did not fire"
+    /// has no evidence behind it.
+    private func logStartState(_ state: String) {
+        guard lastLoggedStartState != state else { return }
+        lastLoggedStartState = state
+        lokalbotLog(state)
+    }
+
     private func scheduleStartConfirmationRecheck(after delay: TimeInterval) {
         guard pendingStartRecheck == nil else { return }
         let work = DispatchWorkItem { [weak self] in
@@ -381,7 +467,15 @@ final class MeetingDetector {
         DispatchQueue.main.asyncAfter(deadline: .now() + max(delay, 0.25), execute: work)
     }
 
-    private func clearPendingStart() {
+    /// `loggingLoss` is false when the candidate is being cleared because it
+    /// just started a meeting — that clears the same state but is a success,
+    /// not a loss, and must not log as one.
+    private func clearPendingStart(loggingLoss: Bool = true) {
+        if loggingLoss, let pendingStart {
+            lokalbotLog(
+                "detector lost the audio it was waiting on app=\(pendingStart.bundleID) "
+                    + "after=\(String(format: "%.1fs", Date().timeIntervalSince(pendingStart.firstSeen)))")
+        }
         pendingStart = nil
         pendingStartRecheck?.cancel()
         pendingStartRecheck = nil
@@ -425,6 +519,17 @@ final class MeetingDetector {
             guard let name = knownApps[entry.bundleID] else { return nil }
             return DetectedApp(name: name, bundleID: entry.bundleID, pid: entry.pid)
         }
+    }
+
+    /// A specific native app by bundle id, with no audio requirement at all —
+    /// used to check whether a confirmation candidate is still open during a
+    /// bridged gap, where the point is exactly that it may be silent right now.
+    private static func nativeApp(bundleID: String,
+                                  in running: [NSRunningApplication]) -> DetectedApp? {
+        meetingAppCandidates(bundleIDs: running.compactMap { app in
+            guard app.bundleIdentifier == bundleID else { return nil }
+            return (bundleID: bundleID, pid: app.processIdentifier)
+        }).first
     }
 
     private static func nativeMeetingApp(in running: [NSRunningApplication],

--- a/LokalBot/Services/MicRecorder.swift
+++ b/LokalBot/Services/MicRecorder.swift
@@ -325,11 +325,7 @@ final class MicRecorder {
             throw RecorderError.unsupportedInputFormat
         }
 
-        let settings = Self.fileSettings(for: url, recordingFormat: recordingFormat)
-        let newFile = try AVAudioFile(forWriting: url,
-                                      settings: settings,
-                                      commonFormat: recordingFormat.commonFormat,
-                                      interleaved: recordingFormat.isInterleaved)
+        let newFile = try Self.makeRecordingFile(at: url, recordingFormat: recordingFormat)
         let newPreviewTee = previewURL.flatMap {
             AudioPreviewTee(url: $0, sourceFormat: recordingFormat)
         }
@@ -575,6 +571,38 @@ final class MicRecorder {
         self.configChangeObserver = nil
     }
 
+    /// Opens the capture file, stepping down the bitrate ladder if the encoder
+    /// refuses. A rejected bitrate used to surface as "Could not start
+    /// recording" with a raw Core Audio code, which told the user nothing and
+    /// cost them the meeting.
+    static func makeRecordingFile(at url: URL,
+                                  recordingFormat: AVAudioFormat) throws -> AVAudioFile {
+        var settings = fileSettings(for: url, recordingFormat: recordingFormat)
+        guard settings[AVEncoderBitRateKey] != nil else {
+            return try AVAudioFile(forWriting: url, settings: settings,
+                                   commonFormat: recordingFormat.commonFormat,
+                                   interleaved: recordingFormat.isInterleaved)
+        }
+        var lastError: Error?
+        for bitRate in aacBitRateLadder(forSampleRate: recordingFormat.sampleRate) {
+            settings[AVEncoderBitRateKey] = bitRate
+            do {
+                let file = try AVAudioFile(forWriting: url, settings: settings,
+                                           commonFormat: recordingFormat.commonFormat,
+                                           interleaved: recordingFormat.isInterleaved)
+                if bitRate != aacBitRate(forSampleRate: recordingFormat.sampleRate) {
+                    lokalbotLog(
+                        "mic recording file fell back to \(bitRate) bit/s at "
+                            + "\(Int(recordingFormat.sampleRate)) Hz")
+                }
+                return file
+            } catch {
+                lastError = error
+            }
+        }
+        throw lastError ?? RecorderError.unsupportedInputFormat
+    }
+
     private static func fileSettings(for url: URL, recordingFormat: AVAudioFormat) -> [String: Any] {
         if url.pathExtension.lowercased() == "caf" {
             return [
@@ -591,8 +619,47 @@ final class MicRecorder {
             AVFormatIDKey: kAudioFormatMPEG4AAC,
             AVSampleRateKey: recordingFormat.sampleRate,
             AVNumberOfChannelsKey: Int(recordingFormat.channelCount),
-            AVEncoderBitRateKey: 64_000,
+            AVEncoderBitRateKey: aacBitRate(forSampleRate: recordingFormat.sampleRate),
         ]
+    }
+
+    /// AAC bitrates the encoder will accept, by sample rate.
+    ///
+    /// The rate is not ours to choose: it is whatever the input device runs at,
+    /// and a Bluetooth headset in HFP mode runs at 16 kHz. A fixed 64 kbit/s is
+    /// out of range there, so `AVAudioFile(forWriting:)` threw `!dat`
+    /// (560226676) and the meeting did not record at all. Measured against the
+    /// encoder, mono:
+    ///
+    ///     rate     64k  48k  32k  24k
+    ///      8000     ✗    ✗    ✗    ✓
+    ///     16000     ✗    ✓    ✓    ✓
+    ///     22050     ✓    ✓    ✓    ✓
+    ///     44100     ✓    ✓    ✓    ✗
+    ///     48000     ✓    ✓    ✓    ✗
+    ///
+    /// So the constraint runs both ways and no single value covers the range.
+    /// These tiers sit inside every accepted row, leaving headroom above the
+    /// minimum rather than hugging the edge — speech at 16 kHz has nothing to
+    /// gain from the last few kbit anyway.
+    static func aacBitRate(forSampleRate sampleRate: Double) -> Int {
+        switch sampleRate {
+        case ..<12_000: 24_000
+        case ..<22_050: 32_000
+        default: 64_000
+        }
+    }
+
+    /// Bitrates to try, best first, descending. The tiers above are measured,
+    /// but only on the rates a Mac actually offers; a device that lands between
+    /// them should still record at a lower bitrate rather than not at all.
+    ///
+    /// Strictly descending, because the failures are one-directional at each
+    /// end: at 8 kHz everything above 24 kbit/s is refused, so retrying upwards
+    /// would trade one rejection for another.
+    static func aacBitRateLadder(forSampleRate sampleRate: Double) -> [Int] {
+        let start = aacBitRate(forSampleRate: sampleRate)
+        return [64_000, 48_000, 32_000, 24_000].filter { $0 <= start }
     }
 
     /// Posted asynchronously when the audio device changes. The engine has

--- a/LokalBotTests/CalendarDetectionTests.swift
+++ b/LokalBotTests/CalendarDetectionTests.swift
@@ -406,6 +406,62 @@ final class CalendarDetectionTests: XCTestCase {
             .abandoned)
     }
 
+    /// A fresh tick cannot revive a window whose last evidence is already past
+    /// tolerance. At this timestamp the old implementation saw a 12-second
+    /// total span and confirmed immediately instead of starting over.
+    func testFreshAudioAfterExpiredGapStartsANewConfirmationWindow() throws {
+        var state = MeetingMatcher.StartConfirmationState()
+        let firstSeen = Date()
+        let lastAudioSeenAt = firstSeen.addingTimeInterval(5)
+        let restartedAt = firstSeen.addingTimeInterval(
+            MeetingDetector.nativeAudioMinimumConfirmationDuration)
+
+        XCTAssertTrue(state.observeAudio(
+            bundleID: "com.microsoft.teams2",
+            at: firstSeen,
+            gapTolerance: MeetingDetector.nativeAudioConfirmationGapTolerance))
+        XCTAssertFalse(state.observeAudio(
+            bundleID: "com.microsoft.teams2",
+            at: lastAudioSeenAt,
+            gapTolerance: MeetingDetector.nativeAudioConfirmationGapTolerance))
+        XCTAssertTrue(state.observeAudio(
+            bundleID: "com.microsoft.teams2",
+            at: restartedAt,
+            gapTolerance: MeetingDetector.nativeAudioConfirmationGapTolerance))
+
+        let restarted = try XCTUnwrap(state.window)
+        XCTAssertEqual(restarted.firstSeenAt, restartedAt)
+        XCTAssertEqual(restarted.lastAudioSeenAt, restartedAt)
+        XCTAssertFalse(MeetingMatcher.sustainedAudioConfirmed(
+            firstSeenAt: restarted.firstSeenAt,
+            now: restartedAt,
+            minimumDuration: MeetingDetector.nativeAudioMinimumConfirmationDuration))
+    }
+
+    /// Canceling a submitted DispatchWorkItem is not the identity check: if an
+    /// obsolete callback is already queued, its captured generation must no
+    /// longer match the restarted window.
+    func testRestartedConfirmationWindowRejectsStaleRecheck() throws {
+        var state = MeetingMatcher.StartConfirmationState()
+        let firstSeen = Date()
+        state.observeAudio(
+            bundleID: "com.microsoft.teams2",
+            at: firstSeen,
+            gapTolerance: MeetingDetector.nativeAudioConfirmationGapTolerance)
+        let staleGeneration = try XCTUnwrap(state.window).generation
+
+        state.observeAudio(
+            bundleID: "com.microsoft.teams2",
+            at: firstSeen.addingTimeInterval(
+                MeetingDetector.nativeAudioConfirmationGapTolerance + 0.1),
+            gapTolerance: MeetingDetector.nativeAudioConfirmationGapTolerance)
+
+        let restartedGeneration = try XCTUnwrap(state.window).generation
+        XCTAssertNotEqual(restartedGeneration, staleGeneration)
+        XCTAssertFalse(state.acceptsRecheck(for: staleGeneration))
+        XCTAssertTrue(state.acceptsRecheck(for: restartedGeneration))
+    }
+
     func testSustainedAudioIsUnconfirmedBeforeAnyAudioWasSeen() {
         XCTAssertFalse(MeetingMatcher.sustainedAudioConfirmed(
             firstSeenAt: nil,

--- a/LokalBotTests/CalendarDetectionTests.swift
+++ b/LokalBotTests/CalendarDetectionTests.swift
@@ -314,6 +314,98 @@ final class CalendarDetectionTests: XCTestCase {
             bundleID: "com.google.Chrome", calendarBacked: false))
     }
 
+    /// `detectRunningMeetingApp` requires fresh output audio, so a candidate
+    /// lost that signal entirely — not just its elapsed time — every time the
+    /// remote side paused to listen rather than talk. Real log, 2026-08-26: six
+    /// consecutive attempts on a live Teams call each failed after 4.2-12.7 s,
+    /// two of them past the 12 s window itself. A gap this short is
+    /// conversational rhythm, not the call ending, and must not restart the
+    /// window.
+    func testABriefPauseInTheRemoteSideDoesNotAbandonTheWindow() {
+        let firstSeen = Date()
+        let lastAudioSeenAt = firstSeen.addingTimeInterval(3)
+        let now = lastAudioSeenAt.addingTimeInterval(4)  // a 4 s quiet turn
+
+        XCTAssertEqual(
+            MeetingMatcher.startConfirmationGapOutcome(
+                firstSeenAt: firstSeen, lastAudioSeenAt: lastAudioSeenAt, now: now,
+                gapTolerance: MeetingDetector.nativeAudioConfirmationGapTolerance,
+                minimumDuration: MeetingDetector.nativeAudioMinimumConfirmationDuration),
+            .stillWaiting)
+    }
+
+    /// Silence past the gap tolerance is what `nativeAudioMinimumConfirmationDuration`
+    /// itself already guards against for a single blip — a candidate that never
+    /// recurs must still be abandoned, gap-tolerant or not.
+    func testSilenceLongerThanTheGapToleranceAbandonsTheCandidate() {
+        let firstSeen = Date()
+        let lastAudioSeenAt = firstSeen.addingTimeInterval(1)
+        let now = lastAudioSeenAt.addingTimeInterval(
+            MeetingDetector.nativeAudioConfirmationGapTolerance + 0.1)
+
+        XCTAssertEqual(
+            MeetingMatcher.startConfirmationGapOutcome(
+                firstSeenAt: firstSeen, lastAudioSeenAt: lastAudioSeenAt, now: now,
+                gapTolerance: MeetingDetector.nativeAudioConfirmationGapTolerance,
+                minimumDuration: MeetingDetector.nativeAudioMinimumConfirmationDuration),
+            .abandoned)
+    }
+
+    /// The two anomalous log lines — "lost the audio... after=12.3s" and
+    /// "after=12.7s" — show the total span already past the window at the
+    /// exact instant the tick found no fresh audio. A bridged gap must confirm
+    /// immediately in that case rather than waiting for evidence that both
+    /// sides have already provided.
+    func testATotalSpanPastTheWindowConfirmsEvenMidGap() {
+        let firstSeen = Date()
+        let lastAudioSeenAt = firstSeen.addingTimeInterval(11)
+        let now = firstSeen.addingTimeInterval(
+            MeetingDetector.nativeAudioMinimumConfirmationDuration + 0.3)
+
+        XCTAssertEqual(
+            MeetingMatcher.startConfirmationGapOutcome(
+                firstSeenAt: firstSeen, lastAudioSeenAt: lastAudioSeenAt, now: now,
+                gapTolerance: MeetingDetector.nativeAudioConfirmationGapTolerance,
+                minimumDuration: MeetingDetector.nativeAudioMinimumConfirmationDuration),
+            .confirmed)
+    }
+
+    /// The tolerance only ever bridges a gap in evidence that already exists;
+    /// it cannot manufacture evidence on its own. A single blip (a
+    /// notification ding) followed by real silence for the rest of the window
+    /// must still be abandoned — the exact case
+    /// `nativeAudioMinimumConfirmationDuration` was introduced to guard
+    /// against, and this tolerance must not reopen it.
+    func testAnIsolatedBlipCannotCoastToConfirmationOnToleranceAlone() {
+        let firstSeen = Date()
+        let lastAudioSeenAt = firstSeen.addingTimeInterval(0.5)  // one brief blip
+        let now = firstSeen.addingTimeInterval(
+            MeetingDetector.nativeAudioMinimumConfirmationDuration + 1)
+
+        XCTAssertEqual(
+            MeetingMatcher.startConfirmationGapOutcome(
+                firstSeenAt: firstSeen, lastAudioSeenAt: lastAudioSeenAt, now: now,
+                gapTolerance: MeetingDetector.nativeAudioConfirmationGapTolerance,
+                minimumDuration: MeetingDetector.nativeAudioMinimumConfirmationDuration),
+            .abandoned)
+    }
+
+    /// The gap boundary is inclusive, matching `sustainedAudioConfirmed`'s own
+    /// inclusive boundary.
+    func testGapToleranceBoundaryIsInclusive() {
+        let firstSeen = Date()
+        let lastAudioSeenAt = firstSeen
+        let now = lastAudioSeenAt.addingTimeInterval(
+            MeetingDetector.nativeAudioConfirmationGapTolerance)
+
+        XCTAssertNotEqual(
+            MeetingMatcher.startConfirmationGapOutcome(
+                firstSeenAt: firstSeen, lastAudioSeenAt: lastAudioSeenAt, now: now,
+                gapTolerance: MeetingDetector.nativeAudioConfirmationGapTolerance,
+                minimumDuration: MeetingDetector.nativeAudioMinimumConfirmationDuration),
+            .abandoned)
+    }
+
     func testSustainedAudioIsUnconfirmedBeforeAnyAudioWasSeen() {
         XCTAssertFalse(MeetingMatcher.sustainedAudioConfirmed(
             firstSeenAt: nil,

--- a/LokalBotTests/MicRecordingFileTests.swift
+++ b/LokalBotTests/MicRecordingFileTests.swift
@@ -1,0 +1,73 @@
+import AVFoundation
+import XCTest
+@testable import LokalBot
+
+/// The capture file is opened with a bitrate the AAC encoder has to accept at
+/// whatever rate the input device runs. These tests need no microphone — only
+/// the encoder — which is why the original defect went unnoticed: nothing
+/// exercised the combination a Bluetooth headset produces.
+final class MicRecordingFileTests: XCTestCase {
+
+    private func format(_ sampleRate: Double, channels: AVAudioChannelCount = 1) -> AVAudioFormat {
+        AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                      sampleRate: sampleRate,
+                      channels: channels,
+                      interleaved: false)!
+    }
+
+    private func temporaryURL(_ ext: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("mic-file-\(UUID().uuidString).\(ext)")
+    }
+
+    /// A Bluetooth headset in HFP mode runs at 16 kHz, where the encoder
+    /// refuses 64 kbit/s. That threw '!dat' (560226676) out of
+    /// `AVAudioFile(forWriting:)`, so the meeting did not record at all.
+    func testOpensAFileAtEveryRateAMacInputCanRun() throws {
+        for rate in [8_000.0, 16_000, 22_050, 24_000, 32_000, 44_100, 48_000] {
+            let url = temporaryURL("m4a")
+            defer { try? FileManager.default.removeItem(at: url) }
+            XCTAssertNoThrow(
+                try MicRecorder.makeRecordingFile(at: url, recordingFormat: format(rate)),
+                "no capture file at \(Int(rate)) Hz")
+        }
+    }
+
+    func testStereoRatesOpenToo() throws {
+        for rate in [16_000.0, 44_100, 48_000] {
+            let url = temporaryURL("m4a")
+            defer { try? FileManager.default.removeItem(at: url) }
+            XCTAssertNoThrow(
+                try MicRecorder.makeRecordingFile(at: url, recordingFormat: format(rate, channels: 2)),
+                "no stereo capture file at \(Int(rate)) Hz")
+        }
+    }
+
+    /// The chosen bitrate is the one the ladder starts from, so a healthy
+    /// device never pays for the fallback.
+    func testBitRateTracksTheSampleRate() {
+        XCTAssertEqual(MicRecorder.aacBitRate(forSampleRate: 8_000), 24_000)
+        XCTAssertEqual(MicRecorder.aacBitRate(forSampleRate: 16_000), 32_000)
+        XCTAssertEqual(MicRecorder.aacBitRate(forSampleRate: 44_100), 64_000)
+        XCTAssertEqual(MicRecorder.aacBitRate(forSampleRate: 48_000), 64_000)
+    }
+
+    /// Descending only: at 8 kHz everything above 24 kbit/s is refused, so
+    /// retrying upwards would swap one rejection for another.
+    func testLadderOnlyEverStepsDown() {
+        for rate in [8_000.0, 16_000, 44_100, 48_000] {
+            let ladder = MicRecorder.aacBitRateLadder(forSampleRate: rate)
+            XCTAssertFalse(ladder.isEmpty)
+            XCTAssertEqual(ladder.first, MicRecorder.aacBitRate(forSampleRate: rate))
+            XCTAssertEqual(ladder, ladder.sorted(by: >), "ladder must descend at \(Int(rate)) Hz")
+        }
+    }
+
+    /// Dictation scratch files are PCM and carry no bitrate to negotiate.
+    func testPCMScratchFileIsUntouchedByTheLadder() throws {
+        let url = temporaryURL("caf")
+        defer { try? FileManager.default.removeItem(at: url) }
+        XCTAssertNoThrow(
+            try MicRecorder.makeRecordingFile(at: url, recordingFormat: format(16_000)))
+    }
+}


### PR DESCRIPTION
Two independent fixes found chasing an unrelated report on `master` today — separate files, separate bugs, bundled because both block a normal meeting from ever being recorded.

### 1. A Bluetooth headset can't start a recording at all

A headset in HFP mode (any Bluetooth headset once it's carrying a call) runs at 16 kHz. The capture file asked for AAC at a hardcoded 64 kbit/s, which the encoder refuses at that rate: `AVAudioFile(forWriting:)` threw `'!dat'` (560226676) and the meeting did not record — "Could not start recording" with a raw Core Audio code was all the user saw.

Measured against the encoder, mono:

```
rate     64k  48k  32k  24k
 8000     x    x    x    ok
16000     x    ok   ok   ok
22050     ok   ok   ok   ok
44100     ok   ok   ok   x
48000     ok   ok   ok   x
```

No single bitrate covers the range — the constraint runs both ways. The bitrate now follows the sample rate, chosen inside every accepted row rather than at its edge, and the file opens through a descending ladder so a device that lands between the measured rates still records at a lower bitrate instead of not at all.

5 new tests, needing no microphone — only the encoder, which is why this went unnoticed: nothing exercised the combination a headset produces.

### 2. Teams autostart essentially never fires during a real conversation

`detectRunningMeetingApp` requires fresh output audio for native apps, so the moment the remote side paused to listen rather than talk, the start candidate didn't just lose elapsed time toward `nativeAudioMinimumConfirmationDuration` (12 s) — it stopped being detected as running *at all*, and the whole window reset.

Requiring an app's helper process to report output continuously for 12 full seconds is close to impossible for real conversational audio. Live log from today, six consecutive attempts on one Teams call:

```
detector waiting for sustained audio app=com.microsoft.teams2 needs=12s
detector lost the audio it was waiting on app=com.microsoft.teams2 after=11.7s
detector waiting for sustained audio app=com.microsoft.teams2 needs=12s
detector lost the audio it was waiting on app=com.microsoft.teams2 after=12.3s
...
```
(full sequence: 11.7s, 12.3s, 4.2s, 12.7s, 10.0s, 12.7s — two of them already past the window itself, killed by a tick that happened to land mid-pause)

Autostart did not fire once in a live call with normal conversational back-and-forth.

A candidate already inside its confirmation window now survives a quiet tick for up to `nativeAudioConfirmationGapTolerance` (6 s, half the window) before that silence is read as the call having ended, tracked via `lastAudioSeenAt` alongside `firstSeen`. The decision is a pure function, `MeetingMatcher.startConfirmationGapOutcome`, so the boundary cases are testable without a live app or Core Audio — including the two anomalous log lines above (total span already past the window, caught mid-gap) and the case the tolerance must *not* reopen: an isolated blip (e.g. a notification) followed by real silence past the tolerance still gets abandoned, which is the exact scenario `nativeAudioMinimumConfirmationDuration` exists to guard against. 5 new tests, one per boundary.

Also gives the detector's start decisions a voice: it previously logged nothing at all unless it actually started a recording, so "it did not fire" had no evidence behind it. That's what made today's diagnosis possible in the first place, and it should help the next one.

### Tests

Full suite: 1657 tests, 0 failures (10 new). Fix 2 verified live against a real Teams call after the change — autostart now fires with normal conversational pauses present.
